### PR TITLE
Исправление контекста вызова JS-конфига MS3 на фронтенде

### DIFF
--- a/assets/components/minishop3/js/web/ms3.js
+++ b/assets/components/minishop3/js/web/ms3.js
@@ -1,7 +1,7 @@
 const ms3 = {
   config: {},
   init () {
-    this.config = window.ms3Config
+    this.config = document.ms3Config
     this.checkToken()
     ms3.form.init()
     ms3.cart.init()

--- a/core/components/minishop3/src/MiniShop3.php
+++ b/core/components/minishop3/src/MiniShop3.php
@@ -163,7 +163,7 @@ class MiniShop3
 
                 $data = json_encode($js_setting, JSON_UNESCAPED_UNICODE);
                 $this->modx->regClientStartupScript(
-                    '<script>ms3Config = ' . $data . ';</script>',
+                    '<script>document.ms3Config = ' . $data . ';</script>',
                     true
                 );
             }


### PR DESCRIPTION
Возможно мы захотим встроить витрину магазина как iframe в другой сайт или магазин, и контекст window сыграет злую шутку, если родительский фрейм будет тоже содержать скрипты MS3, предлагаю сразу от этого застраховаться!

### Что оно делает?

Заменил контекст инициализации JS-конфига MS3

### Зачем это нужно?

Для исключения возможных ошибок
