### PR TITLE
Создание вендора при создании/редактировании товара 

### DIFF
--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -58,8 +58,8 @@ class Create extends CreateProcessor
         }
         $this->setProperty('options', $options);
 
-        if (!empty($properties['vendor'])) {
-            $vendor_id = Utils::getVendorId($this->modx, $properties['vendor']);
+        if (!empty($properties['vendor_id'])) {
+            $vendor_id = Utils::getVendorId($this->modx, $properties['vendor_id']);
             if ($vendor_id) {
                 $this->setProperty('vendor_id', $vendor_id);
             }

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -51,8 +51,8 @@ class Update extends UpdateProcessor
             $this->setProperty('options', $options);
         }
 
-        if (!empty($properties['vendor'])) {
-            $vendor_id = Utils::getVendorId($this->modx, $properties['vendor']);
+        if (!empty($properties['vendor_id'])) {
+            $vendor_id = Utils::getVendorId($this->modx, $properties['vendor_id']);
             if ($vendor_id) {
                 $this->setProperty('vendor_id', $vendor_id);
             }

--- a/core/components/minishop3/src/Utils/Utils.php
+++ b/core/components/minishop3/src/Utils/Utils.php
@@ -246,13 +246,13 @@ class Utils
             'OR:name:=' => $name
         ];
 
-        $vendor = $modx->getObject('msVendor', $criteria);
+        $vendor = $modx->getObject('MiniShop3\Model\msVendor', $criteria);
 
         if ($vendor) {
             return $vendor->get('id');
         }
 
-        $vendor = $modx->newObject('msVendor');
+        $vendor = $modx->newObject('MiniShop3\Model\msVendor');
         $vendor->set('name', $name);
         $vendor->save();
 


### PR DESCRIPTION
### Что оно делает?

Теперь при создании товара можно вписать несуществующего вендора и он будет автоматически создан

### Зачем это нужно?

Ускоряет создание товара

### Связанные проблема(ы)/PR(ы)

https://github.com/modx-pro/miniShop2/pull/748
