### PR TITLE
Работа с плагинами и событиями

### DIFF
--- a/_build/elements/events.php
+++ b/_build/elements/events.php
@@ -1,29 +1,29 @@
 <?php
 
 return [
+    // Cart events
     'msOnBeforeGetCart',
     'msOnGetCart',
     'msOnBeforeGetCartCost',
     'msOnGetCartCost',
-    'msOnBeforeGetDeliveryCost',
-    'msOnGetDeliveryCost',
-    'msOnBeforeGetPaymentCost',
-    'msOnGetPaymentCost',
     'msOnBeforeAddToCart',
     'msOnAddToCart',
     'msOnBeforeChangeInCart',
-    'msOnBeforeChangeOptionsInCart',
     'msOnChangeInCart',
+    'msOnBeforeChangeOptionsInCart',
     'msOnChangeOptionInCart',
     'msOnBeforeRemoveFromCart',
     'msOnRemoveFromCart',
     'msOnBeforeEmptyCart',
     'msOnEmptyCart',
     'msOnGetStatusCart',
+
+    // Order events
     'msOnBeforeAddToOrder',
     'msOnAddToOrder',
     'msOnBeforeValidateOrderValue',
     'msOnValidateOrderValue',
+    'msOnErrorValidateOrderValue',
     'msOnBeforeRemoveFromOrder',
     'msOnRemoveFromOrder',
     'msOnBeforeEmptyOrder',
@@ -33,11 +33,9 @@ return [
     'msOnSubmitOrder',
     'msOnBeforeChangeOrderStatus',
     'msOnChangeOrderStatus',
-    'msOnBeforeGetOrderCustomer',
-    'msOnGetOrderCustomer',
     'msOnBeforeCreateOrder',
-    'msOnBeforeMgrCreateOrder',
     'msOnCreateOrder',
+    'msOnBeforeMgrCreateOrder',
     'msOnMgrCreateOrder',
     'msOnBeforeUpdateOrder',
     'msOnUpdateOrder',
@@ -45,24 +43,63 @@ return [
     'msOnSaveOrder',
     'msOnBeforeRemoveOrder',
     'msOnRemoveOrder',
+
+    // Order product events
     'msOnBeforeCreateOrderProduct',
     'msOnCreateOrderProduct',
     'msOnBeforeUpdateOrderProduct',
     'msOnUpdateOrderProduct',
     'msOnBeforeRemoveOrderProduct',
     'msOnRemoveOrderProduct',
+
+    // Order user events
+    'msOnBeforeGetOrderUser',
+    'msOnGetOrderUser',
+
+    // Order customer events
+    'msOnBeforeGetOrderCustomer',
+    'msOnGetOrderCustomer',
+
+    // Customer events
+    'msOnBeforeAddToCustomer',
+    'msOnAddToCustomer',
+    'msOnBeforeValidateCustomerValue',
+    'msOnValidateCustomerValue',
+    'msOnErrorValidateCustomerValue',
+    'msOnBeforeCreateCustomer',
+    'msOnCreateCustomer',
+    'msOnBeforeAddCustomerAddress',
+    'msOnAddCustomerAddress',
+
+    // Delivery & Payment cost events
+    'msOnBeforeGetDeliveryCost',
+    'msOnGetDeliveryCost',
+    'msOnBeforeGetPaymentCost',
+    'msOnGetPaymentCost',
+
+    // Product events
     'msOnGetProductPrice',
     'msOnGetProductWeight',
     'msOnGetProductFields',
-    'msOnManagerCustomCssJs',
+
+    // Vendor events
     'msOnBeforeVendorCreate',
     'msOnVendorCreate',
     'msOnBeforeVendorUpdate',
     'msOnVendorUpdate',
     'msOnBeforeVendorDelete',
     'msOnVendorDelete',
+
+    // Import events
+    'msOnBeforeImport',
+    'msOnAfterImport',
+    'msOnImportRow',
+
     // Notification events
     'msOnBeforeSendNotification',
     'msOnAfterSendNotification',
     'msOnRegisterNotificationChannels',
+
+    // Manager events
+    'msOnManagerCustomCssJs',
 ];

--- a/core/components/minishop3/src/Controllers/Customer/Customer.php
+++ b/core/components/minishop3/src/Controllers/Customer/Customer.php
@@ -182,15 +182,15 @@ class Customer
             return $this->error('ms3_customer_key_empty');
         }
 
-        // $response = $$this->ms3->utils->invokeEvent('msOnBeforeAddToOrder', [
-        //            'key' => $key,
-        //            'value' => $value,
-        //            'order' => $this,
-        //        ]);
-        //        if (!$response['success']) {
-        //            return $this->error($response['message']);
-        //        }
-        //        $value = $response['data']['value'];
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeAddToCustomer', [
+            'key' => $key,
+            'value' => $value,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            return $this->error($response['message']);
+        }
+        $value = $response['data']['value'];
 
         $response = $this->validate($key, $value);
         if (is_array($response)) {
@@ -199,12 +199,14 @@ class Customer
 
         $validated = $response;
 
+        $isNew = false;
         $msCustomer = $this->modx->getObject(msCustomer::class, [
             'token' => $this->token
         ]);
         if ($msCustomer) {
             $msCustomer->set($key, $validated);
         } else {
+            $isNew = true;
             $userId = 0;
 
             // TODO how to correctly determine current system user if authenticated?
@@ -219,18 +221,16 @@ class Customer
         }
         $msCustomer->save();
 
-        // TODO Implement event after adding field
-
-        //$response = $$this->ms3->utils->invokeEvent('msOnAddToCustomer', [
-        //                    'key' => $key,
-        //                    'value' => $validated,
-        //                    'customer' => $this,
-//                                'mode' => 'new'
-        //                ]);
-        //                if (!$response['success']) {
-        //                    return $this->error($response['message']);
-        //                }
-        //                $validated = $response['data']['value'];
+        $response = $this->ms3->utils->invokeEvent('msOnAddToCustomer', [
+            'key' => $key,
+            'value' => $validated,
+            'customer' => $this,
+            'msCustomer' => $msCustomer,
+            'isNew' => $isNew,
+        ]);
+        if (!$response['success']) {
+            return $this->error($response['message']);
+        }
 
         return ($validated === false)
             ? $this->error('', [$key => $value])
@@ -239,41 +239,55 @@ class Customer
 
     public function validate(string $key, mixed $value): mixed
     {
-        $validator = new Validator();
+        // Allow plugins to modify value before validation
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeValidateCustomerValue', [
+            'key' => $key,
+            'value' => $value,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            return [$key => $response['message']];
+        }
+        $value = $response['data']['value'];
 
-        $validation = $validator->validate(
-            [$key => $value],
-            [$key => $this->validationRules[$key]],
-            $this->validationMessages
-        );
+        // Standard validation
+        if (!empty($this->validationRules[$key])) {
+            $validator = new Validator();
 
-        $validation->validate();
+            $validation = $validator->validate(
+                [$key => $value],
+                [$key => $this->validationRules[$key]],
+                $this->validationMessages
+            );
 
-        if ($validation->fails()) {
-            // handling errors
-            $errors = $validation->errors();
-            return $errors->firstOfAll();
-        } else {
-            return $value;
+            $validation->validate();
+
+            if ($validation->fails()) {
+                $errors = $validation->errors();
+
+                // Allow plugins to handle validation errors
+                $response = $this->ms3->utils->invokeEvent('msOnErrorValidateCustomerValue', [
+                    'key' => $key,
+                    'value' => $value,
+                    'errors' => $errors->firstOfAll(),
+                    'customer' => $this,
+                ]);
+
+                return $errors->firstOfAll();
+            }
         }
 
-        // $eventParams = [
-        //            'key' => $key,
-        //            'value' => $value,
-        //            'customer' => $this,
-        //        ];
-        //        $response = $this->invokeEvent('msOnBeforeValidateCustomerValue', $eventParams);
-        //        $value = $response['data']['value'];
+        // Allow plugins to modify validated value
+        $response = $this->ms3->utils->invokeEvent('msOnValidateCustomerValue', [
+            'key' => $key,
+            'value' => $value,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            return [$key => $response['message']];
+        }
 
-        //$eventParams = [
-        //            'key' => $key,
-        //            'value' => $value,
-        //            'customer' => $this,
-        //        ];
-        //        $response = $this->invokeEvent('msOnValidateCustomerValue', $eventParams);
-        //        return $response['data']['value'];
-
-        return $value;
+        return $response['data']['value'];
     }
 
     /**
@@ -289,30 +303,62 @@ class Customer
 
     public function create(array $customerData): msCustomer|null
     {
+        // Allow plugins to modify data before creation
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeCreateCustomer', [
+            'customerData' => $customerData,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            return null;
+        }
+        $customerData = $response['data']['customerData'];
+
         $msCustomer = $this->modx->newObject(msCustomer::class, $customerData);
         $save = $msCustomer->save();
         if (!$save) {
             return null;
         }
+
+        // Allow plugins to act after customer creation
+        $response = $this->ms3->utils->invokeEvent('msOnCreateCustomer', [
+            'customerData' => $customerData,
+            'msCustomer' => $msCustomer,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            // Customer already created, but plugins can log/handle errors
+            $this->modx->log(modX::LOG_LEVEL_WARN, '[Customer::create] msOnCreateCustomer event failed: ' . $response['message']);
+        }
+
         return $msCustomer;
     }
 
     public function addAddress(array $customerAddressData): bool
     {
         if (empty($customerAddressData['customer_id'])) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[Customer::addAddress] customer_id is required');
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Customer::addAddress] customer_id is required');
             return false;
         }
 
         if (empty($customerAddressData['city'])) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[Customer::addAddress] city is required');
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Customer::addAddress] city is required');
             return false;
         }
 
         if (empty($customerAddressData['street'])) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[Customer::addAddress] street is required');
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Customer::addAddress] street is required');
             return false;
         }
+
+        // Allow plugins to modify address data before saving
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeAddCustomerAddress', [
+            'addressData' => $customerAddressData,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            return false;
+        }
+        $customerAddressData = $response['data']['addressData'];
 
         if (empty($customerAddressData['name'])) {
             $nameParts = array_filter([
@@ -332,7 +378,7 @@ class Customer
         ]);
 
         if (!empty($isExists)) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_INFO, '[Customer::addAddress] Address already exists for customer #' . $customerAddressData['customer_id']);
+            $this->modx->log(modX::LOG_LEVEL_INFO, '[Customer::addAddress] Address already exists for customer #' . $customerAddressData['customer_id']);
             return false;
         }
 
@@ -343,11 +389,21 @@ class Customer
         $msCustomerAddress = $this->modx->newObject(msCustomerAddress::class, $customerAddressData);
 
         if (!$msCustomerAddress->save()) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[Customer::addAddress] Failed to save address');
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Customer::addAddress] Failed to save address');
             return false;
         }
 
-        $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_INFO, '[Customer::addAddress] Created address #' . $msCustomerAddress->get('id') . ' for customer #' . $customerAddressData['customer_id']);
+        $this->modx->log(modX::LOG_LEVEL_INFO, '[Customer::addAddress] Created address #' . $msCustomerAddress->get('id') . ' for customer #' . $customerAddressData['customer_id']);
+
+        // Allow plugins to act after address is added
+        $response = $this->ms3->utils->invokeEvent('msOnAddCustomerAddress', [
+            'addressData' => $customerAddressData,
+            'msCustomerAddress' => $msCustomerAddress,
+            'customer' => $this,
+        ]);
+        if (!$response['success']) {
+            $this->modx->log(modX::LOG_LEVEL_WARN, '[Customer::addAddress] msOnAddCustomerAddress event failed: ' . $response['message']);
+        }
 
         return true;
     }

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -202,7 +202,18 @@ class ProductDataService
     /**
      * Get product price with plugin modifiers
      *
-     * Invokes msOnGetProductPrice event for price modification
+     * Invokes msOnGetProductPrice event for price modification.
+     * Supports plugin chaining: each plugin can read/modify price via $modx->eventData
+     *
+     * Plugin example:
+     * ```php
+     * case 'msOnGetProductPrice':
+     *     $price = $modx->eventData['msOnGetProductPrice']['price'] ?? $scriptProperties['price'];
+     *     $newPrice = $price * 0.9; // 10% discount
+     *     $modx->eventData['msOnGetProductPrice']['price'] = $newPrice;
+     *     $modx->event->returnedValues['price'] = $newPrice;
+     *     break;
+     * ```
      *
      * @param msProductData $productData
      * @param array $data Additional product data
@@ -210,22 +221,39 @@ class ProductDataService
      */
     public function getModifiedPrice(msProductData $productData, array $data = [])
     {
+        $eventName = 'msOnGetProductPrice';
         $price = !empty($data['price'])
             ? $data['price']
             : $productData->get('price');
 
-        $response = $this->modx->invokeEvent('msOnGetProductPrice', [
+        // Initialize eventData for plugin chaining
+        $this->modx->eventData[$eventName] = [
+            'price' => $price,
+            'data' => $data,
+        ];
+
+        // Clear previous returnedValues
+        if (isset($this->modx->event->returnedValues)) {
+            $this->modx->event->returnedValues = null;
+        }
+
+        $this->modx->invokeEvent($eventName, [
             'price' => $price,
             'data' => $data,
         ]);
 
-        if (is_array($response) && count($response) > 0) {
-            foreach ($response as $value) {
-                if (is_numeric($value)) {
-                    $price = $value;
-                }
-            }
+        // Priority 1: Read from eventData (plugin chain result)
+        if (isset($this->modx->eventData[$eventName]['price'])) {
+            $price = $this->modx->eventData[$eventName]['price'];
         }
+
+        // Priority 2: Check returnedValues for backward compatibility
+        if (isset($this->modx->event->returnedValues['price'])) {
+            $price = $this->modx->event->returnedValues['price'];
+        }
+
+        // Cleanup
+        unset($this->modx->eventData[$eventName]);
 
         return $price;
     }
@@ -233,7 +261,18 @@ class ProductDataService
     /**
      * Get product weight with plugin modifiers
      *
-     * Invokes msOnGetProductWeight event for weight modification
+     * Invokes msOnGetProductWeight event for weight modification.
+     * Supports plugin chaining: each plugin can read/modify weight via $modx->eventData
+     *
+     * Plugin example:
+     * ```php
+     * case 'msOnGetProductWeight':
+     *     $weight = $modx->eventData['msOnGetProductWeight']['weight'] ?? $scriptProperties['weight'];
+     *     $newWeight = $weight + 0.5; // Add packaging weight
+     *     $modx->eventData['msOnGetProductWeight']['weight'] = $newWeight;
+     *     $modx->event->returnedValues['weight'] = $newWeight;
+     *     break;
+     * ```
      *
      * @param msProductData $productData
      * @param array $data Additional product data
@@ -241,22 +280,39 @@ class ProductDataService
      */
     public function getModifiedWeight(msProductData $productData, array $data = [])
     {
+        $eventName = 'msOnGetProductWeight';
         $weight = !empty($data['weight'])
             ? $data['weight']
             : $productData->get('weight');
 
-        $response = $this->modx->invokeEvent('msOnGetProductWeight', [
+        // Initialize eventData for plugin chaining
+        $this->modx->eventData[$eventName] = [
+            'weight' => $weight,
+            'data' => $data,
+        ];
+
+        // Clear previous returnedValues
+        if (isset($this->modx->event->returnedValues)) {
+            $this->modx->event->returnedValues = null;
+        }
+
+        $this->modx->invokeEvent($eventName, [
             'weight' => $weight,
             'data' => $data,
         ]);
 
-        if (is_array($response) && count($response) > 0) {
-            foreach ($response as $value) {
-                if (is_numeric($value)) {
-                    $weight = $value;
-                }
-            }
+        // Priority 1: Read from eventData (plugin chain result)
+        if (isset($this->modx->eventData[$eventName]['weight'])) {
+            $weight = $this->modx->eventData[$eventName]['weight'];
         }
+
+        // Priority 2: Check returnedValues for backward compatibility
+        if (isset($this->modx->event->returnedValues['weight'])) {
+            $weight = $this->modx->event->returnedValues['weight'];
+        }
+
+        // Cleanup
+        unset($this->modx->eventData[$eventName]);
 
         return $weight;
     }
@@ -264,7 +320,18 @@ class ProductDataService
     /**
      * Modify product fields via plugins
      *
-     * Invokes msOnGetProductFields event for custom product field processing
+     * Invokes msOnGetProductFields event for custom product field processing.
+     * Supports plugin chaining: each plugin can read/modify fields via $modx->eventData
+     *
+     * Plugin example:
+     * ```php
+     * case 'msOnGetProductFields':
+     *     $data = $modx->eventData['msOnGetProductFields']['data'] ?? $scriptProperties['data'];
+     *     $data['custom_field'] = 'value';
+     *     $modx->eventData['msOnGetProductFields']['data'] = $data;
+     *     $modx->event->returnedValues['data'] = $data;
+     *     break;
+     * ```
      *
      * @param msProductData $productData
      * @param array $data Product fields
@@ -272,15 +339,32 @@ class ProductDataService
      */
     public function getModifiedFields(msProductData $productData, array $data = []): array
     {
-        $response = $this->modx->invokeEvent('msOnGetProductFields', ['data' => $data]);
+        $eventName = 'msOnGetProductFields';
 
-        if (is_array($response) && count($response) > 0) {
-            foreach ($response as $fields) {
-                if (is_array($fields)) {
-                    $data = array_merge($data, $fields);
-                }
-            }
+        // Initialize eventData for plugin chaining
+        $this->modx->eventData[$eventName] = [
+            'data' => $data,
+        ];
+
+        // Clear previous returnedValues
+        if (isset($this->modx->event->returnedValues)) {
+            $this->modx->event->returnedValues = null;
         }
+
+        $this->modx->invokeEvent($eventName, ['data' => $data]);
+
+        // Priority 1: Read from eventData (plugin chain result)
+        if (isset($this->modx->eventData[$eventName]['data']) && is_array($this->modx->eventData[$eventName]['data'])) {
+            $data = $this->modx->eventData[$eventName]['data'];
+        }
+
+        // Priority 2: Check returnedValues for backward compatibility
+        if (isset($this->modx->event->returnedValues['data']) && is_array($this->modx->event->returnedValues['data'])) {
+            $data = $this->modx->event->returnedValues['data'];
+        }
+
+        // Cleanup
+        unset($this->modx->eventData[$eventName]);
 
         return $data;
     }

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -226,6 +226,11 @@ class ProductDataService
             ? $data['price']
             : $productData->get('price');
 
+        // Early return if no plugins registered for this event
+        if (empty($this->modx->eventMap[$eventName])) {
+            return $price;
+        }
+
         // Initialize eventData for plugin chaining
         $this->modx->eventData[$eventName] = [
             'price' => $price,
@@ -285,6 +290,11 @@ class ProductDataService
             ? $data['weight']
             : $productData->get('weight');
 
+        // Early return if no plugins registered for this event
+        if (empty($this->modx->eventMap[$eventName])) {
+            return $weight;
+        }
+
         // Initialize eventData for plugin chaining
         $this->modx->eventData[$eventName] = [
             'weight' => $weight,
@@ -340,6 +350,11 @@ class ProductDataService
     public function getModifiedFields(msProductData $productData, array $data = []): array
     {
         $eventName = 'msOnGetProductFields';
+
+        // Early return if no plugins registered for this event
+        if (empty($this->modx->eventMap[$eventName])) {
+            return $data;
+        }
 
         // Initialize eventData for plugin chaining
         $this->modx->eventData[$eventName] = [


### PR DESCRIPTION

  Этот PR содержит комплексный аудит и улучшение системы событий MiniShop3.

  Изменения

  Исправления

  - Исправлен PHP Deprecated warning в msProductFile.php:201 — параметр $options теперь обязательный в методе makeThumbnail()
  - Исправлена проблема с цепочкой плагинов — несколько плагинов на одном событии теперь корректно передают данные друг другу через $modx->eventData

  Оптимизация производительности

  - Добавлен early return в методах getModifiedPrice(), getModifiedWeight(), getModifiedFields() — если для события нет зарегистрированных плагинов, вызов invokeEvent() пропускается

  Новые события

  Customer события (9 шт.):
  - msOnBeforeAddToCustomer / msOnAddToCustomer — добавление данных покупателя
  - msOnBeforeValidateCustomerValue / msOnValidateCustomerValue / msOnErrorValidateCustomerValue — валидация полей
  - msOnBeforeCreateCustomer / msOnCreateCustomer — создание покупателя
  - msOnBeforeAddCustomerAddress / msOnAddCustomerAddress — добавление адреса

  Добавлены отсутствующие события (6 шт.):
  - msOnErrorValidateOrderValue — обработка ошибок валидации заказа
  - msOnBeforeGetOrderUser / msOnGetOrderUser — получение пользователя заказа
  - msOnBeforeImport / msOnAfterImport / msOnImportRow — импорт данных

  Рефакторинг

  - Файл _build/elements/events.php реорганизован по логическим категориям
  - Общее количество событий: 70 (было 55)