### PR TITLE
Единообразное отображение иконки календаря

### DIFF
--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -93,7 +93,9 @@
       :input-id="fieldConfig.id"
       :placeholder="fieldConfig.placeholder"
       :disabled="disabled"
-      :show-icon="fieldConfig.props?.showIcon ?? true"
+      show-icon
+      fluid
+      icon-display="input"
       :date-format="fieldConfig.props?.dateFormat ?? 'dd.mm.yy'"
       @blur="handleBlur"
     />

--- a/vueManager/src/components/OrderView.vue
+++ b/vueManager/src/components/OrderView.vue
@@ -2304,10 +2304,12 @@ onMounted(async () => {
                           <DatePicker
                             v-model="order[field.name]"
                             :placeholder="field.placeholder"
-                            class="w-full"
                             date-format="dd.mm.yy"
                             show-time
                             hour-format="24"
+                            show-icon
+                            fluid
+                            icon-display="input"
                           />
                         </template>
 

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -602,9 +602,10 @@ onMounted(async () => {
                   :id="`filter-${filter.key}`"
                   v-model="filterValues[filter.key]"
                   date-format="dd.mm.yy"
-                  :show-icon="true"
+                  show-icon
+                  fluid
+                  icon-display="input"
                   :show-button-bar="true"
-                  class="w-full"
                   @date-select="applyFilters"
                 />
               </div>
@@ -621,9 +622,10 @@ onMounted(async () => {
                   v-model="filterValues[filter.key]"
                   selection-mode="range"
                   date-format="dd.mm.yy"
-                  :show-icon="true"
+                  show-icon
+                  fluid
+                  icon-display="input"
                   :show-button-bar="true"
-                  class="w-full"
                   @date-select="applyFilters"
                 />
               </div>


### PR DESCRIPTION
## Описание

Единообразное отображение иконки календаря **внутри** поля ввода у всех DatePicker (PrimeVue): добавлены `showIcon`, `fluid` и `iconDisplay="input"` по [документации PrimeVue](https://primevue.org/datepicker/#icon).

**Изменённые компоненты:**
- **OrdersGrid.vue** — фильтры по дате (одиночная дата и диапазон)
- **OrderView.vue** — поле даты в карточке заказа
- **DynamicField.vue** — универсальное поле типа datefield

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #(номер issue)

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3:
- MODX:
- PHP:

## Скриншоты (если применимо)

| До (иконка снаружи) | После (иконка внутри инпута) |
|:--:|:-----:|
|<img width="1067" height="568" alt="image" src="https://github.com/user-attachments/assets/bfeacab4-cbbd-4f39-a3e3-0b10cad9dbe5" />|<img width="1075" height="559" alt="image" src="https://github.com/user-attachments/assets/63ab3d73-8d5f-4f23-89cb-d0a3ff845033" />|

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Используется вариант с `iconDisplay="input"`: иконка отображается внутри поля ввода справа.
