### PR TITLE
fix: add class_key to getIterator for msProduct/msCategory (#87)

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -61,6 +61,9 @@ class CategoryProductsController
         $c = $this->modx->newQuery(msProduct::class);
         $c->innerJoin(msProductData::class, 'Data', 'msProduct.id = Data.id');
 
+        // class_key filter (getIterator doesn't call addDerivativeCriteria)
+        $c->where(['msProduct.class_key' => msProduct::class]);
+
         // Parent filter
         if ($nested) {
             // Get all child category IDs
@@ -450,7 +453,8 @@ class CategoryProductsController
 
         $children = $this->modx->getIterator(msCategory::class, [
             'parent' => $parentId,
-            'deleted' => 0
+            'deleted' => 0,
+            'class_key' => msCategory::class,
         ]);
 
         foreach ($children as $child) {

--- a/core/components/minishop3/src/Controllers/Api/ReferencesController.php
+++ b/core/components/minishop3/src/Controllers/Api/ReferencesController.php
@@ -392,6 +392,9 @@ class ReferencesController extends BaseApiController
             // Join with msProductData for additional fields
             $c->leftJoin('MiniShop3\\Model\\msProductData', 'Data', 'msProduct.id = Data.id');
 
+            // class_key filter (getIterator doesn't call addDerivativeCriteria)
+            $c->where(['msProduct.class_key' => 'MiniShop3\\Model\\msProduct']);
+
             // Search by pagetitle, article, or id
             $c->where([
                 'msProduct.pagetitle:LIKE' => "%{$searchQuery}%",

--- a/core/components/minishop3/src/Processors/Settings/Option/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Get.php
@@ -36,7 +36,10 @@ class Get extends GetProcessor
     {
         $c = $this->modx->newQuery(msCategory::class);
         $c->leftJoin(msCategoryOption::class, 'msCategoryOption', 'msCategoryOption.category_id = msCategory.id');
-        $c->where(['msCategoryOption.option_id' => $this->object->get('id')]);
+        $c->where([
+            'msCategory.class_key' => msCategory::class,
+            'msCategoryOption.option_id' => $this->object->get('id'),
+        ]);
         $c->select([
             $this->modx->getSelectColumns(msCategory::class, 'msCategory'),
             $this->modx->getSelectColumns(


### PR DESCRIPTION
## Summary
- `xPDO::getIterator()` does not call `addDerivativeCriteria()`, unlike `getCollection()`
- For classes without their own table (msProduct, msCategory extend modResource), queries return wrong class instances
- Added explicit `class_key` filter to all affected `getIterator` calls

**Affected files:**
- `CategoryProductsController::getChildCategories()` — root cause of the bug
- `CategoryProductsController::getList()` — defense-in-depth
- `ReferencesController::searchProducts()` — real risk
- `Settings\Option\Get::beforeOutput()` — defense-in-depth

Fixes #87

## Test plan
- [ ] Open category with nested subcategories containing products — no xPDO errors
- [ ] Search products in References API — only msProduct returned
- [ ] Open option settings — only msCategory in categories list

🤖 Generated with [Claude Code](https://claude.com/claude-code)