### PR TITLE
fix: correct default order status IDs and add fallback for zero values

### DIFF
--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -279,17 +279,17 @@ return [
         'area' => 'ms3_import',
     ],
     'ms3_status_new' => [
-        'value' => 0,
+        'value' => 2,
         'xtype' => 'numberfield',
         'area' => 'ms3_statuses',
     ],
     'ms3_status_paid' => [
-        'value' => 0,
+        'value' => 3,
         'xtype' => 'numberfield',
         'area' => 'ms3_statuses',
     ],
     'ms3_status_canceled' => [
-        'value' => 0,
+        'value' => 5,
         'xtype' => 'numberfield',
         'area' => 'ms3_statuses',
     ],

--- a/core/components/minishop3/elements/tasks/cleanupDrafts.php
+++ b/core/components/minishop3/elements/tasks/cleanupDrafts.php
@@ -29,7 +29,7 @@ if (!$threshold) {
     return false;
 }
 
-$statusDraft = (int)$modx->getOption('ms3_status_draft', null, 1);
+$statusDraft = (int) $modx->getOption('ms3_status_draft', null, 1) ?: 1;
 $thresholdDate = date('Y-m-d H:i:s', $threshold);
 
 // Find and delete old drafts

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -105,7 +105,7 @@ class OrdersController
 
         $showDrafts = $this->modx->getOption('ms3_order_show_drafts', null, false);
         if (!$showDrafts) {
-            $statusDrafts = $this->modx->getOption('ms3_status_draft', null, 1);
+            $statusDrafts = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
             $c->where(['status_id:!=' => $statusDrafts]);
         }
 
@@ -466,7 +466,7 @@ class OrdersController
         $order->set('token', md5(uniqid('ms3_mgr_', true)));
 
         // Set status to "Draft" - order will be finalized later
-        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1);
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
         $order->set('status_id', $statusDraft);
 
         // Context

--- a/core/components/minishop3/src/Controllers/Payment/Payment.php
+++ b/core/components/minishop3/src/Controllers/Payment/Payment.php
@@ -277,7 +277,7 @@ abstract class Payment implements PaymentProviderInterface
      */
     protected function getPaidStatusId(): int
     {
-        return (int)$this->modx->getOption('ms3_status_paid', null, 3);
+        return (int) $this->modx->getOption('ms3_status_paid', null, 3) ?: 3;
     }
 
     /**
@@ -290,6 +290,6 @@ abstract class Payment implements PaymentProviderInterface
      */
     protected function getCanceledStatusId(): int
     {
-        return (int)$this->modx->getOption('ms3_status_canceled', null, 5);
+        return (int) $this->modx->getOption('ms3_status_canceled', null, 5) ?: 5;
     }
 }

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -38,7 +38,7 @@ class OrderDraftManager
             return null;
         }
 
-        $status_draft = $this->modx->getOption('ms3_status_draft', null, 1);
+        $status_draft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
 
         // 1. Try to find by token first (primary method)
         $draft = $this->modx->getObject(msOrder::class, [
@@ -84,7 +84,7 @@ class OrderDraftManager
      */
     public function createDraft(string $token, string $ctx = 'web'): msOrder
     {
-        $status_draft = $this->modx->getOption('ms3_status_draft', null, 1);
+        $status_draft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
 
         /** @var msOrder $msOrder */
         $msOrder = $this->modx->newObject(msOrder::class);
@@ -384,7 +384,7 @@ class OrderDraftManager
             return null;
         }
 
-        $statusDraft = $this->modx->getOption('ms3_status_draft', null, 1);
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
 
         return $this->modx->getObject(msOrder::class, [
             'customer_id' => $customerId,

--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -57,7 +57,7 @@ class OrderFinalizeService
         }
 
         // Check order is in DRAFT status
-        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1);
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
         if ((int) $order->get('status_id') !== $statusDraft) {
             return $this->error('ms3_order_err_already_finalized');
         }
@@ -140,7 +140,7 @@ class OrderFinalizeService
         }
 
         // Change status to "new"
-        $statusNew = (int) $this->modx->getOption('ms3_status_new', null, 2);
+        $statusNew = (int) $this->modx->getOption('ms3_status_new', null, 2) ?: 2;
 
         /** @var OrderStatusService $orderStatus */
         $orderStatus = $this->modx->services->get('ms3_order_status');

--- a/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
+++ b/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
@@ -224,7 +224,7 @@ class OrderSubmitHandler
         $_SESSION['ms3']['orders'][] = $draft->get('id');
 
         // Change status to "new"
-        $statusNew = $this->modx->getOption('ms3_status_new', null, 2);
+        $statusNew = (int) $this->modx->getOption('ms3_status_new', null, 2) ?: 2;
         /** @var OrderStatusService $orderStatus */
         $orderStatus = $this->modx->services->get('ms3_order_status');
         $statusResponse = $orderStatus->change($draft->get('id'), $statusNew);


### PR DESCRIPTION
## Summary
- Fixed default values for `ms3_status_new` (0→2), `ms3_status_paid` (0→3), `ms3_status_canceled` (0→5) in `_build/elements/settings.php`
- Added `?: default` fallback in all 11 `getOption('ms3_status_*')` calls across 7 files to handle existing installations where settings are saved with value 0

## Root cause
`$modx->getOption('ms3_status_new', null, 2)` returns `0` (not the fallback `2`) when the setting exists with value `0`. This caused `OrderStatusService::change()` to fail with "Status not found" error on order submit.

Fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)