### PR TITLE
fix: remove action from miniShop3 menu configuration

### DIFF
--- a/_build/elements/menus.php
+++ b/_build/elements/menus.php
@@ -4,7 +4,7 @@ return [
     'miniShop3' => [
         'description' => 'ms3_menu_desc',
         'icon' => '<i class="icon-shopping-cart icon icon-large"></i>',
-        'action' => 'mgr/orders',
+        'action' => '',
     ],
     'ms3_orders' => [
         'description' => 'ms3_orders_desc',


### PR DESCRIPTION
## Описание

У пункта меню «miniShop3» при установке задавалось поле **Действие** = `mgr/orders`. При клике по пункту подменю (Заказы, Клиенты, Настройки и т.д.) на мгновение появлялось и сразу срабатывал переход по этому action, из‑за чего нельзя было выбрать подпункт.

В `_build/elements/menus.php` у родительского пункта `miniShop3` поле `action` заменено с `'mgr/orders'` на `''`. После установки/обновления пакета клик по «miniShop3» только раскрывает подменю, без перехода на другую страницу.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #25

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.4.1-beta1
- MODX: —
- PHP: —

После установки/обновления: клик по «miniShop3» раскрывает подменю без редиректа; подпункты (Заказы, Клиенты и т.д.) по клику открывают нужные страницы.

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Клик по «miniShop3» сразу переводит на страницу заказов, подменю не выбрать | Клик по «miniShop3» раскрывает подменю, подпункты доступны |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Правка в одном файле: `_build/elements/menus.php`, одна строка (`'action' => 'mgr/orders'` → `'action' => ''`). По комментарию [@biz87](https://github.com/modx-pro/MiniShop3/issues/25#issuecomment-3904423726) MODX поддерживает пустой action у родительских пунктов меню.