### PR TITLE
refactor: remove redundant permission checks from processor initializ…

### DIFF
--- a/core/components/minishop3/src/Processors/Customer/Address/Get.php
+++ b/core/components/minishop3/src/Processors/Customer/Address/Get.php
@@ -13,19 +13,6 @@ class Get extends GetProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function cleanup()

--- a/core/components/minishop3/src/Processors/Customer/Address/GetList.php
+++ b/core/components/minishop3/src/Processors/Customer/Address/GetList.php
@@ -18,18 +18,6 @@ class GetList extends GetListProcessor
     protected $query;
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array
      */
     public function getData()

--- a/core/components/minishop3/src/Processors/Customer/Address/Remove.php
+++ b/core/components/minishop3/src/Processors/Customer/Address/Remove.php
@@ -11,15 +11,4 @@ class Remove extends RemoveProcessor
     public $languageTopics = ['minishop3:default'];
     public $permission = 'msorder_remove';
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Customer/Address/Update.php
+++ b/core/components/minishop3/src/Processors/Customer/Address/Update.php
@@ -13,15 +13,4 @@ class Update extends UpdateProcessor
     public $languageTopics = ['minishop3:default'];
     public $permission = 'msorder_save';
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Customer/Get.php
+++ b/core/components/minishop3/src/Processors/Customer/Get.php
@@ -13,19 +13,6 @@ class Get extends GetProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function cleanup()

--- a/core/components/minishop3/src/Processors/Customer/GetList.php
+++ b/core/components/minishop3/src/Processors/Customer/GetList.php
@@ -18,18 +18,6 @@ class GetList extends GetListProcessor
     protected $query;
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array
      */
     public function getData()

--- a/core/components/minishop3/src/Processors/Customer/Remove.php
+++ b/core/components/minishop3/src/Processors/Customer/Remove.php
@@ -13,18 +13,6 @@ class Remove extends RemoveProcessor
     public $permission = 'msorder_remove';
     public int $customerId = 0;
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
     public function process()
     {
         $canRemove = $this->beforeRemove();

--- a/core/components/minishop3/src/Processors/Customer/Update.php
+++ b/core/components/minishop3/src/Processors/Customer/Update.php
@@ -17,15 +17,4 @@ class Update extends UpdateProcessor
     public $afterSaveEvent = 'msOnUpdateCustomer';
     public $permission = 'msorder_save';
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Gallery/Generate.php
+++ b/core/components/minishop3/src/Processors/Gallery/Generate.php
@@ -14,19 +14,6 @@ class Generate extends ModelProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Gallery/GenerateAll.php
+++ b/core/components/minishop3/src/Processors/Gallery/GenerateAll.php
@@ -15,19 +15,6 @@ class GenerateAll extends  ModelProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Gallery/GetList.php
+++ b/core/components/minishop3/src/Processors/Gallery/GetList.php
@@ -28,9 +28,6 @@ class GetList extends GetListProcessor
      */
     public function initialize()
     {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
         $this->ms3 = $this->modx->services->get('ms3');
 
         /** @var msProduct $product */

--- a/core/components/minishop3/src/Processors/Gallery/Remove.php
+++ b/core/components/minishop3/src/Processors/Gallery/Remove.php
@@ -14,19 +14,6 @@ class Remove extends RemoveProcessor
     public $permission = 'msproductfile_save';
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Gallery/RemoveAll.php
+++ b/core/components/minishop3/src/Processors/Gallery/RemoveAll.php
@@ -14,19 +14,6 @@ class RemoveAll extends ModelProcessor
     public $permission = 'msproductfile_save';
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Gallery/Sort.php
+++ b/core/components/minishop3/src/Processors/Gallery/Sort.php
@@ -9,19 +9,6 @@ use MODX\Revolution\Processors\ModelProcessor;
 class Sort extends ModelProcessor
 {
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      *
      *
      * @return array|string

--- a/core/components/minishop3/src/Processors/Gallery/Update.php
+++ b/core/components/minishop3/src/Processors/Gallery/Update.php
@@ -16,19 +16,6 @@ class Update extends UpdateProcessor
     protected $old_name = null;
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|bool|string
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Gallery/Upload.php
+++ b/core/components/minishop3/src/Processors/Gallery/Upload.php
@@ -27,9 +27,6 @@ class Upload extends ModelProcessor
      */
     public function initialize()
     {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
         /** @var msProduct $product */
         $id = (int)$this->getProperty('id', @$_GET['id']);
         $this->product = $this->modx->getObject(msProduct::class, $id);

--- a/core/components/minishop3/src/Processors/Product/Category.php
+++ b/core/components/minishop3/src/Processors/Product/Category.php
@@ -12,19 +12,6 @@ class Category extends CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Product/ProductLink/Create.php
+++ b/core/components/minishop3/src/Processors/Product/ProductLink/Create.php
@@ -13,19 +13,6 @@ class Create extends CreateProcessor
     public $permission = 'msproduct_save';
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Product/ProductLink/Remove.php
+++ b/core/components/minishop3/src/Processors/Product/ProductLink/Remove.php
@@ -19,13 +19,8 @@ class Remove extends RemoveProcessor
      */
     public function initialize()
     {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
         return true;
     }
-
 
     /**
      * @return array|string

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Create.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Create.php
@@ -15,19 +15,6 @@ class Create extends  CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Get.php
@@ -14,15 +14,4 @@ class Get extends GetProcessor
     public $permission = 'mssetting_view';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Delivery/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/GetList.php
@@ -17,18 +17,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Payments/Disable.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Payments/Disable.php
@@ -20,10 +20,6 @@ class Disable extends RemoveProcessor
      */
     public function initialize()
     {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
         /**
          * @TODO: hardcode
          */

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Payments/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Payments/GetList.php
@@ -18,18 +18,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Remove.php
@@ -12,15 +12,4 @@ class Remove extends RemoveProcessor
     public $permission = 'mssetting_save';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Sort.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Sort.php
@@ -12,18 +12,6 @@ class Sort extends ModelProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Settings/Delivery/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Delivery/Update.php
@@ -15,18 +15,6 @@ class Update extends UpdateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Link/Create.php
+++ b/core/components/minishop3/src/Processors/Settings/Link/Create.php
@@ -15,19 +15,6 @@ class Create extends CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Link/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Link/Get.php
@@ -14,15 +14,4 @@ class Get extends  GetProcessor
     public $permission = 'mssetting_view';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Link/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Link/GetList.php
@@ -16,18 +16,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Link/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Link/Remove.php
@@ -13,15 +13,4 @@ class Remove extends RemoveProcessor
     public $permission = 'mssetting_save';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Link/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Link/Update.php
@@ -16,18 +16,6 @@ class Update extends UpdateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Option/Assign.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Assign.php
@@ -20,19 +20,6 @@ class Assign extends CreateProcessor
     /**
      * @return bool|null|string
      */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
-     * @return bool|null|string
-     */
     public function beforeSet()
     {
         $option_id = $this->getProperty('option_id');

--- a/core/components/minishop3/src/Processors/Settings/Option/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Get.php
@@ -18,18 +18,6 @@ class Get extends GetProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return void
      */
     public function beforeOutput()

--- a/core/components/minishop3/src/Processors/Settings/Option/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Remove.php
@@ -13,15 +13,4 @@ class Remove extends RemoveProcessor
     public $permission = 'mssetting_save';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Option/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Update.php
@@ -18,18 +18,6 @@ class Update extends UpdateProcessor
     protected $oldKey = null;
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Payment/Create.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Create.php
@@ -16,19 +16,6 @@ class Create extends  CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/Disable.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/Disable.php
@@ -21,10 +21,6 @@ class Disable extends RemoveProcessor
      */
     public function initialize()
     {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
         /**
          * @TODO: hardcode
          */

--- a/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/Enable.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/Enable.php
@@ -16,18 +16,6 @@ class Enable extends CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSave()

--- a/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Deliveries/GetList.php
@@ -18,18 +18,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Payment/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Get.php
@@ -14,15 +14,4 @@ class Get extends GetProcessor
     public $permission = 'mssetting_view';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Payment/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/GetList.php
@@ -17,18 +17,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Payment/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Remove.php
@@ -12,15 +12,4 @@ class Remove extends RemoveProcessor
     public $permission = 'mssetting_save';
 
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Payment/Sort.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Sort.php
@@ -13,18 +13,6 @@ class Sort extends ModelProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Settings/Payment/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Update.php
@@ -15,18 +15,6 @@ class Update extends UpdateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Status/Create.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/Create.php
@@ -15,18 +15,6 @@ class Create extends CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Status/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/Get.php
@@ -14,18 +14,6 @@ class Get extends GetProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array
      */
     public function cleanup()

--- a/core/components/minishop3/src/Processors/Settings/Status/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/GetList.php
@@ -20,18 +20,6 @@ class GetList extends GetListProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @param xPDOQuery $c
      *
      * @return xPDOQuery

--- a/core/components/minishop3/src/Processors/Settings/Status/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/Remove.php
@@ -13,18 +13,6 @@ class Remove extends RemoveProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool|string
      */
     public function beforeRemove()

--- a/core/components/minishop3/src/Processors/Settings/Status/Sort.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/Sort.php
@@ -13,18 +13,6 @@ class Sort extends ModelProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/src/Processors/Settings/Status/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Status/Update.php
@@ -16,18 +16,6 @@ class Update extends UpdateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Vendor/Create.php
+++ b/core/components/minishop3/src/Processors/Settings/Vendor/Create.php
@@ -16,18 +16,6 @@ class Create extends CreateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()

--- a/core/components/minishop3/src/Processors/Settings/Vendor/Get.php
+++ b/core/components/minishop3/src/Processors/Settings/Vendor/Get.php
@@ -11,16 +11,4 @@ class Get extends GetProcessor
     public $objectType = 'msVendor';
     public $languageTopics = ['minishop3'];
     public $permission = 'mssetting_view';
-
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Vendor/GetList.php
+++ b/core/components/minishop3/src/Processors/Settings/Vendor/GetList.php
@@ -26,9 +26,6 @@ class GetList extends GetListProcessor
         if ($this->getProperty('combo') && !$this->getProperty('limit') && $id = (int)$this->getProperty('id')) {
             $this->item_id = $id;
         }
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
 
         return parent::initialize();
     }

--- a/core/components/minishop3/src/Processors/Settings/Vendor/Remove.php
+++ b/core/components/minishop3/src/Processors/Settings/Vendor/Remove.php
@@ -14,15 +14,4 @@ class Remove extends RemoveProcessor
     public $beforeRemoveEvent = 'msOnBeforeVendorDelete';
     public $afterRemoveEvent = 'msOnVendorDelete';
 
-    /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
 }

--- a/core/components/minishop3/src/Processors/Settings/Vendor/Update.php
+++ b/core/components/minishop3/src/Processors/Settings/Vendor/Update.php
@@ -16,18 +16,6 @@ class Update extends UpdateProcessor
 
 
     /**
-     * @return bool|null|string
-     */
-    public function initialize()
-    {
-        if (!$this->modx->hasPermission($this->permission)) {
-            return $this->modx->lexicon('access_denied');
-        }
-
-        return parent::initialize();
-    }
-
-    /**
      * @return bool
      */
     public function beforeSet()


### PR DESCRIPTION
## Описание

Убрана дублирующая проверка прав в процессорах MiniShop3 (Issue #9). В ряде процессоров в `initialize()` вызывался `hasPermission($this->permission)` и возвращался `access_denied`, хотя та же проверка уже выполняется в `checkPermissions()` базового Processor/ModelProcessor в `run()` до вызова `initialize()`. В результате права проверялись дважды.

**Что сделано:**
- В процессорах, где `initialize()` содержал только проверку прав и `return parent::initialize()`, метод `initialize()` удалён (54 файла).
- В процессорах, где в `initialize()` есть своя логика (combo/item_id, загрузка object, ms3, product и т.п.), удалён только блок с `hasPermission` и `return access_denied` (6 файлов: Settings/Vendor/GetList, Payment/Deliveries/Disable, Delivery/Payments/Disable, Product/ProductLink/Remove, Gallery/Upload, Gallery/GetList).

Процессоры с кастомным `checkPermissions()` (Api/Index, Utilities/Import/*, Utilities/Gallery/Update, Product/Delete, Publish, Unpublish, Undelete) не менялись. Проверка прав остаётся в базовом `checkPermissions()`; при отказе в доступе используется лексикон базового процессора (`permission_denied_processor`).

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #9

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.4.1-beta1
- MODX: —
- PHP: —

Проверен синтаксис всех процессоров (`php -l`). Логика прав не менялась: проверка по-прежнему выполняется в `checkPermissions()` до `initialize()`.

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| —   | —     |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

По комментарию [@biz87](https://github.com/modx-pro/MiniShop3/issues/9#issuecomment-3904422610): 56 процессоров с дублированием, кастомный `checkPermissions()` оставлен без изменений. Затронуто ~55 файлов в `core/components/minishop3/src/Processors/` (Settings, Product, Gallery, Customer, Customer/Address). Лексиконы и унификацию `access_denied` / `permission_denied_processor` в рамках этого PR не делали.