### PR TITLE
События loading/loaded для асинхронных экшенов (Issue #16)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,11 @@
   },
   "globals": {
     "ms3": "readonly",
-    "ms3Config": "readonly"
+    "ms3Config": "readonly",
+    "dispatchMs3Loading": "readonly"
   },
-  "ignorePatterns": ["**/node_modules/**", "**/mgr/**"]
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/mgr/**"
+  ]
 }

--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -233,6 +233,7 @@ return [
             "[[+jsUrl]]web\/lib\/izitoast\/iziToast.js",
             "[[+jsUrl]]web\/modules\/hooks.js",
             "[[+jsUrl]]web\/modules\/message.js",
+            "[[+jsUrl]]web\/core\/Ms3Events.js",
             "[[+jsUrl]]web\/core\/ApiClient.js",
             "[[+jsUrl]]web\/core\/TokenManager.js",
             "[[+jsUrl]]web\/core\/CartAPI.js",

--- a/assets/components/minishop3/css/web/default.css
+++ b/assets/components/minishop3/css/web/default.css
@@ -54,6 +54,12 @@ textarea.ms3_field_error:focus {
     box-shadow: 0 0 5px rgba(217, 83, 79, 0.5) !important;
 }
 
+/* Loading state (Issue #16): listeners of ms3:*:adding may set this attribute to show loader/block UI */
+[data-ms3-loading] {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
 /* Logs */
 .msProductsLog, .msGalleryLog, .msCartLog, .msOrderLog, .msGetOrderLog {
     width: 100%;

--- a/assets/components/minishop3/js/web/core/Ms3Events.js
+++ b/assets/components/minishop3/js/web/core/Ms3Events.js
@@ -1,0 +1,19 @@
+/**
+ * MiniShop3 DOM events helper (Issue #16)
+ *
+ * Single place for dispatching loading/loaded events.
+ * Loaded before UI modules so dispatchMs3Loading is available globally.
+ *
+ * @see https://github.com/modx-pro/MiniShop3/issues/16
+ */
+
+/**
+ * Dispatch a custom event on document (e.g. ms3:cart:adding, ms3:cart:added).
+ * Detail: { entity, action, form, data, response? }
+ *
+ * @param {string} name - Event name
+ * @param {Object} detail - Event detail
+ */
+window.dispatchMs3Loading = function (name, detail) {
+  document.dispatchEvent(new CustomEvent(name, { detail, bubbles: true }))
+}

--- a/assets/components/minishop3/js/web/ms3.js
+++ b/assets/components/minishop3/js/web/ms3.js
@@ -15,6 +15,25 @@
  *   render: { ... }
  * }
  *
+ * DOM events (Issue #16 — loading/loaded):
+ * - ms3:ready — init finished
+ * - ms3:cart:updated — cart data changed (detail: cart data)
+ * - ms3:cart:adding / ms3:cart:added — add to cart
+ * - ms3:cart:changing / ms3:cart:changed — change quantity
+ * - ms3:cart:removing / ms3:cart:removed — remove from cart
+ * - ms3:cart:cleaning / ms3:cart:cleaned — clear cart
+ * - ms3:order:adding / ms3:order:added — order field update
+ * - ms3:order:submitting / ms3:order:submitted — order submit
+ * - ms3:order:cleaning / ms3:order:cleaned — order clear
+ * - ms3:customer:adding / ms3:customer:added — customer field
+ * - ms3:customer:updating-profile / ms3:customer:updated-profile
+ * - ms3:customer:creating-address / ms3:customer:created-address
+ * - ms3:customer:updating-address / ms3:customer:updated-address
+ * - ms3:customer:changing-address / ms3:customer:changed-address
+ * - ms3:quantity:changing / ms3:quantity:changed — quantity +/-/input
+ * Event detail: { entity, action, form, data, response? }. Use *:ing to show loader, *:ed to hide.
+ * Optional: set [data-ms3-loading] on form/button in *:ing listener for built-in CSS (opacity, pointer-events).
+ *
  * Data attributes for logic (Issue #17): use data-ms3-* for JS selection; keep classes for styling.
  * - data-ms3-form / data-ms3-form="order"|"customer" — form
  * - data-ms3-error — field with validation error

--- a/assets/components/minishop3/js/web/ui/CartUI.js
+++ b/assets/components/minishop3/js/web/ui/CartUI.js
@@ -86,6 +86,13 @@ class CartUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:cart:changing', {
+        entity: 'cart',
+        action: 'change',
+        form: null,
+        data: { productKey, count },
+        response: null
+      })
       const renderTokens = this.getRenderTokens()
       const response = await this.cart.change(productKey, count, renderTokens)
 
@@ -106,9 +113,23 @@ class CartUI {
           this.message.error(response.message)
         }
       }
+      dispatchMs3Loading('ms3:cart:changed', {
+        entity: 'cart',
+        action: 'change',
+        form: null,
+        data: { productKey, count },
+        response
+      })
     } catch (error) {
       console.error('[CartUI] handleChange error:', error)
       this.message.error('Cart update error')
+      dispatchMs3Loading('ms3:cart:changed', {
+        entity: 'cart',
+        action: 'change',
+        form: null,
+        data: { productKey, count },
+        response: { success: false }
+      })
     }
   }
 
@@ -128,6 +149,13 @@ class CartUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:cart:adding', {
+        entity: 'cart',
+        action: 'add',
+        form: null,
+        data: { id, count, options },
+        response: null
+      })
       const renderTokens = this.getRenderTokens()
       const response = await this.cart.add(id, count, options, renderTokens)
 
@@ -148,9 +176,23 @@ class CartUI {
           this.message.error(response.message)
         }
       }
+      dispatchMs3Loading('ms3:cart:added', {
+        entity: 'cart',
+        action: 'add',
+        form: null,
+        data: { id, count, options },
+        response
+      })
     } catch (error) {
       console.error('[CartUI] handleAdd error:', error)
       this.message.error('Product addition error')
+      dispatchMs3Loading('ms3:cart:added', {
+        entity: 'cart',
+        action: 'add',
+        form: null,
+        data: { id, count, options },
+        response: { success: false }
+      })
     }
   }
 
@@ -168,6 +210,13 @@ class CartUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:cart:removing', {
+        entity: 'cart',
+        action: 'remove',
+        form: null,
+        data: { productKey },
+        response: null
+      })
       const renderTokens = this.getRenderTokens()
       const response = await this.cart.remove(productKey, renderTokens)
 
@@ -188,9 +237,23 @@ class CartUI {
           this.message.error(response.message)
         }
       }
+      dispatchMs3Loading('ms3:cart:removed', {
+        entity: 'cart',
+        action: 'remove',
+        form: null,
+        data: { productKey },
+        response
+      })
     } catch (error) {
       console.error('[CartUI] handleRemove error:', error)
       this.message.error('Product removal error')
+      dispatchMs3Loading('ms3:cart:removed', {
+        entity: 'cart',
+        action: 'remove',
+        form: null,
+        data: { productKey },
+        response: { success: false }
+      })
     }
   }
 
@@ -206,6 +269,13 @@ class CartUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:cart:cleaning', {
+        entity: 'cart',
+        action: 'clean',
+        form: null,
+        data: {},
+        response: null
+      })
       const renderTokens = this.getRenderTokens()
       const response = await this.cart.clean(renderTokens)
 
@@ -226,9 +296,23 @@ class CartUI {
           this.message.error(response.message)
         }
       }
+      dispatchMs3Loading('ms3:cart:cleaned', {
+        entity: 'cart',
+        action: 'clean',
+        form: null,
+        data: {},
+        response
+      })
     } catch (error) {
       console.error('[CartUI] handleClean error:', error)
       this.message.error('Cart clearing error')
+      dispatchMs3Loading('ms3:cart:cleaned', {
+        entity: 'cart',
+        action: 'clean',
+        form: null,
+        data: {},
+        response: { success: false }
+      })
     }
   }
 

--- a/assets/components/minishop3/js/web/ui/CustomerUI.js
+++ b/assets/components/minishop3/js/web/ui/CustomerUI.js
@@ -118,6 +118,13 @@ class CustomerUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:customer:adding', {
+        entity: 'customer',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response: null
+      })
       const response = await this.customer.add(key, value)
 
       await this.hooks.runHooks('afterAddCustomer', { key, value, response })
@@ -130,10 +137,24 @@ class CustomerUI {
         this.message.error(response.message)
       }
 
+      dispatchMs3Loading('ms3:customer:added', {
+        entity: 'customer',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response
+      })
       return response
     } catch (error) {
       console.error('CustomerUI.handleAdd error:', error)
       this.message.error(this.t('ms3_customer_err_occurred'))
+      dispatchMs3Loading('ms3:customer:added', {
+        entity: 'customer',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response: { success: false }
+      })
       return { success: false, message: error.message }
     }
   }
@@ -154,6 +175,13 @@ class CustomerUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:customer:changing-address', {
+        entity: 'customer',
+        action: 'change-address',
+        form: null,
+        data: { key, value },
+        response: null
+      })
       const response = await this.customer.changeAddress(key, value)
 
       await this.hooks.runHooks('afterChangeAddressCustomer', { key, value, response })
@@ -166,10 +194,24 @@ class CustomerUI {
         this.message.error(response.message)
       }
 
+      dispatchMs3Loading('ms3:customer:changed-address', {
+        entity: 'customer',
+        action: 'change-address',
+        form: null,
+        data: { key, value },
+        response
+      })
       return response
     } catch (error) {
       console.error('CustomerUI.handleChangeAddress error:', error)
       this.message.error(this.t('ms3_customer_err_occurred'))
+      dispatchMs3Loading('ms3:customer:changed-address', {
+        entity: 'customer',
+        action: 'change-address',
+        form: null,
+        data: { key, value },
+        response: { success: false }
+      })
       return { success: false }
     }
   }
@@ -195,6 +237,13 @@ class CustomerUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:customer:updating-profile', {
+        entity: 'customer',
+        action: 'update-profile',
+        form: null,
+        data,
+        response: null
+      })
       const response = await this.customer.updateProfile(data)
 
       await this.hooks.runHooks('afterUpdateProfile', { data, response })
@@ -209,10 +258,24 @@ class CustomerUI {
         this.message.error(response.message || this.t('ms3_customer_profile_update_error'))
       }
 
+      dispatchMs3Loading('ms3:customer:updated-profile', {
+        entity: 'customer',
+        action: 'update-profile',
+        form: null,
+        data,
+        response
+      })
       return response
     } catch (error) {
       console.error('CustomerUI.handleProfileUpdate error:', error)
       this.message.error(this.t('ms3_customer_err_occurred_saving'))
+      dispatchMs3Loading('ms3:customer:updated-profile', {
+        entity: 'customer',
+        action: 'update-profile',
+        form: null,
+        data,
+        response: { success: false }
+      })
       return { success: false, message: error.message }
     }
   }
@@ -238,6 +301,13 @@ class CustomerUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:customer:creating-address', {
+        entity: 'customer',
+        action: 'create-address',
+        form: null,
+        data,
+        response: null
+      })
       const response = await this.customer.createAddress(data)
 
       await this.hooks.runHooks('afterCreateAddress', { data, response })
@@ -252,10 +322,24 @@ class CustomerUI {
         this.message.error(response.message || this.t('ms3_customer_address_creation_error'))
       }
 
+      dispatchMs3Loading('ms3:customer:created-address', {
+        entity: 'customer',
+        action: 'create-address',
+        form: null,
+        data,
+        response
+      })
       return response
     } catch (error) {
       console.error('CustomerUI.handleAddressCreate error:', error)
       this.message.error(this.t('ms3_customer_err_occurred_saving'))
+      dispatchMs3Loading('ms3:customer:created-address', {
+        entity: 'customer',
+        action: 'create-address',
+        form: null,
+        data,
+        response: { success: false }
+      })
       return { success: false, message: error.message }
     }
   }
@@ -288,6 +372,13 @@ class CustomerUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:customer:updating-address', {
+        entity: 'customer',
+        action: 'update-address',
+        form: null,
+        data: { addressId, ...data },
+        response: null
+      })
       const response = await this.customer.updateAddress(addressId, data)
 
       await this.hooks.runHooks('afterUpdateAddress', { addressId, data, response })
@@ -302,10 +393,24 @@ class CustomerUI {
         this.message.error(response.message || this.t('ms3_customer_address_update_error'))
       }
 
+      dispatchMs3Loading('ms3:customer:updated-address', {
+        entity: 'customer',
+        action: 'update-address',
+        form: null,
+        data: { addressId, ...data },
+        response
+      })
       return response
     } catch (error) {
       console.error('CustomerUI.handleAddressUpdate error:', error)
       this.message.error(this.t('ms3_customer_err_occurred_saving'))
+      dispatchMs3Loading('ms3:customer:updated-address', {
+        entity: 'customer',
+        action: 'update-address',
+        form: null,
+        data: { addressId, ...data },
+        response: { success: false }
+      })
       return { success: false, message: error.message }
     }
   }

--- a/assets/components/minishop3/js/web/ui/OrderUI.js
+++ b/assets/components/minishop3/js/web/ui/OrderUI.js
@@ -122,6 +122,13 @@ class OrderUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:order:adding', {
+        entity: 'order',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response: null
+      })
       const response = await this.order.add(key, value)
 
       await this.hooks.runHooks('afterAddOrder', { key, value, response })
@@ -139,9 +146,23 @@ class OrderUI {
         await this.updateOrderCosts()
       }
 
+      dispatchMs3Loading('ms3:order:added', {
+        entity: 'order',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response
+      })
       return response
     } catch (error) {
       this.message.error('An error occurred')
+      dispatchMs3Loading('ms3:order:added', {
+        entity: 'order',
+        action: 'add',
+        form: null,
+        data: { key, value },
+        response: { success: false }
+      })
       return { success: false, message: error.message }
     }
   }
@@ -209,6 +230,13 @@ class OrderUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:order:submitting', {
+        entity: 'order',
+        action: 'submit',
+        form: null,
+        data: {},
+        response: null
+      })
       const response = await this.order.submit()
 
       await this.hooks.runHooks('afterSubmitOrder', { response })
@@ -230,9 +258,23 @@ class OrderUI {
         }
       }
 
+      dispatchMs3Loading('ms3:order:submitted', {
+        entity: 'order',
+        action: 'submit',
+        form: null,
+        data: {},
+        response
+      })
       return response
     } catch (error) {
       this.message.error('Order submission error')
+      dispatchMs3Loading('ms3:order:submitted', {
+        entity: 'order',
+        action: 'submit',
+        form: null,
+        data: {},
+        response: { success: false }
+      })
       return { success: false }
     }
   }
@@ -251,6 +293,13 @@ class OrderUI {
     }
 
     try {
+      dispatchMs3Loading('ms3:order:cleaning', {
+        entity: 'order',
+        action: 'clean',
+        form: null,
+        data: {},
+        response: null
+      })
       const response = await this.order.clean()
 
       await this.hooks.runHooks('afterCleanOrder', { response })
@@ -270,9 +319,23 @@ class OrderUI {
         document.dispatchEvent(new CustomEvent('ms3:cart:updated'))
       }
 
+      dispatchMs3Loading('ms3:order:cleaned', {
+        entity: 'order',
+        action: 'clean',
+        form: null,
+        data: {},
+        response
+      })
       return response
     } catch (error) {
       this.message.error('Order clearing error')
+      dispatchMs3Loading('ms3:order:cleaned', {
+        entity: 'order',
+        action: 'clean',
+        form: null,
+        data: {},
+        response: { success: false }
+      })
       return { success: false }
     }
   }

--- a/assets/components/minishop3/js/web/ui/QuantityUI.js
+++ b/assets/components/minishop3/js/web/ui/QuantityUI.js
@@ -158,6 +158,13 @@ class QuantityUI {
     count = hookData.count
 
     try {
+      dispatchMs3Loading('ms3:quantity:changing', {
+        entity: 'quantity',
+        action: 'change',
+        form,
+        data: { productKey, count },
+        response: null
+      })
       let response
       const renderTokens = this.getRenderTokens()
 
@@ -193,9 +200,23 @@ class QuantityUI {
           this.message.error(response.message)
         }
       }
+      dispatchMs3Loading('ms3:quantity:changed', {
+        entity: 'quantity',
+        action: 'change',
+        form,
+        data: { productKey, count },
+        response
+      })
     } catch (error) {
       console.error('[QuantityUI] updateQuantity error:', error)
       this.message.error('Cart update error')
+      dispatchMs3Loading('ms3:quantity:changed', {
+        entity: 'quantity',
+        action: 'change',
+        form,
+        data: { productKey, count },
+        response: { success: false }
+      })
     }
   }
 

--- a/core/components/minishop3/migrations/20260217130000_add_ms3_events_to_frontend_assets.php
+++ b/core/components/minishop3/migrations/20260217130000_add_ms3_events_to_frontend_assets.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Migration: Add Ms3Events.js to ms3_frontend_assets setting
+ *
+ * Adds the events helper (Issue #16) before ApiClient so it is available to UI modules.
+ *
+ * @see https://github.com/modx-pro/MiniShop3/issues/16
+ */
+class AddMs3EventsToFrontendAssets extends AbstractMigration
+{
+    private const NEW_FILE = '[[+jsUrl]]web/core/Ms3Events.js';
+
+    private const INSERT_AFTER = '[[+jsUrl]]web/modules/message.js';
+
+    public function up(): void
+    {
+        $prefix = $this->getAdapter()->getOption('table_prefix');
+        $table = $prefix . 'system_settings';
+
+        $row = $this->fetchRow(
+            "SELECT `value` FROM `{$table}` WHERE `key` = 'ms3_frontend_assets'"
+        );
+
+        if (!$row) {
+            return;
+        }
+
+        $assets = json_decode($row['value'], true);
+        if (!is_array($assets)) {
+            return;
+        }
+
+        $normalizedAssets = array_map(function ($path) {
+            return str_replace('\\/', '/', $path);
+        }, $assets);
+
+        $newFileNormalized = str_replace('\\/', '/', self::NEW_FILE);
+        $insertAfterNormalized = str_replace('\\/', '/', self::INSERT_AFTER);
+
+        if (in_array($newFileNormalized, $normalizedAssets, true)) {
+            return;
+        }
+
+        $insertPosition = array_search($insertAfterNormalized, $normalizedAssets, true);
+
+        if ($insertPosition !== false) {
+            array_splice($assets, $insertPosition + 1, 0, [self::NEW_FILE]);
+        } else {
+            $assets[] = self::NEW_FILE;
+        }
+
+        $newValue = json_encode($assets, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        $this->execute(
+            "UPDATE `{$table}` SET `value` = " . $this->getAdapter()->getConnection()->quote($newValue) .
+            " WHERE `key` = 'ms3_frontend_assets'"
+        );
+    }
+
+    public function down(): void
+    {
+        $prefix = $this->getAdapter()->getOption('table_prefix');
+        $table = $prefix . 'system_settings';
+
+        $row = $this->fetchRow(
+            "SELECT `value` FROM `{$table}` WHERE `key` = 'ms3_frontend_assets'"
+        );
+
+        if (!$row) {
+            return;
+        }
+
+        $assets = json_decode($row['value'], true);
+        if (!is_array($assets)) {
+            return;
+        }
+
+        $assets = array_values(array_filter($assets, function ($path) {
+            $normalized = str_replace('\\/', '/', $path);
+            return $normalized !== str_replace('\\/', '/', self::NEW_FILE);
+        }));
+
+        $newValue = json_encode($assets, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        $this->execute(
+            "UPDATE `{$table}` SET `value` = " . $this->getAdapter()->getConnection()->quote($newValue) .
+            " WHERE `key` = 'ms3_frontend_assets'"
+        );
+    }
+}


### PR DESCRIPTION
## Описание

Добавлены пары DOM-событий «начало/конец» для асинхронных операций (Issue #16). Подписчики могут показывать лоадер или блокировать элементы на время запроса.

**Что сделано:**
- События `ms3:{entity}:{action}ing` перед вызовом API и `ms3:{entity}:{action}ed` после (cart, order, customer, quantity).
- В `detail`: `entity`, `action`, `form`, `data`, `response` (в `*:ed`).
- Общий хелпер `dispatchMs3Loading` в `Ms3Events.js` (без дублирования в UI).
- CSS `[data-ms3-loading]` для стилизации состояния загрузки (атрибут выставляют подписчики).
- Документация списка событий и формата `detail` в комментариях `ms3.js`.
- Миграция для добавления `Ms3Events.js` в `ms3_frontend_assets`.

**Пример подписки:**
```js
document.addEventListener('ms3:cart:adding', (e) => {
  e.detail.form?.setAttribute('data-ms3-loading', '')
})
document.addEventListener('ms3:cart:added', (e) => {
  e.detail.form?.removeAttribute('data-ms3-loading')
})
```

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #16

## Как это было протестировано?

- [x] Ручное тестирование
- [x] Автоматические тесты (ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка feature/16-loading-events
- MODX: —
- PHP: —

## Скриншоты (если применимо)

Не применимо — визуальное поведение без подписки на события не меняется.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- В QuantityUI в `detail` передаётся `form` (форма с контролами количества).
- События `*:ed` диспатчатся и при успехе, и при ошибке (в catch с `response: { success: false }`).
