### PR TITLE
fix: allow clearing EAV options from product form

### DIFF
--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -100,19 +100,13 @@ class Create extends CreateProcessor
         // JSON fields like color/size are saved separately via msProductData::save()
         $options = $this->getProperty('options');
         if (!empty($options) && is_array($options)) {
-            // Filter out empty values
-            $options = array_filter($options, function ($value) {
-                return $value !== '' && $value !== null && $value !== [];
-            });
-
-            if (!empty($options)) {
-                /** @var \MiniShop3\Model\msProductData $productData */
-                $productData = $this->object->loadData();
-                if ($productData) {
-                    $service = $this->modx->services->get('ms3_product_data_service');
-                    // Don't remove other options - they come from JSON fields
-                    $service->saveOptions($productData, $options, false);
-                }
+            /** @var \MiniShop3\Model\msProductData $productData */
+            $productData = $this->object->loadData();
+            if ($productData) {
+                $service = $this->modx->services->get('ms3_product_data_service');
+                // Don't remove other options - they come from JSON fields
+                // Empty values are passed through to signal deletion
+                $service->saveOptions($productData, $options, false);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -112,19 +112,13 @@ class Update extends UpdateProcessor
         // JSON fields like color/size are saved separately via msProductData::save()
         $options = $this->getProperty('options');
         if (!empty($options) && is_array($options)) {
-            // Filter out empty values
-            $options = array_filter($options, function ($value) {
-                return $value !== '' && $value !== null && $value !== [];
-            });
-
-            if (!empty($options)) {
-                /** @var \MiniShop3\Model\msProductData $productData */
-                $productData = $this->object->loadData();
-                if ($productData) {
-                    $service = $this->modx->services->get('ms3_product_data_service');
-                    // Don't remove other options - they come from JSON fields
-                    $service->saveOptions($productData, $options, false);
-                }
+            /** @var \MiniShop3\Model\msProductData $productData */
+            $productData = $this->object->loadData();
+            if ($productData) {
+                $service = $this->modx->services->get('ms3_product_data_service');
+                // Don't remove other options - they come from JSON fields
+                // Empty values are passed through to signal deletion
+                $service->saveOptions($productData, $options, false);
             }
         }
 

--- a/core/components/minishop3/src/Services/Option/OptionSyncService.php
+++ b/core/components/minishop3/src/Services/Option/OptionSyncService.php
@@ -52,6 +52,9 @@ class OptionSyncService
 
             if (is_array($values) && !empty($values)) {
                 $this->syncOptionValues($productId, $key, $values, $existingOptions);
+            } elseif (isset($existingOptions[$key])) {
+                // Empty value explicitly passed — delete option from DB
+                $this->removeOptionKey($productId, $key);
             }
         }
 
@@ -163,6 +166,22 @@ class OptionSyncService
             }
             $addStmt->execute([$productId, $key, $newValue]);
         }
+    }
+
+    /**
+     * Remove all values for a single option key
+     *
+     * Used when an explicitly empty value is passed for an option,
+     * signaling that the option should be cleared.
+     *
+     * @param int $productId Product ID
+     * @param string $key Option key to remove
+     */
+    protected function removeOptionKey(int $productId, string $key): void
+    {
+        $table = $this->xpdo->getTableName(msProductOption::class);
+        $stmt = $this->xpdo->prepare("DELETE FROM {$table} WHERE `product_id` = ? AND `key` = ?");
+        $stmt->execute([$productId, $key]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Убран `array_filter` в процессорах `Product/Create` и `Product/Update`, который отбрасывал пустые значения опций до передачи в сервис
- Добавлен метод `removeOptionKey()` в `OptionSyncService` — пустое значение опции теперь сигнализирует об удалении записи из `ms3_product_options`

**Проблема:** при очистке EAV-опции на вкладке "Опции" в админке значение не удалялось из БД, а оставалось старым.

## Test plan

- [ ] Создать товар с EAV-опцией (вкладка "Опции"), сохранить
- [ ] Очистить значение опции, сохранить
- [ ] Убедиться что запись удалена из `ms3_product_options`
- [ ] Проверить что JSON-поля (color, size, tags) на основной вкладке продолжают работать корректно

🤖 Generated with [Claude Code](https://claude.com/claude-code)