### PR TITLE
fix: make grid seed migrations idempotent

### DIFF
--- a/core/components/minishop3/migrations/20251204140000_seed_orders_grid_config.php
+++ b/core/components/minishop3/migrations/20251204140000_seed_orders_grid_config.php
@@ -9,6 +9,15 @@ class SeedOrdersGridConfig extends AbstractMigration
 {
     public function up()
     {
+        $prefix = $this->adapter->getOption('table_prefix');
+
+        // Check if data already exists (idempotency for partial re-runs)
+        $count = $this->fetchRow("SELECT COUNT(*) as cnt FROM {$prefix}ms3_grid_fields WHERE grid_key = 'orders'");
+        if ($count['cnt'] > 0) {
+            $this->output->writeln('<comment>Orders grid fields already exist, skipping</comment>');
+            return;
+        }
+
         $now = date('Y-m-d H:i:s');
         $data = [
             // ID column

--- a/core/components/minishop3/migrations/20260119220000_update_orders_grid_status_fields.php
+++ b/core/components/minishop3/migrations/20260119220000_update_orders_grid_status_fields.php
@@ -26,8 +26,8 @@ final class UpdateOrdersGridStatusFields extends AbstractMigration
         $now = date('Y-m-d H:i:s');
         $table = $this->table('ms3_grid_fields');
 
-        // Delete old status_name field
-        $this->execute("DELETE FROM {$this->prefix}ms3_grid_fields WHERE grid_key = 'orders' AND field_name = 'status_name'");
+        // Delete old status_name and cleanup new fields (idempotency for partial re-runs)
+        $this->execute("DELETE FROM {$this->prefix}ms3_grid_fields WHERE grid_key = 'orders' AND field_name IN ('status_name', 'order_status', 'status_color')");
 
         // Add new fields
         $newFields = [


### PR DESCRIPTION
## Summary

- Добавлен `SELECT COUNT(*)` guard в `seed_orders_grid_config` — если записи orders grid уже есть, миграция пропускается
- Расширен `DELETE` в `update_orders_grid_status_fields` — перед INSERT удаляются все три новых поля (`status_name`, `order_status`, `status_color`), а не только старое `status_name`

**Проблема:** при частичном выполнении миграции `20260119220000` (Phinx + MySQL = нет транзакций) запись `order_status` оставалась в БД, повторный запуск падал с `Duplicate entry 'orders-order_status'`.

## Test plan

- [ ] Чистая установка — миграции проходят без ошибок
- [ ] Повторный запуск миграций — seed пропускается, update не падает на duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)