### PR TITLE
Release 1.5.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,71 +16,56 @@
 
 ## Февраль 2026
 
-### [2026-02-15] Исправления getIterator и статусов заказов
+### 🚀 Версия 1.5.0-beta1
 
-#### 🐛 Исправлено
-
-**Критический баг getIterator + class_key (PR #90, Issue #87):**
-- `xPDO::getIterator()` не вызывает `addDerivativeCriteria()` — в отличие от `getCollection()`
-- Для классов без собственной таблицы (msCategory, msProduct наследуют modResource) это приводило к ошибке: `Instantiated a derived class msProduct that is not a subclass of the requested class msCategory`
-- Добавлен явный фильтр `class_key` в 3 местах:
-  - `CategoryProductsController::getList()` — `class_key => msProduct::class`
-  - `CategoryProductsController::getChildCategories()` — `class_key => msCategory::class`
-  - `ReferencesController::searchProducts()` — `class_key => msProduct::class`
-  - `Settings/Option/Get::beforeOutput()` — `class_key => msCategory::class`
-
-**Ошибка "Статус с таким идентификатором не найден" при оформлении заказа (PR #91, Issue #89):**
-- Системные настройки `ms3_status_new`, `ms3_status_paid`, `ms3_status_canceled` имели дефолтное значение `0` в `_build/elements/settings.php`
-- `$modx->getOption('ms3_status_new', null, 2)` возвращает `0` (а не fallback `2`), когда настройка существует со значением `0`
-- Исправлены дефолты: `ms3_status_new` → 2, `ms3_status_paid` → 3, `ms3_status_canceled` → 5
-- Добавлен fallback `?: default` во все 11 вызовов `getOption('ms3_status_*')` в 7 файлах для существующих установок
-
----
-
-### [2026-02-14] 🚀 Версия 1.4.1-beta1
-
-**Тип релиза:** PATCH (beta) — рефакторинг UI, локализация галереи, исправления
+**Тип релиза:** MINOR (beta) — селекторы, обработка ошибок, community PRs
 
 ---
 
 #### ✨ Добавлено
 
-**Локализация загрузчика Uppy в галерее (PR #79):**
-- Все строки интерфейса Uppy переведены через lexicon (ru/en)
-- Поддержка плюрализации для русского языка (3 формы)
-- 22 новых ключа лексикона `ms3_gallery_uppy_*`
+**Централизация селекторов (Issue #18):**
+- Новый модуль `Selectors.js` с дефолтными селекторами для всех UI-компонентов
+- Переопределение через `ms3Config.selectors` — частичное слияние с дефолтами
+- UI-классы (CartUI, OrderUI, QuantityUI, CustomerUI, ProductCardUI) используют селекторы из конфига
+- Миграция для добавления `Selectors.js` в `ms3_frontend_assets`
 
-**Улучшения товаров:**
-- Tooltip с ключом плейсхолдера на полях товара в админке
-- Поддержка HTML array формата для опций товара в корзине
+**Обработка отсутствия сервиса ms3 (Issue #68):**
+- `ServiceCheckMiddleware` — проверка `has('ms3')` на уровне роутера для всех `/api/v1` маршрутов
+- Проверка `has('ms3')` в точках входа (api.php, connector.php), плагине и всех сниппетах
+- 503 + лог вместо необработанного Exception при отсутствии сервиса
 
-**Инфраструктура:**
-- Единообразное отображение иконки календаря в DatePicker (PR #83)
-- GitHub Actions workflow для автоматического создания релизов
+**data-* атрибуты как основные селекторы (Issue #17):**
+- `data-ms3-form`, `data-ms3-qty`, `data-ms3-cart-options`, `data-ms3-product-card` и др.
+- CSS-классы сохранены как fallback для обратной совместимости
 
-#### 🔧 Изменено
+**Пагинация и количество строк в гриде заказов (Issue #78):**
+- Выбор количества строк на странице
+- Кнопки перехода в начало/конец списка
+- Хеш-параметры в чанках
 
-**Рефакторинг Vue UI (PR #71):**
-- Все размеры в Vue компонентах переведены из `px` в `rem`
-- Компоненты `Dropdown` заменены на `Select` (PrimeVue 4)
-- Обновлены текстовые цветовые переменные для консистентности UI
-- Плейсхолдеры и значения в контролах приведены к единому виду
-- Обновлены стили и иконки OptionsChips и StatusesGrid
-- Обновлена конфигурация ESLint, добавлены скрипты форматирования
-- Применён Prettier ко всем Vue компонентам
-
-**Рефакторинг кода:**
-- Выделен `QuantityUI` для управления количеством товаров в корзине
-- Минимальная версия PHP повышена до 8.2
-- Удалён мёртвый PHP код
+**Прочее:**
+- Событие `ms3:cart:updated` при успешном оформлении заказа (#96)
+- Параметр `formatPrices` в сниппете `msOrderTotal`
+- Сортировка в таблице списка заказов (Vue)
 
 #### 🐛 Исправлено
 
-- Исправлено отображение JSON-полей `color` и `size` в шаблоне товара
-- Исправлен префикс плейсхолдеров вендора с `vendor.` на `vendor_`
-- Исправлено копирование товара — изображения больше не дублируются при дубликации
-- Исправлена подгрузка описаний в сниппеты (PR #70)
-- Восстановлена корректная зависимость `@primeuix/themes`
+- Исправлены неточности в лексиконах (Issue #21)
+- Удалён `action` из конфигурации меню miniShop3 (#94)
+- Очистка EAV-опций из формы товара
+- Пустой список заказов из-за лишнего `GROUP BY`
+- Идемпотентность seed-миграций грид-конфигурации
+- `Response::error` теперь включает корректный HTTP-код (`code`) в JSON-ответ
+- `CartController::change()`/`remove()` — исправлен тип возвращаемого значения (array вместо Response)
+- Корректные дефолтные ID статусов заказов с fallback для нулевых значений
+- `getIterator` для msProduct/msCategory — добавлен `class_key` в критерии
+
+#### 🔧 Изменено
+
+- Удалены избыточные проверки прав в `initialize()` процессоров (#95)
+- `CustomerAddressController::getAuthorizedCustomer()` упрощён (middleware гарантирует сервис)
+- Убран fallback-регистрация сервиса в `api.php` — при сбое bootstrap возвращается 503
 
 ---
 

--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -12,7 +12,7 @@ return [
     'name' => 'MiniShop3',
     'name_lower' => 'minishop3',
     'name_short' => 'ms3',
-    'version' => '1.4.1',
+    'version' => '1.5.0',
     'release' => 'beta1',
     // Install package to site right after build
     'install' => false,

--- a/core/components/minishop3/docs/changelog.txt
+++ b/core/components/minishop3/docs/changelog.txt
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta1]
+
+### Added
+- Centralized selectors module (`Selectors.js`) with override via `ms3Config.selectors` (Issue #18)
+- `ServiceCheckMiddleware` for graceful 503 on missing ms3 service (Issue #68)
+- `has('ms3')` checks in all entry points, plugin events, and snippets
+- `data-ms3-*` attributes as primary selectors, CSS classes as fallback (Issue #17)
+- Rows per page selector, first/last pagination buttons, chunk hashes (Issue #78)
+- `ms3:cart:updated` event on successful order submission (#96)
+- `formatPrices` parameter for `msOrderTotal` snippet
+- Sorting in orders list grid (Vue)
+
+### Fixed
+- Lexicon corrections (Issue #21)
+- Removed `action` from miniShop3 menu configuration (#94)
+- EAV options clearing from product form
+- Empty orders list caused by unnecessary `GROUP BY`
+- Idempotent grid seed migrations
+- `Response::error` now includes correct HTTP status code in JSON response
+- `CartController::change()`/`remove()` return type (array instead of Response object)
+- Correct default order status IDs with fallback for zero values
+- `getIterator` for msProduct/msCategory — added `class_key` to criteria
+
+### Changed
+- Removed redundant permission checks from processor `initialize()` methods (#95)
+- Simplified `CustomerAddressController::getAuthorizedCustomer()` (middleware guarantees service)
+- Removed fallback service registration in `api.php` — returns 503 on bootstrap failure
+
+## [1.4.1-beta1] - 2026-02-14
+
+### Added
+- Tooltip with placeholder key on product fields
+- HTML array format support for cart options
+- QuantityUI module extracted from cart logic
+- Gallery interface localization
+- GitHub Actions workflow for automatic release creation
+
+### Changed
+- Minimum PHP version raised to 8.2
+- All px units converted to rem in Vue components
+- Dropdown components replaced with Select (PrimeVue 4)
+- Unified placeholder/value display in form controls
+- Text color variables updated for UI consistency
+
+### Fixed
+- Product copy no longer duplicates gallery images
+- JSON fields (color, size) display in product template
+- Vendor placeholder prefix (`vendor.` → `vendor_`)
+- Snippet descriptions loading
+- Calendar icon display unified across components
+
 ## [1.4.0-beta1] - 2026-02-07
 
 ### Added

--- a/core/components/minishop3/src/MiniShop3.php
+++ b/core/components/minishop3/src/MiniShop3.php
@@ -20,7 +20,7 @@ use xPDO\xPDO;
 
 class MiniShop3
 {
-    public $version = '1.4.1-beta1';
+    public $version = '1.5.0-beta1';
 
     /** @var modX $modx */
     public $modx;


### PR DESCRIPTION
## Summary
- Версия обновлена до 1.5.0-beta1
- Включает все изменения из beta (PR #97, #99, #104, #103, #102) + предыдущие фиксы

### Ключевые изменения
- **Issue #18:** Централизация селекторов — `Selectors.js`, переопределение через `ms3Config.selectors`
- **Issue #68:** Обработка отсутствия сервиса ms3 — `ServiceCheckMiddleware`, graceful 503
- **Issue #17:** `data-ms3-*` атрибуты как основные селекторы
- **Issue #78:** Пагинация и выбор количества строк в гриде заказов
- **Issue #21:** Исправления лексиконов
- Исправления: пустой список заказов (GROUP BY), идемпотентность миграций, сортировка заказов, EAV-опции, Response::error HTTP-код, CartController return type

### Файлы релиза
- `_build/config.inc.php` — version 1.5.0 / beta1
- `src/MiniShop3.php` — version 1.5.0-beta1
- `CHANGELOG.md` — секция 1.5.0-beta1
- `docs/changelog.txt` — секции 1.5.0-beta1 и 1.4.1-beta1

## Test plan
- [ ] Проверить фронтенд: корзина, заказ, quantity +/-, product cards
- [ ] Проверить переопределение селекторов через `ms3Config.selectors`
- [ ] Проверить 503 при отсутствии сервиса ms3
- [ ] Проверить админку: список заказов (сортировка, пагинация)
- [ ] PHPStan без новых ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)