### PR TITLE
fix(policies): формат data для совместимости с апгрейдом MODX

### DIFF
--- a/_build/elements/policies.php
+++ b/_build/elements/policies.php
@@ -1,26 +1,28 @@
 <?php
 
+$permissions = [
+    'mscategory_save',
+    'msproduct_save',
+    'msproduct_publish',
+    'msproduct_delete',
+    'msorder_save',
+    'msorder_view',
+    'msorder_list',
+    'msorder_remove',
+    'mssetting_save',
+    'mssetting_view',
+    'mssetting_list',
+    'msproductfile_save',
+    'msproductfile_generate',
+    'msproductfile_list',
+];
+
 return [
     'miniShopManagerPolicy' => [
         'description' => 'A policy for create and update MiniShop3 categories and products.',
         'parent' => 0,
         'class' => '',
         'lexicon' => 'minishop3:permissions',
-        'data' => json_encode(array(
-            'mscategory_save' => true,
-            'msproduct_save' => true,
-            'msproduct_publish' => true,
-            'msproduct_delete' => true,
-            'msorder_save' => true,
-            'msorder_view' => true,
-            'msorder_list' => true,
-            'msorder_remove' => true,
-            'mssetting_save' => true,
-            'mssetting_view' => true,
-            'mssetting_list' => true,
-            'msproductfile_save' => true,
-            'msproductfile_generate' => true,
-            'msproductfile_list' => true,
-        )),
+        'data' => array_fill_keys($permissions, true),
     ],
 ];


### PR DESCRIPTION
## Описание

Поле `data` в политиках доступа передаётся массивом вместо `json_encode(array(...))`. В `build.php` массив кодируется в JSON один раз; устраняется двойное кодирование при сборке пакета. Рефакторинг: список разрешений вынесен в `$permissions`, `data` собирается через `array_fill_keys($permissions, true)` (DRY).

При апгрейде MODX (например, 3.12 → 3.20) скрипт `upgrade.install.php` вызывает `array_diff_key($adminPolicy->get('data'), $policy->get('data'))`. Если в БД попадал двойной JSON или сырая строка, `get('data')` мог вернуть не массив → PHP 8 TypeError. Корректный формат при сборке устраняет эту причину со стороны экстры.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #100

Связано с modxcms/revolution#16825 (исправление в ядре MODX для `modAccessPolicy::get('data')`).

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: —
- PHP: —

## Скриншоты (если применимо)

Не применимо.

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Поведение для уже установленных сайтов не меняется. Новые установки и пересборки пакета получают корректный JSON в `mod_access_policy.data`.