### PR TITLE
fix(manager): correct Save button display in products and categories for MODX 3.2

### DIFF
--- a/core/components/minishop3/controllers/category/update.class.php
+++ b/core/components/minishop3/controllers/category/update.class.php
@@ -111,18 +111,16 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             'show_nested_products' => (bool) $this->modx->getOption('ms3_category_show_nested_products', null, true),
             'category_products_rows' => (int) $this->getOption('ms3_category_products_default_rows', null, 20),
         );
-        $canSaveCategory = $this->modx->hasPermission('save_document')
-            && $this->modx->hasPermission('mscategory_save')
-            && $this->resource->checkPolicy('save');
+        // Parent already sets $this->canSave (save_document, checkPolicy('save'), lock). Add component permission only.
         $ready = array(
             'xtype' => 'ms3-page-category-update',
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
             'publish_document' => $this->canPublish,
             'preview_url' => $this->previewUrl,
-            'locked' => $canSaveCategory ? false : $this->locked,
+            'locked' => $this->locked,
             'lockedText' => $this->lockedText,
-            'canSave' => (int) $canSaveCategory,
+            'canSave' => (int) ($this->canSave && $this->modx->hasPermission('mscategory_save')),
             'canEdit' => $this->canEdit,
             'canCreate' => $this->canCreate,
             'canDuplicate' => $this->canDuplicate,

--- a/core/components/minishop3/controllers/category/update.class.php
+++ b/core/components/minishop3/controllers/category/update.class.php
@@ -111,15 +111,18 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             'show_nested_products' => (bool) $this->modx->getOption('ms3_category_show_nested_products', null, true),
             'category_products_rows' => (int) $this->getOption('ms3_category_products_default_rows', null, 20),
         );
+        $canSaveCategory = $this->modx->hasPermission('save_document')
+            && $this->modx->hasPermission('mscategory_save')
+            && $this->resource->checkPolicy('save');
         $ready = array(
             'xtype' => 'ms3-page-category-update',
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
             'publish_document' => $this->canPublish,
             'preview_url' => $this->previewUrl,
-            'locked' => $this->locked,
+            'locked' => $canSaveCategory ? false : $this->locked,
             'lockedText' => $this->lockedText,
-            'canSave' => $this->modx->hasPermission('mscategory_save'),
+            'canSave' => (int) $canSaveCategory,
             'canEdit' => $this->canEdit,
             'canCreate' => $this->canCreate,
             'canDuplicate' => $this->canDuplicate,

--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -135,15 +135,18 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'fields_config' => $fieldsConfig,
         ];
 
+        $canSaveProduct = $this->modx->hasPermission('save_document')
+            && $this->modx->hasPermission('msproduct_save')
+            && $this->resource->checkPolicy('save');
         $ready = [
             'xtype' => 'ms3-page-product-update',
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
             'publish_document' => $this->canPublish,
             'preview_url' => $this->previewUrl,
-            'locked' => $this->locked,
+            'locked' => $canSaveProduct ? false : $this->locked,
             'lockedText' => $this->lockedText,
-            'canSave' => $this->canSave,
+            'canSave' => (int) $canSaveProduct,
             'canEdit' => $this->canEdit,
             'canCreate' => $this->canCreate,
             'canDuplicate' => $this->canDuplicate,

--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -135,18 +135,16 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'fields_config' => $fieldsConfig,
         ];
 
-        $canSaveProduct = $this->modx->hasPermission('save_document')
-            && $this->modx->hasPermission('msproduct_save')
-            && $this->resource->checkPolicy('save');
+        // Parent already sets $this->canSave (save_document, checkPolicy('save'), lock). Add component permission only.
         $ready = [
             'xtype' => 'ms3-page-product-update',
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
             'publish_document' => $this->canPublish,
             'preview_url' => $this->previewUrl,
-            'locked' => $canSaveProduct ? false : $this->locked,
+            'locked' => $this->locked,
             'lockedText' => $this->lockedText,
-            'canSave' => (int) $canSaveProduct,
+            'canSave' => (int) ($this->canSave && $this->modx->hasPermission('msproduct_save')),
             'canEdit' => $this->canEdit,
             'canCreate' => $this->canCreate,
             'canDuplicate' => $this->canDuplicate,


### PR DESCRIPTION
## Описание

После обновления MODX до 3.2.0 (Editor grids permissions refactor #16653) кнопка «Сохранить» на страницах редактирования товаров и категорий некорректно заменялась на иконку замка.

Исправление: явно задаём `canSave` и `locked` в конфиге `$ready` на основе проверки прав `save_document`, компонентной permission (`msproduct_save`/`mscategory_save`) и `checkPolicy('save')` для совместимости с Resource Groups.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Связано с изменениями в MODX 3.2.0 (#16653).

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: beta
- MODX: 3.2.0+
- PHP: 8.1+

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений) — не применимо
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Изменения в `product/update.class.php` и `category/update.class.php`: вместо наследования значений `canSave`/`locked` от родительского контроллера явно вычисляем их с учётом всех необходимых проверок прав.