### PR TITLE
feat(product): remember active Vue tab across page reloads

### DIFF
--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -129,6 +129,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'additional_fields' => [],
             'media_source' => $this->getSourceProperties(),
             'isHideContent' => $this->isHideContent(),
+            'product_remember_tabs' => (bool)$this->getOption('ms3_product_remember_tabs', null, true),
             'lexicon' => [
                 'ms3_product_data_vue' => $this->modx->lexicon('ms3_product_data_vue'),
             ],

--- a/vueManager/src/components/ProductData.vue
+++ b/vueManager/src/components/ProductData.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { useLexicon } from '@vuetools/useLexicon'
 import { Button, Card, Column, DataTable, Dialog, InputText, Select } from 'primevue'
 import ConfirmDialog from 'primevue/confirmdialog'
 import Toast from 'primevue/toast'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { onMounted, ref } from 'vue'
+import { useLexicon } from '@vuetools/useLexicon'
 
 const confirm = useConfirm()
 const toast = useToast()
@@ -114,12 +114,7 @@ const confirmRemove = field => {
     accept: () => {
       remove(field.name)
       save()
-      toast.add({
-        severity: 'success',
-        summary: _('ms3_vue_success_title'),
-        detail: _('ms3_vue_record_deleted'),
-        life: 3000,
-      })
+      toast.add({ severity: 'success', summary: _('ms3_vue_success_title'), detail: _('ms3_vue_record_deleted'), life: 3000 })
     },
   })
 }

--- a/vueManager/src/components/ProductData.vue
+++ b/vueManager/src/components/ProductData.vue
@@ -1,11 +1,11 @@
 <script setup>
+import { useLexicon } from '@vuetools/useLexicon'
 import { Button, Card, Column, DataTable, Dialog, InputText, Select } from 'primevue'
 import ConfirmDialog from 'primevue/confirmdialog'
 import Toast from 'primevue/toast'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { onMounted, ref } from 'vue'
-import { useLexicon } from '@vuetools/useLexicon'
 
 const confirm = useConfirm()
 const toast = useToast()
@@ -114,7 +114,12 @@ const confirmRemove = field => {
     accept: () => {
       remove(field.name)
       save()
-      toast.add({ severity: 'success', summary: _('ms3_vue_success_title'), detail: _('ms3_vue_record_deleted'), life: 3000 })
+      toast.add({
+        severity: 'success',
+        summary: _('ms3_vue_success_title'),
+        detail: _('ms3_vue_record_deleted'),
+        life: 3000,
+      })
     },
   })
 }

--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -29,6 +29,8 @@ const props = defineProps({
 const { _ } = useLexicon()
 useToast() // Required for Toast component to work
 
+const STORAGE_KEY = 'ms3-product-vue-active-tab'
+
 // Active tab value (index as string for Tabs v4)
 const activeTab = ref('0')
 
@@ -302,6 +304,14 @@ function onTabChange(newValue) {
 
   if (!currentTab) return
 
+  if (props.config.product_remember_tabs && currentTab.key) {
+    try {
+      localStorage.setItem(STORAGE_KEY, currentTab.key)
+    } catch (_e) {
+      // ignore quota or private mode
+    }
+  }
+
   nextTick(() => {
     if (currentTab.type === 'extjs' && !mountedExtComponents.value[currentTab.key]) {
       mountExtJS(currentTab.key, currentTab)
@@ -369,6 +379,16 @@ defineExpose({
 
 onMounted(() => {
   tabsReady.value = true
+
+  if (props.config.product_remember_tabs) {
+    nextTick(() => {
+      const savedKey = localStorage.getItem(STORAGE_KEY)
+      if (savedKey) {
+        const idx = tabConfig.value.findIndex(t => t.key === savedKey)
+        if (idx >= 0) activeTab.value = String(idx)
+      }
+    })
+  }
 
   // Register this instance in global registry
   if (window.MS3ProductTabsRegistry) {

--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -377,26 +377,24 @@ defineExpose({
   getActiveTab: () => parseInt(activeTab.value, 10),
 })
 
-onMounted(() => {
-  if (props.config.product_remember_tabs) {
-    try {
-      const savedKey = localStorage.getItem(STORAGE_KEY)
-      if (savedKey) {
-        const idx = tabConfig.value.findIndex(t => t.key === savedKey)
-        if (idx >= 0) activeTab.value = String(idx)
-      }
-    } catch (_e) {
-      // ignore quota, private mode, security policies
-    }
+/** Restore active tab from localStorage so first render shows correct tab (no flash). */
+function restoreSavedTabIfEnabled() {
+  if (!props.config.product_remember_tabs) return
+  try {
+    const savedKey = localStorage.getItem(STORAGE_KEY)
+    if (!savedKey) return
+    const idx = tabConfig.value.findIndex(t => t.key === savedKey)
+    if (idx >= 0) activeTab.value = String(idx)
+  } catch {
+    // Quota, private mode, or strict security policies — ignore
   }
+}
 
+onMounted(() => {
+  restoreSavedTabIfEnabled()
   tabsReady.value = true
-
-  // Register this instance in global registry
   if (window.MS3ProductTabsRegistry) {
-    window.MS3ProductTabsRegistry._instance = {
-      registerPluginTab,
-    }
+    window.MS3ProductTabsRegistry._instance = { registerPluginTab }
   }
 })
 

--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -378,17 +378,19 @@ defineExpose({
 })
 
 onMounted(() => {
-  tabsReady.value = true
-
   if (props.config.product_remember_tabs) {
-    nextTick(() => {
+    try {
       const savedKey = localStorage.getItem(STORAGE_KEY)
       if (savedKey) {
         const idx = tabConfig.value.findIndex(t => t.key === savedKey)
         if (idx >= 0) activeTab.value = String(idx)
       }
-    })
+    } catch (_e) {
+      // ignore quota, private mode, security policies
+    }
   }
+
+  tabsReady.value = true
 
   // Register this instance in global registry
   if (window.MS3ProductTabsRegistry) {


### PR DESCRIPTION
## Описание

Реализовано запоминание активной вкладки панели товара при перезагрузке страницы. При переключении вкладки её ключ сохраняется в `localStorage`, при следующей загрузке страницы восстанавливается последняя активная вкладка. Поведение аналогично ExtJS-вкладкам и управляется системной настройкой `ms3_product_remember_tabs`.

## Тип изменений

- [x] Новая функциональность (non-breaking change)
- [ ] Исправление бага (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #111

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: beta
- MODX: 3.2.x
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| При перезагрузке всегда открывалась первая вкладка | Открывается последняя активная вкладка |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Настройка `ms3_product_remember_tabs` по умолчанию включена (`true`)
- Сохраняется ключ вкладки, а не индекс — устойчиво к изменению порядка вкладок
- При ошибках `localStorage` (quota, private mode) сохранение игнорируется без падения
