### PR TITLE
fix(auth): httpOnly cookie token architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 #### 🐛 Исправлено
 
+- **httpOnly cookie token architecture (#124):** единый httpOnly cookie `ms3_token` вместо 4 несинхронизированных хранилищ. Middleware injection для обратной совместимости. Корзина сохраняется при логине/регистрации.
 - Исправлены неточности в лексиконах (Issue #21)
 - Удалён `action` из конфигурации меню miniShop3 (#94)
 - Очистка EAV-опций из формы товара
@@ -65,6 +66,10 @@
 - `CartController::change()`/`remove()` — исправлен тип возвращаемого значения (array вместо Response)
 - Корректные дефолтные ID статусов заказов с fallback для нулевых значений
 - `getIterator` для msProduct/msCategory — добавлен `class_key` в критерии
+
+#### ⚠️ Breaking changes
+
+- **Register.php response format (#124):** поле `token` изменено с объекта `{token, expires_at}` на строку. `expires_at` вынесен на верхний уровень ответа. Кастомные темы, обращающиеся к `result.object.token.token`, потребуют обновления.
 
 #### 🔧 Изменено
 

--- a/assets/components/minishop3/js/web/core/ApiClient.js
+++ b/assets/components/minishop3/js/web/core/ApiClient.js
@@ -2,7 +2,7 @@
  * HTTP client for MiniShop3 REST API
  *
  * Simple wrapper over fetch() for backend API interaction.
- * Automatically adds authorization token and handles JSON.
+ * Token is sent automatically via httpOnly cookie (credentials: 'same-origin').
  * Handles token refresh on 401 errors.
  *
  * @example
@@ -38,11 +38,6 @@ class ApiClient {
 
     url.searchParams.set('route', endpoint)
 
-    const token = this.tokenManager.getToken()
-    if (token) {
-      url.searchParams.set('ms3_token', token)
-    }
-
     const headers = {
       Accept: 'application/json',
       'X-Requested-With': 'XMLHttpRequest'
@@ -50,7 +45,8 @@ class ApiClient {
 
     const options = {
       method,
-      headers
+      headers,
+      credentials: 'same-origin'
     }
 
     if (data && (method === 'POST' || method === 'PATCH' || method === 'PUT')) {
@@ -66,10 +62,9 @@ class ApiClient {
       const response = await fetch(url.toString(), options)
       const result = await response.json()
 
-      // Handle token errors: clear invalid token, get new one, and retry
+      // Handle token errors: request new token from server and retry
       if (!isRetry && response.status === 401 && this.isTokenError(result)) {
         console.log('[ApiClient] Token invalid, refreshing and retrying request')
-        this.tokenManager.removeToken()
         await this.tokenManager.fetchNewToken()
         return this.request(method, endpoint, data, true)
       }

--- a/assets/components/minishop3/js/web/core/TokenManager.js
+++ b/assets/components/minishop3/js/web/core/TokenManager.js
@@ -1,24 +1,26 @@
 /**
- * Customer token manager
+ * Customer token manager (httpOnly cookie mode)
  *
- * Manages customer authorization token:
- * - Storage in localStorage
- * - Expiry validation
- * - Automatic token retrieval when missing/expired
+ * Token is stored in httpOnly cookie by the server.
+ * JS cannot read it directly — it's sent automatically with every request.
+ * This class handles initialization and legacy localStorage cleanup.
  *
  * @example
  * const tokenManager = new TokenManager({ tokenName: 'ms3_token' })
  * await tokenManager.ensureToken()
- * const token = tokenManager.getToken()
  */
 class TokenManager {
   /**
    * @param {Object} config - Configuration
-   * @param {string} config.tokenName - Key for storing token in localStorage
+   * @param {string} config.tokenName - Legacy key (for localStorage cleanup)
    */
   constructor (config) {
     this.tokenName = config.tokenName || 'ms3_token'
     this.apiClient = null
+    this.tokenInitialized = false
+
+    // Clean up legacy localStorage on construction
+    this.cleanupLegacyStorage()
   }
 
   /**
@@ -31,70 +33,47 @@ class TokenManager {
   }
 
   /**
-   * Get token from localStorage
+   * Get token — always returns null (httpOnly cookie, not accessible from JS)
    *
-   * @returns {string|null} - Token or null if missing/expired
+   * @returns {null}
    */
   getToken () {
-    const tokenData = this.getTokenData()
-    return tokenData ? tokenData.token : null
+    return null
   }
 
   /**
-   * Get full token data (token + expiry)
+   * Get full token data — always returns null (httpOnly cookie)
    *
-   * @returns {Object|null} - { token: string, expiry: number } or null
+   * @returns {null}
    */
   getTokenData () {
-    const stored = localStorage.getItem(this.tokenName)
-    if (!stored) {
-      return null
-    }
-
-    try {
-      const data = JSON.parse(stored)
-      const now = Date.now()
-
-      if (now > data.expiry) {
-        this.removeToken()
-        return null
-      }
-
-      return data
-    } catch (e) {
-      this.removeToken()
-      return null
-    }
+    return null
   }
 
   /**
-   * Save token to localStorage
+   * Set token — no-op (token is managed by server via httpOnly cookie)
    *
-   * @param {string} token - Token
-   * @param {number} lifetime - Token lifetime in seconds
+   * @param {string} _token - Unused
+   * @param {number} _lifetime - Unused
    */
-  setToken (token, lifetime) {
-    const data = {
-      token,
-      expiry: Date.now() + (lifetime * 1000)
-    }
-    localStorage.setItem(this.tokenName, JSON.stringify(data))
+  setToken (_token, _lifetime) {
+    // No-op: token is in httpOnly cookie, managed by server
   }
 
   /**
-   * Remove token from localStorage
+   * Remove token — cleans up legacy localStorage only
    */
   removeToken () {
-    localStorage.removeItem(this.tokenName)
+    this.cleanupLegacyStorage()
   }
 
   /**
-   * Check for valid token, fetch new if needed
+   * Ensure token cookie exists by requesting from server if needed
    *
    * @returns {Promise<void>}
    */
   async ensureToken () {
-    if (this.getToken()) {
+    if (this.tokenInitialized) {
       return
     }
 
@@ -102,7 +81,7 @@ class TokenManager {
   }
 
   /**
-   * Fetch new token from server
+   * Fetch new token from server (server sets httpOnly cookie)
    *
    * @returns {Promise<void>}
    */
@@ -118,6 +97,7 @@ class TokenManager {
 
       const response = await fetch(url.toString(), {
         method: 'GET',
+        credentials: 'same-origin',
         headers: {
           Accept: 'application/json',
           'X-Requested-With': 'XMLHttpRequest'
@@ -126,8 +106,8 @@ class TokenManager {
 
       const result = await response.json()
 
-      if (result.success && result.data) {
-        this.setToken(result.data.token, result.data.lifetime)
+      if (result.success) {
+        this.tokenInitialized = true
       } else {
         console.error('TokenManager: Failed to get token', result)
       }
@@ -150,11 +130,22 @@ class TokenManager {
     try {
       const response = await this.apiClient.post('/customer/token/update')
 
-      if (response.success && response.data) {
-        this.setToken(response.data.token, response.data.lifetime)
+      if (response.success) {
+        this.tokenInitialized = true
       }
     } catch (error) {
       console.error('TokenManager: Error refreshing token', error)
+    }
+  }
+
+  /**
+   * Remove legacy localStorage data
+   */
+  cleanupLegacyStorage () {
+    try {
+      localStorage.removeItem(this.tokenName)
+    } catch (e) {
+      // Ignore storage errors
     }
   }
 }

--- a/assets/components/minishop3/js/web/modules/auth-forms.js
+++ b/assets/components/minishop3/js/web/modules/auth-forms.js
@@ -98,8 +98,6 @@ class AuthForms {
       if (result.success) {
         this.showMessage('login-messages', this.getLexicon('ms3_customer_login_success'), 'success')
 
-        // Token is set by server via httpOnly cookie — no JS storage needed
-
         setTimeout(() => {
           this.handleRedirect(result.object)
         }, 1000)
@@ -161,7 +159,7 @@ class AuthForms {
         )
 
         if (result.object && result.object.token) {
-          // Token is set by server via httpOnly cookie — no JS storage needed
+          // Auto-login: redirect to account page
           setTimeout(() => {
             this.handleRedirect(result.object)
           }, 1500)

--- a/assets/components/minishop3/js/web/modules/auth-forms.js
+++ b/assets/components/minishop3/js/web/modules/auth-forms.js
@@ -98,9 +98,7 @@ class AuthForms {
       if (result.success) {
         this.showMessage('login-messages', this.getLexicon('ms3_customer_login_success'), 'success')
 
-        if (result.object && result.object.token) {
-          this.saveToken(result.object.token)
-        }
+        // Token is set by server via httpOnly cookie — no JS storage needed
 
         setTimeout(() => {
           this.handleRedirect(result.object)
@@ -163,7 +161,7 @@ class AuthForms {
         )
 
         if (result.object && result.object.token) {
-          this.saveToken(result.object.token)
+          // Token is set by server via httpOnly cookie — no JS storage needed
           setTimeout(() => {
             this.handleRedirect(result.object)
           }, 1500)
@@ -208,39 +206,37 @@ class AuthForms {
   }
 
   /**
-   * Save authorization token
+   * Save authorization token — no-op (httpOnly cookie managed by server)
+   * Cleans up legacy localStorage.
    *
-   * @param {string} token - API token
+   * @param {string} _token - Unused
    */
-  saveToken (token) {
-    if (!token) return
-
-    localStorage.setItem('ms3_token', token)
-
-    if (window.ms3 && window.ms3.config) {
-      window.ms3.config.token = token
+  saveToken (_token) {
+    // Clean up legacy localStorage
+    try {
+      localStorage.removeItem('ms3_token')
+    } catch (e) {
+      // Ignore
     }
-
-    console.log('[AuthForms] Token saved, length:', token.length)
   }
 
   /**
-   * Get saved token
+   * Get saved token — returns null (httpOnly cookie, not accessible from JS)
    *
-   * @returns {string|null} - Token or null
+   * @returns {null}
    */
   getToken () {
-    return localStorage.getItem('ms3_token')
+    return null
   }
 
   /**
-   * Remove token (on logout)
+   * Remove token (on logout) — cleans up legacy localStorage
    */
   clearToken () {
-    localStorage.removeItem('ms3_token')
-
-    if (window.ms3 && window.ms3.config) {
-      window.ms3.config.token = null
+    try {
+      localStorage.removeItem('ms3_token')
+    } catch (e) {
+      // Ignore
     }
   }
 
@@ -257,6 +253,7 @@ class AuthForms {
 
     const response = await fetch(url.toString(), {
       method: 'POST',
+      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json'

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -27,14 +27,11 @@ $ms3->initialize($modx->context->key);
 // Load lexicons for template
 $modx->lexicon->load('minishop3:cart');
 
-if (!empty($scriptProperties['customer_token'])) {
-    $token = $scriptProperties['customer_token'];
-} elseif (!empty($_SESSION['ms3']) && !empty($_SESSION['ms3']['customer_token'])) {
-    $token = $_SESSION['ms3']['customer_token'];
-} else {
-    $response = $ms3->customer->generateToken();
-    $token = $response['data']['token'];
-}
+/** @var \MiniShop3\Services\TokenService $tokenService */
+$tokenService = $modx->services->get('ms3_token_service');
+$token = !empty($scriptProperties['customer_token'])
+    ? $scriptProperties['customer_token']
+    : $tokenService->resolveOrCreateToken();
 if (!empty($_GET['msorder'])) {
     return '';
 }

--- a/core/components/minishop3/elements/snippets/ms3_customer.php
+++ b/core/components/minishop3/elements/snippets/ms3_customer.php
@@ -40,9 +40,6 @@ if (isset($_GET['action']) && $_GET['action'] === 'logout') {
         unset($_SESSION['ms3']['customer_token_expires']);
     }
 
-    // Clear httpOnly cookie
-    \MiniShop3\Utils\CookieHelper::clearTokenCookie($modx);
-
     $loginPageId = $modx->getOption('ms3_customer_login_page_id', null, 1);
     $modx->sendRedirect($modx->makeUrl($loginPageId));
     exit;

--- a/core/components/minishop3/elements/snippets/ms3_customer.php
+++ b/core/components/minishop3/elements/snippets/ms3_customer.php
@@ -6,7 +6,7 @@ use MiniShop3\Services\Customer\AddressesPageService;
 use MiniShop3\Services\Customer\OrdersPageService;
 use ModxPro\PdoTools\Fetch;
 
-/** @var modX $modx */
+/** @var \MODX\Revolution\modX $modx */
 /** @var array $scriptProperties */
 /** @var MiniShop3 $ms3 */
 
@@ -39,6 +39,9 @@ if (isset($_GET['action']) && $_GET['action'] === 'logout') {
         unset($_SESSION['ms3']['customer_token']);
         unset($_SESSION['ms3']['customer_token_expires']);
     }
+
+    // Clear httpOnly cookie
+    \MiniShop3\Utils\CookieHelper::clearTokenCookie($modx);
 
     $loginPageId = $modx->getOption('ms3_customer_login_page_id', null, 1);
     $modx->sendRedirect($modx->makeUrl($loginPageId));

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -56,8 +56,10 @@ if (!$msOrder) {
     return $modx->lexicon('ms3_err_order_nf');
 }
 $customerId = null;
-if (!empty($_SESSION['ms3']) && !empty($_SESSION['ms3']['customer_token'])) {
-    $token = $_SESSION['ms3']['customer_token'];
+/** @var \MiniShop3\Services\TokenService $tokenService */
+$tokenService = $modx->services->get('ms3_token_service');
+$token = $tokenService->resolveOrCreateToken();
+if (!empty($token)) {
     $customer = $ms3->customer->getByToken($token);
     if (!empty($customer)) {
         $customerId = $customer->get('id');

--- a/core/components/minishop3/elements/snippets/ms3_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_order.php
@@ -22,12 +22,9 @@ if (!$modx->services->has('ms3')) {
 $ms3 = $modx->services->get('ms3');
 $ms3->initialize($modx->context->key);
 
-if (!empty($_SESSION['ms3']) && !empty($_SESSION['ms3']['customer_token'])) {
-    $token = $_SESSION['ms3']['customer_token'];
-} else {
-    $response = $ms3->customer->generateToken();
-    $token = $response['data']['token'];
-}
+/** @var \MiniShop3\Services\TokenService $tokenService */
+$tokenService = $modx->services->get('ms3_token_service');
+$token = $tokenService->resolveOrCreateToken();
 
 /** @var Fetch $pdoFetch */
 $pdoFetch = $modx->services->get(Fetch::class);

--- a/core/components/minishop3/elements/snippets/ms3_order_total.php
+++ b/core/components/minishop3/elements/snippets/ms3_order_total.php
@@ -16,12 +16,9 @@ $ms3 = $modx->services->get('ms3');
 $ms3->initialize($modx->context->key);
 $ms3->registerSnippet($scriptProperties, 'msOrderTotal');
 
-if (!empty($_SESSION['ms3']) && !empty($_SESSION['ms3']['customer_token'])) {
-    $token = $_SESSION['ms3']['customer_token'];
-} else {
-    $response = $ms3->customer->generateToken();
-    $token = $response['data']['token'];
-}
+/** @var \MiniShop3\Services\TokenService $tokenService */
+$tokenService = $modx->services->get('ms3_token_service');
+$token = $tokenService->resolveOrCreateToken();
 
 /** @var Fetch $pdoFetch */
 $pdoFetch = $modx->services->get(Fetch::class);

--- a/core/components/minishop3/src/Controllers/Customer/Customer.php
+++ b/core/components/minishop3/src/Controllers/Customer/Customer.php
@@ -8,7 +8,9 @@ require_once($autoload);
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerToken;
 use MiniShop3\Services\Customer\CustomerAddressManager;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\modX;
 
 use Rakit\Validation\Validator;
@@ -438,6 +440,42 @@ class Customer
     }
 
     /**
+     * Auto-login customer after order creation
+     *
+     * Binds existing msCustomerToken to customer and sets session + cookie.
+     *
+     * @param msCustomer $msCustomer Customer to login
+     */
+    protected function autoLoginCustomer(msCustomer $msCustomer): void
+    {
+        if (!isset($_SESSION['ms3'])) {
+            $_SESSION['ms3'] = [];
+        }
+        $_SESSION['ms3']['customer_id'] = $msCustomer->id;
+
+        // Bind existing msCustomerToken to customer
+        $currentToken = CookieHelper::getTokenFromCookie();
+        if (empty($currentToken)) {
+            $currentToken = $_SESSION['ms3']['customer_token'] ?? $this->token;
+        }
+
+        if (!empty($currentToken)) {
+            $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+                'token' => $currentToken,
+                'type' => msCustomerToken::TYPE_API,
+            ]);
+
+            if ($tokenObj) {
+                $tokenObj->set('customer_id', $msCustomer->id);
+                $tokenObj->save();
+            }
+
+            $_SESSION['ms3']['customer_token'] = $currentToken;
+            CookieHelper::setTokenCookie($this->modx, $currentToken);
+        }
+    }
+
+    /**
      * Find customer by email
      *
      * @param string $email Customer email
@@ -496,8 +534,7 @@ class Customer
                     $msCustomer = $registerResult['customer'];
 
                     if ($autoLogin) {
-                        $_SESSION['ms3']['customer_id'] = $msCustomer->id;
-                        $_SESSION['ms3']['customer_token'] = $msCustomer->get('token');
+                        $this->autoLoginCustomer($msCustomer);
                     }
                 } else {
                     $msCustomer = $this->findByEmail($email);
@@ -507,8 +544,7 @@ class Customer
                         $msCustomer->save();
 
                         if ($autoLogin) {
-                            $_SESSION['ms3']['customer_id'] = $msCustomer->id;
-                            $_SESSION['ms3']['customer_token'] = $msCustomer->get('token');
+                            $this->autoLoginCustomer($msCustomer);
                         }
                     }
                 }
@@ -527,8 +563,7 @@ class Customer
             $msCustomer = $this->create($customerData);
 
             if ($msCustomer && $autoLogin) {
-                $_SESSION['ms3']['customer_id'] = $msCustomer->id;
-                $_SESSION['ms3']['customer_token'] = $msCustomer->get('token');
+                $this->autoLoginCustomer($msCustomer);
             }
         }
 

--- a/core/components/minishop3/src/Controllers/Customer/Customer.php
+++ b/core/components/minishop3/src/Controllers/Customer/Customer.php
@@ -453,7 +453,8 @@ class Customer
         }
         $_SESSION['ms3']['customer_id'] = $msCustomer->id;
 
-        // Bind existing msCustomerToken to customer
+        // Resolve current token: cookie → session → controller token
+        // ($this->token comes from $_REQUEST via middleware cookie injection)
         $currentToken = CookieHelper::getTokenFromCookie();
         if (empty($currentToken)) {
             $currentToken = $_SESSION['ms3']['customer_token'] ?? $this->token;

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -4,6 +4,8 @@ namespace MiniShop3\Middleware;
 
 use MiniShop3\Router\Middleware\MiddlewareInterface;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\TokenService;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\modX;
 
 /**
@@ -38,81 +40,136 @@ class TokenMiddleware implements MiddlewareInterface
     /**
      * Handle request
      *
+     * Token resolution order:
+     * 1. Authorization: Bearer header (for mobile apps)
+     * 2. HTTP_MS3TOKEN header (legacy)
+     * 3. httpOnly cookie ms3_token
+     * 4. $_REQUEST['ms3_token'] (legacy URL parameter)
+     *
+     * Cookie injection: copies $_COOKIE['ms3_token'] → $_REQUEST['ms3_token']
+     * so all controllers (CartController, OrderController, etc.) work without changes.
+     *
      * @param array $params URL parameters from router
      * @return Response|null Return Response to stop execution, or null to continue
      */
     public function handle(array $params)
     {
-        $uri = $_SERVER['REQUEST_URI'] ?? '/';
-
-        // Public endpoints don't require token
-        if ($this->isPublicRoute($uri)) {
-            return null; // Continue execution
+        // Cookie injection: make cookie token available via $_REQUEST for backward compat
+        $cookieToken = CookieHelper::getTokenFromCookie();
+        if (!empty($cookieToken) && empty($_REQUEST['ms3_token'])) {
+            $_REQUEST['ms3_token'] = $cookieToken;
         }
 
-        // Check session - if customer is already authenticated, pass through
+        $uri = $_SERVER['REQUEST_URI'] ?? '/';
+        $isPublic = $this->isPublicRoute($uri);
+
+        // Ensure session is active
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }
 
-        if (!empty($_SESSION['ms3']['customer_id'])) {
-            // Customer is authenticated in session - check that they exist
+        // For non-public routes: check session first
+        if (!$isPublic && !empty($_SESSION['ms3']['customer_id'])) {
             $customer = $this->modx->getObject(\MiniShop3\Model\msCustomer::class, $_SESSION['ms3']['customer_id']);
             if ($customer) {
-                return null; // Continue execution
+                return null;
             }
         }
 
-        // Get token from header
-        $token = $_SERVER['HTTP_MS3TOKEN'] ?? '';
+        // Resolve token from multiple sources
+        $token = $this->resolveToken();
 
-        // Alternatively token can be passed in parameter (support both formats)
-        if (empty($token)) {
-            $token = $_REQUEST['ms3_token'] ?? $_REQUEST['token'] ?? '';
+        if (!empty($token)) {
+            // Validate token in DB
+            $tokenObj = $this->modx->getObject(\MiniShop3\Model\msCustomerToken::class, [
+                'token' => $token,
+                'type' => \MiniShop3\Model\msCustomerToken::TYPE_API
+            ]);
+
+            if ($tokenObj) {
+                // Auto-renew expired token
+                if ($tokenObj->isExpired()) {
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+                    $newExpiresAt = date('Y-m-d H:i:s', time() + $ttl);
+                    $tokenObj->set('expires_at', $newExpiresAt);
+                    $tokenObj->save();
+                }
+
+                // Save to session
+                if (!isset($_SESSION['ms3'])) {
+                    $_SESSION['ms3'] = [];
+                }
+                $_SESSION['ms3']['customer_token'] = $token;
+                $_SESSION['ms3']['customer_id'] = $tokenObj->get('customer_id');
+                $_SESSION['ms3']['customer_token_expires'] = strtotime($tokenObj->get('expires_at'));
+
+                // Refresh cookie
+                CookieHelper::setTokenCookie($this->modx, $token);
+
+                // Ensure $_REQUEST has the token for controllers
+                $_REQUEST['ms3_token'] = $token;
+
+                return null;
+            }
+
+            // Token found in request but not in DB — invalid
+            if (!$isPublic) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    "[TokenMiddleware] Token not found in database. Token: " . substr($token, 0, 16) . "..."
+                );
+                return Response::error('ms3_err_token_invalid', 401);
+            }
         }
 
-        // Check token presence
-        if (empty($token)) {
+        // No valid token found
+        if (!$isPublic) {
+            // Auto-create token for first visit
+            /** @var TokenService $tokenService */
+            $tokenService = $this->modx->services->get('ms3_token_service');
+            $result = $tokenService->generateCustomerToken();
+
+            if (!empty($result['token'])) {
+                $_REQUEST['ms3_token'] = $result['token'];
+                return null;
+            }
+
             return Response::error('ms3_err_token', 401);
         }
 
-        // Check token validity and get customer_id
-        $tokenObj = $this->modx->getObject(\MiniShop3\Model\msCustomerToken::class, [
-            'token' => $token,
-            'type' => \MiniShop3\Model\msCustomerToken::TYPE_API
-        ]);
+        return null;
+    }
 
-        if (!$tokenObj) {
-            $this->modx->log(
-                \MODX\Revolution\modX::LOG_LEVEL_ERROR,
-                "[TokenMiddleware] Token not found in database. Token: " . substr($token, 0, 16) . "... Length: " . strlen($token)
-            );
-            return Response::error('ms3_err_token_invalid', 401);
+    /**
+     * Resolve token from request sources
+     *
+     * @return string Token or empty string
+     */
+    private function resolveToken(): string
+    {
+        // 1. Authorization: Bearer header (for mobile apps)
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        if (str_starts_with($authHeader, 'Bearer ')) {
+            $token = substr($authHeader, 7);
+            if (!empty($token)) {
+                return $token;
+            }
         }
 
-        // Auto-renew expired token instead of returning error
-        if ($tokenObj->isExpired()) {
-            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
-            $newExpiresAt = date('Y-m-d H:i:s', time() + $ttl);
-
-            $tokenObj->set('expires_at', $newExpiresAt);
-            $tokenObj->save();
-
-            $this->modx->log(
-                \MODX\Revolution\modX::LOG_LEVEL_INFO,
-                "[TokenMiddleware] Token auto-renewed. New expires: " . $newExpiresAt
-            );
+        // 2. HTTP_MS3TOKEN header (legacy)
+        $token = $_SERVER['HTTP_MS3TOKEN'] ?? '';
+        if (!empty($token)) {
+            return $token;
         }
 
-        // Save token and customer_id to session
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
+        // 3. httpOnly cookie
+        $token = CookieHelper::getTokenFromCookie();
+        if (!empty($token)) {
+            return $token;
         }
-        $_SESSION['ms3']['customer_token'] = $token;
-        $_SESSION['ms3']['customer_id'] = $tokenObj->get('customer_id');
-        $_SESSION['ms3']['customer_token_expires'] = strtotime($tokenObj->get('expires_at'));
 
-        return null; // Continue execution
+        // 4. $_REQUEST parameter (legacy URL param)
+        return $_REQUEST['ms3_token'] ?? $_REQUEST['token'] ?? '';
     }
 
     /**

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -11,8 +11,16 @@ use MODX\Revolution\modX;
 /**
  * Middleware for authorization token verification (Web API)
  *
- * Checks for token in HTTP_MS3TOKEN header and saves it to session.
+ * Token resolution order:
+ * 1. Authorization: Bearer header (mobile apps)
+ * 2. HTTP_MS3TOKEN header (legacy)
+ * 3. $_REQUEST['ms3_token'] (includes httpOnly cookie via injection)
+ *
+ * Cookie injection at start of handle() copies $_COOKIE['ms3_token'] → $_REQUEST['ms3_token']
+ * for backward compatibility with controllers reading $_REQUEST.
+ *
  * For public endpoints (cart/get, product/get) token is optional.
+ * For non-public endpoints without token — auto-creates anonymous token.
  */
 class TokenMiddleware implements MiddlewareInterface
 {
@@ -89,7 +97,7 @@ class TokenMiddleware implements MiddlewareInterface
             if ($tokenObj) {
                 // Auto-renew expired token
                 if ($tokenObj->isExpired()) {
-                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
                     $newExpiresAt = date('Y-m-d H:i:s', time() + $ttl);
                     $tokenObj->set('expires_at', $newExpiresAt);
                     $tokenObj->save();
@@ -162,11 +170,7 @@ class TokenMiddleware implements MiddlewareInterface
             return $token;
         }
 
-        // 3. httpOnly cookie
-        $token = CookieHelper::getTokenFromCookie();
-        if (!empty($token)) {
-            return $token;
-        }
+        // 3. $_REQUEST parameter (includes cookie via injection at top of handle())
 
         // 4. $_REQUEST parameter (legacy URL param)
         return $_REQUEST['ms3_token'] ?? $_REQUEST['token'] ?? '';

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -51,8 +51,7 @@ class TokenMiddleware implements MiddlewareInterface
      * Token resolution order:
      * 1. Authorization: Bearer header (for mobile apps)
      * 2. HTTP_MS3TOKEN header (legacy)
-     * 3. httpOnly cookie ms3_token
-     * 4. $_REQUEST['ms3_token'] (legacy URL parameter)
+     * 3. $_REQUEST['ms3_token'] (includes httpOnly cookie via injection + legacy URL param)
      *
      * Cookie injection: copies $_COOKIE['ms3_token'] → $_REQUEST['ms3_token']
      * so all controllers (CartController, OrderController, etc.) work without changes.
@@ -170,9 +169,7 @@ class TokenMiddleware implements MiddlewareInterface
             return $token;
         }
 
-        // 3. $_REQUEST parameter (includes cookie via injection at top of handle())
-
-        // 4. $_REQUEST parameter (legacy URL param)
+        // 3. $_REQUEST (includes cookie via injection + legacy URL param)
         return $_REQUEST['ms3_token'] ?? $_REQUEST['token'] ?? '';
     }
 

--- a/core/components/minishop3/src/Processors/Api/Customer/Login.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Login.php
@@ -2,14 +2,18 @@
 
 namespace MiniShop3\Processors\Api\Customer;
 
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Model\msOrder;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Customer\RateLimiter;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\Processors\Processor;
 
 /**
  * Login - customer login processor
  *
- * Authenticates customer and creates API token for session.
+ * Authenticates customer and binds existing session token to customer.
+ * Token does NOT change on login — guest cart is preserved.
  * Protected from brute-force via RateLimiter.
  *
  * @package MiniShop3\Processors\Api\Customer
@@ -67,18 +71,63 @@ class Login extends Processor
 
         $rateLimiter->reset('login', $ip);
 
-        $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
-        $tokenObj = $authManager->createToken($customer, 'api', $ttl);
-
-        if (!$tokenObj) {
-            return $this->failure($this->modx->lexicon('ms3_customer_err_token_create'));
+        // Use existing token from cookie/session instead of creating new one
+        $currentToken = CookieHelper::getTokenFromCookie();
+        if (empty($currentToken)) {
+            $currentToken = $_SESSION['ms3']['customer_token'] ?? '';
         }
 
+        $tokenObj = null;
+        $tokenString = '';
+        $expiresAt = '';
+
+        if (!empty($currentToken)) {
+            // Find existing token in DB
+            $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+                'token' => $currentToken,
+                'type' => msCustomerToken::TYPE_API,
+            ]);
+
+            if ($tokenObj) {
+                // Bind customer to existing token
+                $tokenObj->set('customer_id', $customer->id);
+
+                // Extend TTL
+                $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
+                $tokenObj->save();
+
+                $tokenString = $tokenObj->get('token');
+                $expiresAt = $tokenObj->get('expires_at');
+
+                // Bind draft order to customer
+                $this->bindDraftToCustomer($tokenString, $customer->id);
+            }
+        }
+
+        // Edge case: no valid existing token — create new one
+        if (!$tokenObj) {
+            $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+            $tokenObj = $authManager->createToken($customer, 'api', $ttl);
+
+            if (!$tokenObj) {
+                return $this->failure($this->modx->lexicon('ms3_customer_err_token_create'));
+            }
+
+            $tokenString = $tokenObj->get('token');
+            $expiresAt = $tokenObj->get('expires_at');
+
+            // Set cookie for new token
+            CookieHelper::setTokenCookie($this->modx, $tokenString);
+        }
+
+        // Update session
         if (!isset($_SESSION['ms3'])) {
             $_SESSION['ms3'] = [];
         }
         $_SESSION['ms3']['customer_id'] = $customer->id;
-        $_SESSION['ms3']['customer_token'] = $tokenObj->get('token');
+        $_SESSION['ms3']['customer_token'] = $tokenString;
+        $_SESSION['ms3']['customer_token_expires'] = strtotime($expiresAt);
 
         $redirectPageId = (int)$this->getProperty('redirect_page_id', 0);
         if (!$redirectPageId) {
@@ -99,9 +148,32 @@ class Login extends Processor
                 'phone' => $customer->get('phone'),
                 'email_verified' => !empty($customer->get('email_verified_at')),
             ],
-            'token' => $tokenObj->get('token'),
-            'expires_at' => $tokenObj->get('expires_at'),
+            'token' => $tokenString,
+            'expires_at' => $expiresAt,
             'redirect_url' => $redirectUrl,
         ]);
+    }
+
+    /**
+     * Bind draft order to customer
+     */
+    private function bindDraftToCustomer(string $token, int $customerId): void
+    {
+        $statusDraft = (int)$this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+
+        $draft = $this->modx->getObject(msOrder::class, [
+            'token' => $token,
+            'status_id' => $statusDraft,
+        ]);
+
+        if ($draft && empty($draft->get('customer_id'))) {
+            $draft->set('customer_id', $customerId);
+            $draft->save();
+
+            $this->modx->log(
+                \MODX\Revolution\modX::LOG_LEVEL_INFO,
+                "[Login] Bound draft #{$draft->get('id')} to customer #{$customerId}"
+            );
+        }
     }
 }

--- a/core/components/minishop3/src/Processors/Api/Customer/Login.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Login.php
@@ -3,9 +3,9 @@
 namespace MiniShop3\Processors\Api\Customer;
 
 use MiniShop3\Model\msCustomerToken;
-use MiniShop3\Model\msOrder;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Customer\RateLimiter;
+use MiniShop3\Services\Order\OrderDraftManager;
 use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\Processors\Processor;
 
@@ -93,7 +93,7 @@ class Login extends Processor
                 $tokenObj->set('customer_id', $customer->id);
 
                 // Extend TTL
-                $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
                 $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
                 $tokenObj->save();
 
@@ -101,13 +101,15 @@ class Login extends Processor
                 $expiresAt = $tokenObj->get('expires_at');
 
                 // Bind draft order to customer
-                $this->bindDraftToCustomer($tokenString, $customer->id);
+                /** @var OrderDraftManager $draftManager */
+                $draftManager = $this->modx->services->get('ms3_order_draft_manager');
+                $draftManager->bindDraftToCustomer($tokenString, $customer->id);
             }
         }
 
         // Edge case: no valid existing token — create new one
         if (!$tokenObj) {
-            $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
             $tokenObj = $authManager->createToken($customer, 'api', $ttl);
 
             if (!$tokenObj) {
@@ -154,26 +156,4 @@ class Login extends Processor
         ]);
     }
 
-    /**
-     * Bind draft order to customer
-     */
-    private function bindDraftToCustomer(string $token, int $customerId): void
-    {
-        $statusDraft = (int)$this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
-
-        $draft = $this->modx->getObject(msOrder::class, [
-            'token' => $token,
-            'status_id' => $statusDraft,
-        ]);
-
-        if ($draft && empty($draft->get('customer_id'))) {
-            $draft->set('customer_id', $customerId);
-            $draft->save();
-
-            $this->modx->log(
-                \MODX\Revolution\modX::LOG_LEVEL_INFO,
-                "[Login] Bound draft #{$draft->get('id')} to customer #{$customerId}"
-            );
-        }
-    }
 }

--- a/core/components/minishop3/src/Processors/Api/Customer/Logout.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Logout.php
@@ -11,9 +11,8 @@ use MODX\Revolution\Processors\Processor;
 /**
  * Logout - customer logout processor
  *
- * Detaches customer from current token (session continues as guest).
- * Cookie is preserved — guest cart remains accessible.
- * Other API tokens for this customer are revoked.
+ * Revokes all customer tokens and creates a fresh anonymous token.
+ * New cookie is set — guest cart starts fresh (security: old token invalidated).
  *
  * @package MiniShop3\Processors\Api\Customer
  */
@@ -30,12 +29,6 @@ class Logout extends Processor
             return $this->success($this->modx->lexicon('ms3_customer_logout_success'));
         }
 
-        // Get current token from cookie/session
-        $currentTokenString = CookieHelper::getTokenFromCookie();
-        if (empty($currentTokenString)) {
-            $currentTokenString = $_SESSION['ms3']['customer_token'] ?? '';
-        }
-
         /** @var msCustomer $customer */
         $customer = $this->modx->getObject(msCustomer::class, $customerId);
 
@@ -43,32 +36,8 @@ class Logout extends Processor
             /** @var AuthManager $authManager */
             $authManager = $this->modx->services->get('ms3_auth_manager');
 
-            // Revoke all OTHER api tokens for this customer
+            // Revoke ALL api tokens for this customer (including current)
             $authManager->revokeTokens($customer, 'api');
-
-            // Re-create current token as anonymous (customer_id = 0)
-            // This keeps the same token string valid for guest cart
-            if (!empty($currentTokenString)) {
-                $tokenObj = $this->modx->getObject(msCustomerToken::class, [
-                    'token' => $currentTokenString,
-                    'type' => msCustomerToken::TYPE_API,
-                ]);
-
-                // Token was revoked by revokeTokens above — re-create it as anonymous
-                if (!$tokenObj) {
-                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
-                    $tokenObj = $this->modx->newObject(msCustomerToken::class);
-                    $tokenObj->set('token', $currentTokenString);
-                    $tokenObj->set('type', msCustomerToken::TYPE_API);
-                    $tokenObj->set('customer_id', 0);
-                    $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
-                    $tokenObj->set('created_at', date('Y-m-d H:i:s'));
-                    $tokenObj->save();
-                } else {
-                    $tokenObj->set('customer_id', 0);
-                    $tokenObj->save();
-                }
-            }
 
             $this->modx->log(
                 \MODX\Revolution\modX::LOG_LEVEL_INFO,
@@ -76,11 +45,29 @@ class Logout extends Processor
             );
         }
 
-        // Clear customer data from session, keep token
-        unset($_SESSION['ms3']['customer_id']);
-        unset($_SESSION['ms3']['customer_token_expires']);
+        // Generate fresh anonymous token
+        $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
+        $newToken = bin2hex(random_bytes(32));
+        $expiresAt = date('Y-m-d H:i:s', time() + $ttl);
 
-        // Cookie stays — guest cart preserved
+        $tokenObj = $this->modx->newObject(msCustomerToken::class);
+        $tokenObj->set('token', $newToken);
+        $tokenObj->set('type', msCustomerToken::TYPE_API);
+        $tokenObj->set('customer_id', 0);
+        $tokenObj->set('expires_at', $expiresAt);
+        $tokenObj->set('created_at', date('Y-m-d H:i:s'));
+        $tokenObj->save();
+
+        // Update session with new anonymous token
+        if (!isset($_SESSION['ms3'])) {
+            $_SESSION['ms3'] = [];
+        }
+        unset($_SESSION['ms3']['customer_id']);
+        $_SESSION['ms3']['customer_token'] = $newToken;
+        $_SESSION['ms3']['customer_token_expires'] = time() + $ttl;
+
+        // Set new cookie
+        CookieHelper::setTokenCookie($this->modx, $newToken);
 
         return $this->success($this->modx->lexicon('ms3_customer_logout_success'));
     }

--- a/core/components/minishop3/src/Processors/Api/Customer/Logout.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Logout.php
@@ -3,13 +3,17 @@
 namespace MiniShop3\Processors\Api\Customer;
 
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerToken;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\Processors\Processor;
 
 /**
  * Logout - customer logout processor
  *
- * Removes API tokens and clears session.
+ * Detaches customer from current token (session continues as guest).
+ * Cookie is preserved — guest cart remains accessible.
+ * Other API tokens for this customer are revoked.
  *
  * @package MiniShop3\Processors\Api\Customer
  */
@@ -26,6 +30,12 @@ class Logout extends Processor
             return $this->success($this->modx->lexicon('ms3_customer_logout_success'));
         }
 
+        // Get current token from cookie/session
+        $currentTokenString = CookieHelper::getTokenFromCookie();
+        if (empty($currentTokenString)) {
+            $currentTokenString = $_SESSION['ms3']['customer_token'] ?? '';
+        }
+
         /** @var msCustomer $customer */
         $customer = $this->modx->getObject(msCustomer::class, $customerId);
 
@@ -33,7 +43,32 @@ class Logout extends Processor
             /** @var AuthManager $authManager */
             $authManager = $this->modx->services->get('ms3_auth_manager');
 
+            // Revoke all OTHER api tokens for this customer
             $authManager->revokeTokens($customer, 'api');
+
+            // Re-create current token as anonymous (customer_id = 0)
+            // This keeps the same token string valid for guest cart
+            if (!empty($currentTokenString)) {
+                $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+                    'token' => $currentTokenString,
+                    'type' => msCustomerToken::TYPE_API,
+                ]);
+
+                // Token was revoked by revokeTokens above — re-create it as anonymous
+                if (!$tokenObj) {
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+                    $tokenObj = $this->modx->newObject(msCustomerToken::class);
+                    $tokenObj->set('token', $currentTokenString);
+                    $tokenObj->set('type', msCustomerToken::TYPE_API);
+                    $tokenObj->set('customer_id', 0);
+                    $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
+                    $tokenObj->set('created_at', date('Y-m-d H:i:s'));
+                    $tokenObj->save();
+                } else {
+                    $tokenObj->set('customer_id', 0);
+                    $tokenObj->save();
+                }
+            }
 
             $this->modx->log(
                 \MODX\Revolution\modX::LOG_LEVEL_INFO,
@@ -41,8 +76,11 @@ class Logout extends Processor
             );
         }
 
+        // Clear customer data from session, keep token
         unset($_SESSION['ms3']['customer_id']);
-        unset($_SESSION['ms3']['customer_token']);
+        unset($_SESSION['ms3']['customer_token_expires']);
+
+        // Cookie stays — guest cart preserved
 
         return $this->success($this->modx->lexicon('ms3_customer_logout_success'));
     }

--- a/core/components/minishop3/src/Processors/Api/Customer/Register.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Register.php
@@ -3,11 +3,11 @@
 namespace MiniShop3\Processors\Api\Customer;
 
 use MiniShop3\Model\msCustomerToken;
-use MiniShop3\Model\msOrder;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MiniShop3\Services\Customer\RateLimiter;
 use MiniShop3\Services\Customer\RegisterService;
+use MiniShop3\Services\Order\OrderDraftManager;
 use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\Processors\Processor;
 
@@ -104,7 +104,7 @@ class Register extends Processor
                     // Bind customer to existing token
                     $tokenObj->set('customer_id', $customer->id);
 
-                    $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
                     $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
                     $tokenObj->save();
 
@@ -112,7 +112,9 @@ class Register extends Processor
                     $expiresAt = $tokenObj->get('expires_at');
 
                     // Bind draft order to customer
-                    $this->bindDraftToCustomer($tokenString, $customer->id);
+                    /** @var OrderDraftManager $draftManager */
+                    $draftManager = $this->modx->services->get('ms3_order_draft_manager');
+                    $draftManager->bindDraftToCustomer($tokenString, $customer->id);
                 }
             }
 
@@ -120,7 +122,7 @@ class Register extends Processor
             if (!$tokenObj) {
                 /** @var AuthManager $authManager */
                 $authManager = $this->modx->services->get('ms3_auth_manager');
-                $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
                 $tokenObj = $authManager->createToken($customer, 'api', $ttl);
 
                 if ($tokenObj) {
@@ -170,21 +172,4 @@ class Register extends Processor
         ]);
     }
 
-    /**
-     * Bind draft order to customer
-     */
-    private function bindDraftToCustomer(string $token, int $customerId): void
-    {
-        $statusDraft = (int)$this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
-
-        $draft = $this->modx->getObject(msOrder::class, [
-            'token' => $token,
-            'status_id' => $statusDraft,
-        ]);
-
-        if ($draft && empty($draft->get('customer_id'))) {
-            $draft->set('customer_id', $customerId);
-            $draft->save();
-        }
-    }
 }

--- a/core/components/minishop3/src/Processors/Api/Customer/Register.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Register.php
@@ -2,16 +2,20 @@
 
 namespace MiniShop3\Processors\Api\Customer;
 
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Model\msOrder;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MiniShop3\Services\Customer\RateLimiter;
 use MiniShop3\Services\Customer\RegisterService;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\Processors\Processor;
 
 /**
  * Register - processor for registering a new customer
  *
  * Creates a new customer with validation and optional email verification.
+ * On auto-login: binds existing session token to new customer (preserves guest cart).
  * Protected from spam via RateLimiter.
  *
  * @package MiniShop3\Processors\Api\Customer
@@ -78,26 +82,61 @@ class Register extends Processor
         $autoLogin = (bool)$this->modx->getOption('ms3_customer_auto_login_after_register', null, true);
         $requireEmailVerification = (bool)$this->modx->getOption('ms3_customer_require_email_verification', null, true);
 
-        $tokenData = null;
+        $tokenString = null;
+        $expiresAt = null;
 
         if ($autoLogin && !$requireEmailVerification) {
-            /** @var AuthManager $authManager */
-            $authManager = $this->modx->services->get('ms3_auth_manager');
+            // Use existing token from cookie/session instead of creating new one
+            $currentToken = CookieHelper::getTokenFromCookie();
+            if (empty($currentToken)) {
+                $currentToken = $_SESSION['ms3']['customer_token'] ?? '';
+            }
 
-            $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
-            $tokenObj = $authManager->createToken($customer, 'api', $ttl);
+            $tokenObj = null;
 
-            if ($tokenObj) {
+            if (!empty($currentToken)) {
+                $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+                    'token' => $currentToken,
+                    'type' => msCustomerToken::TYPE_API,
+                ]);
+
+                if ($tokenObj) {
+                    // Bind customer to existing token
+                    $tokenObj->set('customer_id', $customer->id);
+
+                    $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                    $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
+                    $tokenObj->save();
+
+                    $tokenString = $tokenObj->get('token');
+                    $expiresAt = $tokenObj->get('expires_at');
+
+                    // Bind draft order to customer
+                    $this->bindDraftToCustomer($tokenString, $customer->id);
+                }
+            }
+
+            // Edge case: no valid existing token
+            if (!$tokenObj) {
+                /** @var AuthManager $authManager */
+                $authManager = $this->modx->services->get('ms3_auth_manager');
+                $ttl = (int)$this->modx->getOption('ms3_customer_api_token_ttl', null, 86400);
+                $tokenObj = $authManager->createToken($customer, 'api', $ttl);
+
+                if ($tokenObj) {
+                    $tokenString = $tokenObj->get('token');
+                    $expiresAt = $tokenObj->get('expires_at');
+                    CookieHelper::setTokenCookie($this->modx, $tokenString);
+                }
+            }
+
+            if ($tokenString) {
                 if (!isset($_SESSION['ms3'])) {
                     $_SESSION['ms3'] = [];
                 }
                 $_SESSION['ms3']['customer_id'] = $customer->id;
-                $_SESSION['ms3']['customer_token'] = $tokenObj->get('token');
-
-                $tokenData = [
-                    'token' => $tokenObj->get('token'),
-                    'expires_at' => $tokenObj->get('expires_at'),
-                ];
+                $_SESSION['ms3']['customer_token'] = $tokenString;
+                $_SESSION['ms3']['customer_token_expires'] = strtotime($expiresAt);
             }
         }
 
@@ -124,9 +163,28 @@ class Register extends Processor
                 'phone' => $customer->get('phone'),
                 'email_verified' => !empty($customer->get('email_verified_at')),
             ],
-            'token' => $tokenData,
+            'token' => $tokenString,
+            'expires_at' => $expiresAt,
             'email_verification_required' => $requireEmailVerification,
             'redirect_url' => $redirectUrl,
         ]);
+    }
+
+    /**
+     * Bind draft order to customer
+     */
+    private function bindDraftToCustomer(string $token, int $customerId): void
+    {
+        $statusDraft = (int)$this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+
+        $draft = $this->modx->getObject(msOrder::class, [
+            'token' => $token,
+            'status_id' => $statusDraft,
+        ]);
+
+        if ($draft && empty($draft->get('customer_id'))) {
+            $draft->set('customer_id', $customerId);
+            $draft->save();
+        }
     }
 }

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -448,4 +448,42 @@ class OrderDraftManager
     {
         return (int)($_SESSION['ms3']['customer_id'] ?? 0);
     }
+
+    /**
+     * Bind draft order to customer by token
+     *
+     * Finds draft with given token and sets customer_id if not already set.
+     * Used during login/register to preserve guest cart.
+     *
+     * @param string $token Session token
+     * @param int $customerId Customer ID to bind
+     * @return bool True if draft was found and bound
+     */
+    public function bindDraftToCustomer(string $token, int $customerId): bool
+    {
+        if (empty($token) || $customerId <= 0) {
+            return false;
+        }
+
+        $statusDraft = (int)$this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+
+        $draft = $this->modx->getObject(msOrder::class, [
+            'token' => $token,
+            'status_id' => $statusDraft,
+        ]);
+
+        if ($draft && empty($draft->get('customer_id'))) {
+            $draft->set('customer_id', $customerId);
+            $draft->save();
+
+            $this->modx->log(
+                modX::LOG_LEVEL_INFO,
+                "[OrderDraftManager] Bound draft #{$draft->get('id')} to customer #{$customerId}"
+            );
+
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -52,13 +52,17 @@ class OrderDraftManager
         }
 
         // 2. Fallback: search by customer_id for authenticated customers
+        //    Sort by id DESC to get the most recent draft when multiple exist
         $customerId = (int)($_SESSION['ms3']['customer_id'] ?? 0);
         if ($customerId > 0) {
-            $draft = $this->modx->getObject(msOrder::class, [
+            $q = $this->modx->newQuery(msOrder::class);
+            $q->where([
                 'customer_id' => $customerId,
                 'status_id' => $status_draft,
                 'context' => $ctx,
             ]);
+            $q->sortby('id', 'DESC');
+            $draft = $this->modx->getObject(msOrder::class, $q);
 
             if ($draft) {
                 // Sync token: update draft token to match current session token
@@ -386,11 +390,15 @@ class OrderDraftManager
 
         $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
 
-        return $this->modx->getObject(msOrder::class, [
+        $q = $this->modx->newQuery(msOrder::class);
+        $q->where([
             'customer_id' => $customerId,
             'status_id' => $statusDraft,
             'context' => $ctx,
         ]);
+        $q->sortby('id', 'DESC');
+
+        return $this->modx->getObject(msOrder::class, $q);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -457,9 +457,10 @@ class OrderDraftManager
      *
      * @param string $token Session token
      * @param int $customerId Customer ID to bind
+     * @param string $ctx Context key
      * @return bool True if draft was found and bound
      */
-    public function bindDraftToCustomer(string $token, int $customerId): bool
+    public function bindDraftToCustomer(string $token, int $customerId, string $ctx = 'web'): bool
     {
         if (empty($token) || $customerId <= 0) {
             return false;
@@ -470,6 +471,7 @@ class OrderDraftManager
         $draft = $this->modx->getObject(msOrder::class, [
             'token' => $token,
             'status_id' => $statusDraft,
+            'context' => $ctx,
         ]);
 
         if ($draft && empty($draft->get('customer_id'))) {

--- a/core/components/minishop3/src/Services/TokenService.php
+++ b/core/components/minishop3/src/Services/TokenService.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3\Services;
 
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Utils\CookieHelper;
 use MODX\Revolution\modX;
 
 /**
@@ -12,6 +14,7 @@ use MODX\Revolution\modX;
  * - TTL (Time-To-Live) for tokens
  * - Centralized secrets management
  * - Token validation and verification
+ * - httpOnly cookie management for ms3_token
  */
 class TokenService
 {
@@ -46,6 +49,9 @@ class TokenService
         if ($existingToken) {
             $expires = $_SESSION['ms3']['customer_token_expires'] ?? (time() + 86400);
             $lifetime = max(0, $expires - time());
+
+            // Refresh cookie TTL
+            CookieHelper::setTokenCookie($this->modx, $existingToken);
 
             return [
                 'token' => $existingToken,
@@ -82,6 +88,9 @@ class TokenService
         $_SESSION['ms3']['customer_token'] = $token;
         $_SESSION['ms3']['customer_token_expires'] = time() + $ttl;
 
+        // Set httpOnly cookie
+        CookieHelper::setTokenCookie($this->modx, $token);
+
         $this->modx->log(
             modX::LOG_LEVEL_INFO,
             "[TokenService] Generated customer token for customer_id={$customerId}, expires: " . $expiresAt
@@ -92,6 +101,65 @@ class TokenService
             'expires' => time() + $ttl,
             'lifetime' => $ttl * 1000,
         ];
+    }
+
+    /**
+     * Resolve existing token or create new one
+     *
+     * Resolution chain:
+     * 1. Session token → if valid, return
+     * 2. Cookie token → verify in DB (msCustomerToken type=api), restore session, return
+     * 3. Generate new token → set cookie + session, return
+     *
+     * @return string Token string
+     */
+    public function resolveOrCreateToken(): string
+    {
+        // 1. Check session
+        $sessionToken = $this->getCustomerToken();
+        if ($sessionToken) {
+            CookieHelper::setTokenCookie($this->modx, $sessionToken);
+            return $sessionToken;
+        }
+
+        // 2. Check cookie
+        $cookieToken = CookieHelper::getTokenFromCookie();
+        if (!empty($cookieToken)) {
+            $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+                'token' => $cookieToken,
+                'type' => msCustomerToken::TYPE_API,
+            ]);
+
+            if ($tokenObj) {
+                // Auto-renew expired token
+                if ($tokenObj->isExpired()) {
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+                    $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
+                    $tokenObj->save();
+                }
+
+                // Restore session
+                if (!isset($_SESSION['ms3'])) {
+                    $_SESSION['ms3'] = [];
+                }
+                $_SESSION['ms3']['customer_token'] = $cookieToken;
+                $_SESSION['ms3']['customer_token_expires'] = strtotime($tokenObj->get('expires_at'));
+
+                $customerId = (int)$tokenObj->get('customer_id');
+                if ($customerId > 0) {
+                    $_SESSION['ms3']['customer_id'] = $customerId;
+                }
+
+                // Refresh cookie TTL
+                CookieHelper::setTokenCookie($this->modx, $cookieToken);
+
+                return $cookieToken;
+            }
+        }
+
+        // 3. Generate new token
+        $result = $this->generateCustomerToken();
+        return $result['token'];
     }
 
     /**

--- a/core/components/minishop3/src/Services/TokenService.php
+++ b/core/components/minishop3/src/Services/TokenService.php
@@ -65,7 +65,7 @@ class TokenService
         $token = bin2hex(random_bytes(32));
 
         if ($ttl === null) {
-            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
         }
 
         $expiresAt = date('Y-m-d H:i:s', time() + $ttl);
@@ -133,7 +133,7 @@ class TokenService
             if ($tokenObj) {
                 // Auto-renew expired token
                 if ($tokenObj->isExpired()) {
-                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
                     $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
                     $tokenObj->save();
                 }
@@ -176,7 +176,7 @@ class TokenService
         }
 
         if ($ttl === null) {
-            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 86400);
+            $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
         }
 
         $expires = time() + $ttl;

--- a/core/components/minishop3/src/Utils/CookieHelper.php
+++ b/core/components/minishop3/src/Utils/CookieHelper.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MiniShop3\Utils;
+
+use MODX\Revolution\modX;
+
+/**
+ * Helper for httpOnly cookie management
+ *
+ * Provides secure cookie operations for ms3_token.
+ * Uses MODX system settings for domain/path/secure/samesite.
+ * httpOnly is always true (security requirement, not configurable).
+ */
+class CookieHelper
+{
+    private const COOKIE_NAME = 'ms3_token';
+
+    /**
+     * Set token cookie
+     *
+     * Uses MODX session_cookie_* settings for domain, path, secure, samesite.
+     * httpOnly is always true — token must not be accessible from JS.
+     * Lifetime from ms3_customer_token_ttl (default 604800 = 7 days).
+     *
+     * @param modX $modx MODX instance (for reading system settings)
+     * @param string $token Token value
+     * @param int|null $maxAge Max age in seconds (null = from ms3_customer_token_ttl)
+     */
+    public static function setTokenCookie(modX $modx, string $token, ?int $maxAge = null): void
+    {
+        if (empty($token)) {
+            return;
+        }
+
+        if ($maxAge === null) {
+            $maxAge = (int)$modx->getOption('ms3_customer_token_ttl', null, 604800);
+        }
+
+        $domain = (string)$modx->getOption('session_cookie_domain', null, '');
+        $path = (string)$modx->getOption('session_cookie_path', null, '/');
+        $secure = (bool)$modx->getOption('session_cookie_secure', null, false);
+        $samesite = (string)$modx->getOption('session_cookie_samesite', null, 'Lax');
+
+        setcookie(self::COOKIE_NAME, $token, [
+            'expires' => time() + $maxAge,
+            'path' => $path ?: '/',
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => true,
+            'samesite' => $samesite ?: 'Lax',
+        ]);
+
+        // Make cookie available in current request immediately
+        $_COOKIE[self::COOKIE_NAME] = $token;
+    }
+
+    /**
+     * Clear token cookie
+     *
+     * @param modX $modx MODX instance
+     */
+    public static function clearTokenCookie(modX $modx): void
+    {
+        $domain = (string)$modx->getOption('session_cookie_domain', null, '');
+        $path = (string)$modx->getOption('session_cookie_path', null, '/');
+        $secure = (bool)$modx->getOption('session_cookie_secure', null, false);
+        $samesite = (string)$modx->getOption('session_cookie_samesite', null, 'Lax');
+
+        setcookie(self::COOKIE_NAME, '', [
+            'expires' => time() - 3600,
+            'path' => $path ?: '/',
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => true,
+            'samesite' => $samesite ?: 'Lax',
+        ]);
+
+        unset($_COOKIE[self::COOKIE_NAME]);
+    }
+
+    /**
+     * Get token from cookie
+     *
+     * @return string Token or empty string
+     */
+    public static function getTokenFromCookie(): string
+    {
+        return $_COOKIE[self::COOKIE_NAME] ?? '';
+    }
+}

--- a/core/components/minishop3/src/Utils/CookieHelper.php
+++ b/core/components/minishop3/src/Utils/CookieHelper.php
@@ -15,12 +15,18 @@ class CookieHelper
 {
     private const COOKIE_NAME = 'ms3_token';
 
+    /** @var bool Whether cookie was already set in this PHP request (prevents duplicate Set-Cookie headers) */
+    private static bool $cookieSetInThisRequest = false;
+
     /**
-     * Set token cookie
+     * Set token cookie (sliding expiry)
      *
      * Uses MODX session_cookie_* settings for domain, path, secure, samesite.
      * httpOnly is always true — token must not be accessible from JS.
      * Lifetime from ms3_customer_token_ttl (default 604800 = 7 days).
+     *
+     * Cookie is set once per PHP request (first call renews expires,
+     * subsequent calls are skipped to avoid duplicate Set-Cookie headers).
      *
      * @param modX $modx MODX instance (for reading system settings)
      * @param string $token Token value
@@ -32,8 +38,8 @@ class CookieHelper
             return;
         }
 
-        // Skip if cookie already has correct value (avoid duplicate Set-Cookie headers)
-        if (($_COOKIE[self::COOKIE_NAME] ?? '') === $token) {
+        // Set cookie once per request: first call renews expires, subsequent calls skip
+        if (self::$cookieSetInThisRequest) {
             return;
         }
 
@@ -54,6 +60,8 @@ class CookieHelper
             'httponly' => true,
             'samesite' => $samesite ?: 'Lax',
         ]);
+
+        self::$cookieSetInThisRequest = true;
 
         // Make cookie available in current request immediately
         $_COOKIE[self::COOKIE_NAME] = $token;

--- a/core/components/minishop3/src/Utils/CookieHelper.php
+++ b/core/components/minishop3/src/Utils/CookieHelper.php
@@ -15,8 +15,8 @@ class CookieHelper
 {
     private const COOKIE_NAME = 'ms3_token';
 
-    /** @var bool Whether cookie was already set in this PHP request (prevents duplicate Set-Cookie headers) */
-    private static bool $cookieSetInThisRequest = false;
+    /** @var string|null Token value set in this PHP request (prevents duplicate Set-Cookie headers, allows token change) */
+    private static ?string $lastTokenSet = null;
 
     /**
      * Set token cookie (sliding expiry)
@@ -25,8 +25,8 @@ class CookieHelper
      * httpOnly is always true — token must not be accessible from JS.
      * Lifetime from ms3_customer_token_ttl (default 604800 = 7 days).
      *
-     * Cookie is set once per PHP request (first call renews expires,
-     * subsequent calls are skipped to avoid duplicate Set-Cookie headers).
+     * Deduplication: skips if same token was already set in this PHP request.
+     * Allows token change (e.g. Logout sets new token after middleware set old one).
      *
      * @param modX $modx MODX instance (for reading system settings)
      * @param string $token Token value
@@ -38,8 +38,9 @@ class CookieHelper
             return;
         }
 
-        // Set cookie once per request: first call renews expires, subsequent calls skip
-        if (self::$cookieSetInThisRequest) {
+        // Skip if same token already set in this request (avoids duplicate Set-Cookie headers)
+        // Allows token change (e.g. Logout creates new token after middleware set old one)
+        if (self::$lastTokenSet === $token) {
             return;
         }
 
@@ -61,7 +62,7 @@ class CookieHelper
             'samesite' => $samesite ?: 'Lax',
         ]);
 
-        self::$cookieSetInThisRequest = true;
+        self::$lastTokenSet = $token;
 
         // Make cookie available in current request immediately
         $_COOKIE[self::COOKIE_NAME] = $token;
@@ -89,6 +90,7 @@ class CookieHelper
         ]);
 
         unset($_COOKIE[self::COOKIE_NAME]);
+        self::$lastTokenSet = null;
     }
 
     /**

--- a/core/components/minishop3/src/Utils/CookieHelper.php
+++ b/core/components/minishop3/src/Utils/CookieHelper.php
@@ -32,6 +32,11 @@ class CookieHelper
             return;
         }
 
+        // Skip if cookie already has correct value (avoid duplicate Set-Cookie headers)
+        if (($_COOKIE[self::COOKIE_NAME] ?? '') === $token) {
+            return;
+        }
+
         if ($maxAge === null) {
             $maxAge = (int)$modx->getOption('ms3_customer_token_ttl', null, 604800);
         }


### PR DESCRIPTION
## Summary

- **Проблема:** 4 независимых хранилища токена (localStorage, `$_SESSION`, `ms3_customer_tokens`, `msCustomer.token`) без синхронизации. Корзина не работает после логина — добавление идёт по одному токену, отображение по другому.
- **Решение:** httpOnly cookie `ms3_token` как единственный источник правды. Токен устанавливается сервером, отправляется браузером автоматически, недоступен из JS.
- Middleware injection (`$_COOKIE → $_REQUEST`) обеспечивает обратную совместимость — CartController, OrderController, AuthorizedCustomerTrait работают без изменений.

## Changes

### New
- `CookieHelper` — управление httpOnly cookie, использует MODX `session_cookie_*` настройки
- `TokenService::resolveOrCreateToken()` — единая цепочка разрешения токена (session → cookie → generate)
- `Customer::autoLoginCustomer()` — привязка `msCustomerToken` к customer при автологине после первого заказа

### Modified
- **TokenMiddleware** — cookie injection в `$_REQUEST`, поддержка `Authorization: Bearer`, auto-create токена для первого визита
- **Login.php** — использует существующий токен вместо создания нового, привязывает draft к customer
- **Register.php** — аналогично Login + фикс формата response (`token` возвращает строку, не объект)
- **Logout.php** — revoke всех API-токенов customer, генерация свежего анонимного токена (`bin2hex(random_bytes(32))`). Старая гостевая корзина **теряется** (security: старый токен инвалидирован)
- **5 сниппетов** — единый `$tokenService->resolveOrCreateToken()` вместо дублирующейся логики
- **JS (TokenManager, ApiClient, auth-forms)** — убран localStorage, добавлен `credentials: 'same-origin'`
- **OrderDraftManager** — `sortby('id', 'DESC')` при поиске draft по customer_id, `bindDraftToCustomer()` с фильтром по context

### Not modified (backward compat via middleware)
- CartController (6 мест с `$_REQUEST`)
- OrderController (14 мест с `$_REQUEST`)
- AuthorizedCustomerTrait

## ⚠️ Breaking changes

### Register.php response format

**До:**
```json
{
  "token": { "token": "abc123...", "expires_at": "2026-03-09 12:00:00" }
}
```

**После:**
```json
{
  "token": "abc123...",
  "expires_at": "2026-03-09 12:00:00"
}
```

Поле `token` теперь возвращает строку вместо объекта. Поле `expires_at` вынесено на верхний уровень. Кастомные темы/интеграции, обращающиеся к `result.object.token.token`, потребуют обновления.

## Test plan

- [ ] Гость: добавление в корзину → cookie `ms3_token` появляется (httpOnly=true)
- [ ] Гость: оформление заказа → customer создаётся, корзина сохраняется
- [ ] Логин: гостевая корзина сохраняется после авторизации
- [ ] Регистрация с autoLogin: корзина сохраняется
- [ ] Логаут: старый токен revoked, создаётся новый анонимный токен, корзина начинается заново
- [ ] Обновление страницы: корзина не теряется
- [ ] Протухание PHP-сессии: cookie восстанавливает сессию
- [ ] localStorage: очищается, не используется
- [ ] DevTools: `ms3_token` нет в URL-параметрах запросов

🤖 Generated with [Claude Code](https://claude.com/claude-code)