### PR TITLE
fix(build): ensure 'desc' key exists in snippet and source properties

### DIFF
--- a/_build/resolvers/resolver_04_sources.php
+++ b/_build/resolvers/resolver_04_sources.php
@@ -130,6 +130,11 @@ if ($transport->xpdo) {
                         $default[$k] = $v;
                     }
                 }
+                foreach ($default as $k => $prop) {
+                    if (is_array($prop) && !array_key_exists('desc', $prop)) {
+                        $default[$k]['desc'] = '';
+                    }
+                }
                 $source->set('properties', $default);
             }
             $source->save();

--- a/_build/resolvers/resolver_08_snippet_properties.php
+++ b/_build/resolvers/resolver_08_snippet_properties.php
@@ -41,9 +41,13 @@ switch ($options[xPDOTransport::PACKAGE_ACTION] ?? null) {
                 if (!is_array($propDef)) {
                     continue;
                 }
+                if (!array_key_exists('desc', $propDef)) {
+                    $properties[$propName]['desc'] = '';
+                    $changed = true;
+                }
                 $propKey = $propName === 'includeTVs' ? 'include_tvs' : $camelToSnake($propName);
                 $newDesc = 'ms3_prop_' . $propKey;
-                $currentDesc = $propDef['desc'] ?? '';
+                $currentDesc = $properties[$propName]['desc'] ?? '';
                 if ($currentDesc !== $newDesc) {
                     $properties[$propName]['desc'] = $newDesc;
                     $changed = true;


### PR DESCRIPTION
## Описание

Исправление ошибок при сборке пакета, когда у свойств сниппетов и источников отсутствует ключ `desc`. Добавлена инициализация пустой строки для `desc`, если ключ отсутствует в определении свойства.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

https://modx.pro/components/25458#comment-146331

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Изменения:**
- `resolver_04_sources.php`: добавлена проверка и инициализация `desc` для свойств источников
- `resolver_08_snippet_properties.php`: добавлена проверка `array_key_exists('desc')` перед обращением к ключу, исправлено чтение `currentDesc` из обновлённого массива `$properties`

## Скриншоты (если применимо)

Не применимо.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Исправление предотвращает предупреждения/ошибки при `array_key_exists` и обращении к несуществующему ключу `desc` в определениях свойств.
