### PR TITLE
fix(manager): cast permission flags to int for MODX JS strict comparison

### DIFF
--- a/core/components/minishop3/controllers/category/create.class.php
+++ b/core/components/minishop3/controllers/category/create.class.php
@@ -71,8 +71,8 @@ class msCategoryCreateManagerController extends msResourceCreateController
                 'isfolder' => true,
             ]),
             'publish_document' => $this->canPublish,
-            'canSave' => $this->modx->hasPermission('mscategory_save'),
-            'show_tvs' => !empty($this->tvCounts),
+            'canSave' => (int) ($this->canSave && $this->modx->hasPermission('mscategory_save')),
+            'show_tvs' => (int) !empty($this->tvCounts),
             'mode' => 'create',
         ];
 

--- a/core/components/minishop3/controllers/category/update.class.php
+++ b/core/components/minishop3/controllers/category/update.class.php
@@ -112,6 +112,7 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             'category_products_rows' => (int) $this->getOption('ms3_category_products_default_rows', null, 20),
         );
         // Parent already sets $this->canSave (save_document, checkPolicy('save'), lock). Add component permission only.
+        // All permission flags must be cast to (int) because MODX JS uses strict comparison (=== 1).
         $ready = array(
             'xtype' => 'ms3-page-category-update',
             'resource' => $this->resource->get('id'),
@@ -121,11 +122,12 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             'locked' => $this->locked,
             'lockedText' => $this->lockedText,
             'canSave' => (int) ($this->canSave && $this->modx->hasPermission('mscategory_save')),
-            'canEdit' => $this->canEdit,
-            'canCreate' => $this->canCreate,
-            'canDuplicate' => $this->canDuplicate,
-            'canDelete' => $this->canDelete,
-            'canPublish' => $this->canPublish,
+            'canEdit' => (int) $this->canEdit,
+            'canCreate' => (int) $this->canCreate,
+            'canCreateRoot' => (int) $this->canCreateRoot,
+            'canDuplicate' => (int) $this->canDuplicate,
+            'canDelete' => (int) $this->canDelete,
+            'canPublish' => (int) $this->canPublish,
             'show_tvs' => !empty($this->tvCounts),
             'next_page' => !empty($neighborhood['right'][0]) ? $neighborhood['right'][0] : 0,
             'prev_page' => !empty($neighborhood['left'][0]) ? $neighborhood['left'][0] : 0,

--- a/core/components/minishop3/controllers/category/update.class.php
+++ b/core/components/minishop3/controllers/category/update.class.php
@@ -128,7 +128,7 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             'canDuplicate' => (int) $this->canDuplicate,
             'canDelete' => (int) $this->canDelete,
             'canPublish' => (int) $this->canPublish,
-            'show_tvs' => !empty($this->tvCounts),
+            'show_tvs' => (int) !empty($this->tvCounts),
             'next_page' => !empty($neighborhood['right'][0]) ? $neighborhood['right'][0] : 0,
             'prev_page' => !empty($neighborhood['left'][0]) ? $neighborhood['left'][0] : 0,
             'up_page' => $this->resource->parent,

--- a/core/components/minishop3/controllers/product/create.class.php
+++ b/core/components/minishop3/controllers/product/create.class.php
@@ -133,13 +133,8 @@ class msProductCreateManagerController extends msResourceCreateController
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
             'publish_document' => $this->canPublish,
-            'canSave' => $this->canSave,
-            'canEdit' => $this->canEdit,
-            'canCreate' => $this->canCreate,
-            'canDuplicate' => $this->canDuplicate,
-            'canDelete' => $this->canDelete,
-            'canPublish' => $this->canPublish,
-            'show_tvs' => !empty($this->tvCounts),
+            'canSave' => (int) ($this->canSave && $this->modx->hasPermission('msproduct_save')),
+            'show_tvs' => (int) !empty($this->tvCounts),
             'mode' => 'create',
         ];
 

--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -137,6 +137,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
         ];
 
         // Parent already sets $this->canSave (save_document, checkPolicy('save'), lock). Add component permission only.
+        // All permission flags must be cast to (int) because MODX JS uses strict comparison (=== 1).
         $ready = [
             'xtype' => 'ms3-page-product-update',
             'resource' => $this->resource->get('id'),
@@ -146,11 +147,12 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'locked' => $this->locked,
             'lockedText' => $this->lockedText,
             'canSave' => (int) ($this->canSave && $this->modx->hasPermission('msproduct_save')),
-            'canEdit' => $this->canEdit,
-            'canCreate' => $this->canCreate,
-            'canDuplicate' => $this->canDuplicate,
-            'canDelete' => $this->canDelete,
-            'canPublish' => $this->canPublish,
+            'canEdit' => (int) $this->canEdit,
+            'canCreate' => (int) $this->canCreate,
+            'canCreateRoot' => (int) $this->canCreateRoot,
+            'canDuplicate' => (int) $this->canDuplicate,
+            'canDelete' => (int) $this->canDelete,
+            'canPublish' => (int) $this->canPublish,
             'show_tvs' => !empty($this->tvCounts),
             'next_page' => !empty($neighborhood['right'][0])
                 ? $neighborhood['right'][0]

--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -153,7 +153,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'canDuplicate' => (int) $this->canDuplicate,
             'canDelete' => (int) $this->canDelete,
             'canPublish' => (int) $this->canPublish,
-            'show_tvs' => !empty($this->tvCounts),
+            'show_tvs' => (int) !empty($this->tvCounts),
             'next_page' => !empty($neighborhood['right'][0])
                 ? $neighborhood['right'][0]
                 : 0,


### PR DESCRIPTION
## Описание

Восстановлена кнопка «Копировать» (и «Удалить») у товаров и категорий в админ-панели.

**Корневая причина:** MODX JS использует строгое сравнение `=== 1` для permission-флагов (`canDuplicate`, `canDelete`, `canCreateRoot`). При передаче `boolean` через `json_encode` значения становятся `true`/`false` вместо `1`/`0`, и выражение `true === 1` в JavaScript возвращает `false` — кнопки не отображаются.

**Изменения:**
- Все permission-флаги приведены к `(int)` в контроллерах обновления товаров и категорий — в соответствии с паттерном MODX core
- Добавлен недостающий флаг `canCreateRoot` (необходим для дублирования ресурсов в корне сайта)
- Контроллеры создания приведены в соответствие: добавлена компонентная проверка прав, удалены неиспользуемые permission-флаги

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #128

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.6.0-beta1
- MODX: 3.2
- PHP: 8.x

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Кнопка «Копировать» отсутствует | Кнопка «Копировать» отображается |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Исправление следует паттерну MODX core: `manager/controllers/default/resource/update.class.php` — все permission-флаги приведены к `(int)` в PHP.