### PR TITLE
feat: support custom fields in order validation

### DIFF
--- a/assets/components/minishop3/js/web/ui/OrderUI.js
+++ b/assets/components/minishop3/js/web/ui/OrderUI.js
@@ -71,12 +71,13 @@ class OrderUI {
         feedback.textContent = ''
       }
 
-      const response = await this.handleAdd(input.name, input.value)
+      const value = input.type === 'checkbox' ? (input.checked ? '1' : '0') : input.value
+      const response = await this.handleAdd(input.name, value)
 
       if (response.success) {
         parent.classList.add('was-validated')
 
-        if (response.data && response.data[input.name] !== undefined) {
+        if (input.type !== 'checkbox' && response.data && response.data[input.name] !== undefined) {
           input.value = response.data[input.name]
         }
       } else {

--- a/core/components/minishop3/src/Services/Order/OrderAddressManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderAddressManager.php
@@ -114,12 +114,12 @@ class OrderAddressManager
      *
      * @param int $customerId Customer ID
      * @param array $orderData Order data with address fields
-     * @return msCustomerAddress|null Created address or null on failure
+     * @return bool True on success, false on failure or duplicate
      */
-    public function saveToCustomerAddresses(int $customerId, array $orderData): ?msCustomerAddress
+    public function saveToCustomerAddresses(int $customerId, array $orderData): bool
     {
         if (empty($customerId)) {
-            return null;
+            return false;
         }
 
         $addressData = [

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -268,9 +268,36 @@ class OrderDraftManager
         }
 
         // Handle save_address in properties
-        if ($key === 'save_address' && !empty($value)) {
+        if ($key === 'save_address') {
             $properties = $draft->get('properties') ?? [];
-            $properties['save_address'] = 1;
+            if (!empty($value)) {
+                $properties['save_address'] = 1;
+            } else {
+                unset($properties['save_address']);
+            }
+            $draft->set('properties', $properties);
+            $draft->set('updatedon', time());
+            $draft->save();
+            $updated = true;
+        }
+
+        // Fallback: save non-model fields to properties['_validated']
+        if (!$updated) {
+            $properties = $draft->get('properties') ?? [];
+            $validated = $properties['_validated'] ?? [];
+
+            if ($value === null || $value === '') {
+                unset($validated[$key]);
+            } else {
+                $validated[$key] = $value;
+            }
+
+            if (empty($validated)) {
+                unset($properties['_validated']);
+            } else {
+                $properties['_validated'] = $validated;
+            }
+
             $draft->set('properties', $properties);
             $draft->set('updatedon', time());
             $draft->save();

--- a/core/components/minishop3/src/Services/Order/OrderFieldManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderFieldManager.php
@@ -66,7 +66,7 @@ class OrderFieldManager
         $value = $response['data']['value'];
 
         // Empty value = remove field
-        if (empty($value)) {
+        if ($value === null || $value === '') {
             if ($draft) {
                 $this->remove($draft, $orderData, $key);
             }
@@ -142,8 +142,12 @@ class OrderFieldManager
      */
     public function remove(msOrder $draft, array $orderData, string $key): bool
     {
+        $properties = $draft->get('properties') ?? [];
+        $existsInValidated = isset($properties['_validated'][$key]);
+
         $exists = array_key_exists($key, $orderData)
-            || array_key_exists('address_' . $key, $orderData);
+            || array_key_exists('address_' . $key, $orderData)
+            || $existsInValidated;
 
         if ($exists) {
             $response = $this->ms3->utils->invokeEvent('msOnBeforeRemoveFromOrder', [

--- a/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
+++ b/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
@@ -128,9 +128,10 @@ class OrderSubmitHandler
         }
 
         $requires = $requiredResponse['data']['requires'];
+        $validatedFields = $orderData['properties']['_validated'] ?? [];
         $errors = [];
         foreach ($requires as $field => $rules) {
-            if (empty($orderData[$field]) && empty($orderData['address_' . $field])) {
+            if (empty($orderData[$field]) && empty($orderData['address_' . $field]) && empty($validatedFields[$field])) {
                 $errors[] = $field;
             }
         }
@@ -197,10 +198,14 @@ class OrderSubmitHandler
             $this->addressManager->saveToCustomerAddresses($customerId, $orderData);
         }
 
+        // Extract custom validated fields before events
+        $customFields = $properties['_validated'] ?? [];
+
         // Event: before create order
         $response = $this->ms3->utils->invokeEvent('msOnBeforeCreateOrder', [
             'handler' => $this,
             'msOrder' => $draft,
+            'customFields' => $customFields,
         ]);
 
         if (!$response['success']) {
@@ -211,10 +216,19 @@ class OrderSubmitHandler
         $response = $this->ms3->utils->invokeEvent('msOnCreateOrder', [
             'handler' => $this,
             'msOrder' => $draft,
+            'customFields' => $customFields,
         ]);
 
         if (!$response['success']) {
             return $this->error($response['message']);
+        }
+
+        // Clean up _validated from properties
+        if (!empty($customFields)) {
+            $properties = $draft->get('properties') ?? [];
+            unset($properties['_validated']);
+            $draft->set('properties', $properties);
+            $draft->save();
         }
 
         // Store order in session

--- a/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
+++ b/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
@@ -131,7 +131,7 @@ class OrderSubmitHandler
         $validatedFields = $orderData['properties']['_validated'] ?? [];
         $errors = [];
         foreach ($requires as $field => $rules) {
-            if (empty($orderData[$field]) && empty($orderData['address_' . $field]) && empty($validatedFields[$field])) {
+            if (empty($orderData[$field]) && empty($orderData['address_' . $field]) && !isset($validatedFields[$field])) {
                 $errors[] = $field;
             }
         }


### PR DESCRIPTION
## Summary

- Кастомные поля (например, чекбокс `agreement` с правилом `required|accepted`) в правилах валидации доставки теперь корректно сохраняются между `order/add` и `order/submit`
- Значения кастомных полей хранятся в `draft->properties['_validated']` и передаются в события `msOnBeforeCreateOrder` / `msOnCreateOrder` через параметр `customFields`
- Чекбоксы на фронтенде отправляют состояние `.checked` (`'1'`/`'0'`) вместо статического атрибута `value`

## Changes

| Файл | Изменение |
|------|-----------|
| `OrderDraftManager.php` | `updateField()`: fallback для не-модельных полей в `properties['_validated']`; `save_address` корректно обрабатывает снятие чекбокса |
| `OrderFieldManager.php` | `add()`: фикс `empty('0')` → `$value === null \|\| $value === ''`; `remove()`: проверка `properties['_validated']` |
| `OrderSubmitHandler.php` | `submit()`: required-проверка учитывает `_validated`; `customFields` в события; очистка `_validated` после создания заказа |
| `OrderAddressManager.php` | `saveToCustomerAddresses()`: фикс return type `?msCustomerAddress` → `bool` |
| `OrderUI.js` | Чекбоксы: `input.checked ? '1' : '0'`; не перезаписывать `value` из ответа сервера |

## Test plan

- [ ] Настроить доставку с правилом `"agree": "required|accepted"`
- [ ] `order/add('agree', '1')` → success, значение в `properties['_validated']['agree']`
- [ ] `order/add('agree', '0')` → ошибка валидации `accepted`
- [ ] `order/submit` без отмеченного чекбокса → ошибка required
- [ ] `order/submit` с отмеченным чекбоксом → заказ создан, `_validated` очищен
- [ ] Стандартные поля (`first_name`, `email`) работают как раньше
- [ ] `save_address` чекбокс: отметка → сохраняет, снятие → убирает из properties
- [ ] PHPStan без новых ошибок