### PR TITLE
fix: add MODX table prefix to relation field table names

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -388,6 +388,12 @@ class CustomersController
                 continue;
             }
 
+            // Ensure table prefix is present (fallback for configs saved without prefix)
+            $tablePrefix = $this->modx->config['table_prefix'] ?? '';
+            if ($tablePrefix !== '' && strpos($relationTable, $tablePrefix) !== 0) {
+                $relationTable = $tablePrefix . $relationTable;
+            }
+
             if ($aggregation) {
                 $selectExpr = "{$aggregation}({$relationTable}.{$displayField})";
             } else {

--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -388,9 +388,13 @@ class CustomersController
                 continue;
             }
 
-            // Ensure table prefix is present (fallback for configs saved without prefix)
+            // Fallback for configs saved before table prefix fix — can be removed
+            // after all existing relation configs are re-saved via utility page
             $tablePrefix = $this->modx->config['table_prefix'] ?? '';
-            if ($tablePrefix !== '' && strpos($relationTable, $tablePrefix) !== 0) {
+            if ($tablePrefix !== ''
+                && !str_starts_with($relationTable, $tablePrefix)
+                && !str_starts_with($relationTable, '`')
+            ) {
                 $relationTable = $tablePrefix . $relationTable;
             }
 

--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -584,7 +584,11 @@ class GridConfigService
                 return ['success' => false, 'message' => "Invalid model class: {$tableOrModel}. " . $e->getMessage()];
             }
         } else {
-            // This is direct table name - use as is
+            // This is direct table name - add table prefix if not already present
+            $tablePrefix = $this->modx->config['table_prefix'] ?? '';
+            if ($tablePrefix !== '' && strpos($tableOrModel, $tablePrefix) !== 0) {
+                $tableOrModel = $tablePrefix . $tableOrModel;
+            }
             $config['relation']['resolvedTableName'] = $tableOrModel;
         }
 

--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -586,7 +586,7 @@ class GridConfigService
         } else {
             // This is direct table name - add table prefix if not already present
             $tablePrefix = $this->modx->config['table_prefix'] ?? '';
-            if ($tablePrefix !== '' && strpos($tableOrModel, $tablePrefix) !== 0) {
+            if ($tablePrefix !== '' && !str_starts_with($tableOrModel, $tablePrefix)) {
                 $tableOrModel = $tablePrefix . $tableOrModel;
             }
             $config['relation']['resolvedTableName'] = $tableOrModel;


### PR DESCRIPTION
## Summary

- Relation fields in grid config utility (e.g. `orders_count` with `COUNT()` on `ms3_orders`) returned zeros because the MODX table prefix was not applied to direct table names
- `GridConfigService::validateRelationConfig()` now adds the table prefix when saving relation config with a direct table name
- `CustomersController::fetchRelationData()` adds a fallback prefix check for configs already saved without prefix

## Test plan

- [ ] Create a relation field in grid config with a direct table name (e.g. `ms3_orders`)
- [ ] Verify the aggregated values display correctly (not zeros)
- [ ] Verify that entering a table name with prefix already included does not double-prefix
- [ ] Test on installations with different table prefixes (e.g. `modx_`, empty)