### PR TITLE
fix: implement server-side sorting for customers grid

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -34,6 +34,8 @@ class CustomersController
         $start = (int)($params['start'] ?? 0);
         $limit = (int)($params['limit'] ?? 20);
         $query = trim($params['query'] ?? '');
+        $sort = $params['sort'] ?? 'id';
+        $dir = strtoupper($params['dir'] ?? 'DESC');
 
         $gridConfig = $this->modx->services->get('ms3_grid_config');
         $gridFields = $gridConfig ? $gridConfig->getGridConfig('customers') : [];
@@ -41,37 +43,39 @@ class CustomersController
         $relationFields = $this->extractRelationFields($gridFields);
         $computedFields = $this->extractComputedFields($gridFields);
 
-        $criteria = [];
+        $c = $this->modx->newQuery(msCustomer::class);
 
         if (!empty($query)) {
-            $criteria[] = [
+            $c->where([
                 'first_name:LIKE' => "%{$query}%",
                 'OR:last_name:LIKE' => "%{$query}%",
                 'OR:email:LIKE' => "%{$query}%",
                 'OR:phone:LIKE' => "%{$query}%",
-            ];
+            ]);
         }
 
         foreach ($params as $key => $value) {
-            if (strpos($key, 'filter_') === 0 && !empty($value)) {
+            if (str_starts_with($key, 'filter_') && !empty($value)) {
                 $fieldName = substr($key, 7);
 
                 if ($fieldName === 'active') {
-                    $criteria['is_active'] = (int)$value;
+                    $c->where(['is_active' => (int)$value]);
                 } else {
-                    $criteria[$fieldName . ':LIKE'] = "%{$value}%";
+                    $c->where([$fieldName . ':LIKE' => "%{$value}%"]);
                 }
             }
         }
 
-        $total = $this->modx->getCount(msCustomer::class, $criteria);
+        $total = $this->modx->getCount(msCustomer::class, $c);
 
-        $customers = $this->modx->getIterator(msCustomer::class, $criteria, [
-            'limit' => $limit,
-            'offset' => $start,
-            'sortby' => 'id',
-            'sortdir' => 'DESC'
-        ]);
+        $sortField = $this->mapSortField($sort);
+        if (!in_array($dir, ['ASC', 'DESC'])) {
+            $dir = 'DESC';
+        }
+        $c->sortby($sortField, $dir);
+        $c->limit($limit, $start);
+
+        $customers = $this->modx->getIterator(msCustomer::class, $c);
 
         $results = [];
 
@@ -279,6 +283,33 @@ class CustomersController
             'deleted' => $deleted,
             'failed' => $failed
         ], "Deleted {$deleted} customers")->getData();
+    }
+
+    /**
+     * Map sort field name to safe column reference
+     *
+     * @param string $sort Field name from request
+     * @return string Safe column reference for ORDER BY
+     */
+    protected function mapSortField(string $sort): string
+    {
+        $mapping = [
+            'id' => 'msCustomer.id',
+            'first_name' => 'msCustomer.first_name',
+            'last_name' => 'msCustomer.last_name',
+            'email' => 'msCustomer.email',
+            'phone' => 'msCustomer.phone',
+            'is_active' => 'msCustomer.is_active',
+            'is_blocked' => 'msCustomer.is_blocked',
+            'created_at' => 'msCustomer.created_at',
+            'updated_at' => 'msCustomer.updated_at',
+            'last_login_at' => 'msCustomer.last_login_at',
+            'orders_count' => 'msCustomer.orders_count',
+            'total_spent' => 'msCustomer.total_spent',
+            'last_order_at' => 'msCustomer.last_order_at',
+        ];
+
+        return $mapping[$sort] ?? 'msCustomer.id';
     }
 
     /**

--- a/vueManager/src/components/CustomersGrid.vue
+++ b/vueManager/src/components/CustomersGrid.vue
@@ -47,6 +47,8 @@ const customers = ref([])
 const totalRecords = ref(0)
 const first = ref(0)
 const rows = ref(20)
+const sortField = ref('id')
+const sortOrder = ref(-1)
 const filterValues = ref({})
 const filterableColumns = computed(() => columns.value.filter(col => col.filterable && col.visible))
 const searchQuery = ref('')
@@ -73,6 +75,8 @@ async function loadCustomers() {
     const params = {
       start: first.value,
       limit: rows.value,
+      sort: sortField.value,
+      dir: sortOrder.value === 1 ? 'ASC' : 'DESC',
     }
 
     if (searchQuery.value) {
@@ -115,6 +119,16 @@ async function loadCustomers() {
 function onPage(event) {
   first.value = event.first
   rows.value = event.rows
+  loadCustomers()
+}
+
+/**
+ * Handle sort
+ */
+function onSort(event) {
+  sortField.value = event.sortField || 'id'
+  sortOrder.value = event.sortOrder ?? -1
+  first.value = 0
   loadCustomers()
 }
 
@@ -722,10 +736,13 @@ onMounted(async () => {
           :rows="rows"
           :total-records="totalRecords"
           :lazy="true"
+          :sort-field="sortField"
+          :sort-order="sortOrder"
           data-key="id"
           striped-rows
           responsive-layout="scroll"
           @page="onPage"
+          @sort="onSort"
         >
           <!-- Selection checkbox column -->
           <Column selection-mode="multiple" header-style="width: 3rem" frozen></Column>


### PR DESCRIPTION
## Summary

- Sorting in customers grid was visual-only — PrimeVue DataTable showed sort icons but data never actually sorted
- Root cause: `CustomersController::getList()` had hardcoded `sortby: 'id'` and passed sort/limit options as 3rd argument to `getIterator()`, which is actually `$cacheFlag` — so sorting AND pagination were silently ignored
- Also: `CustomersGrid.vue` never sent `sort`/`dir` parameters to the API

### Changes

**CustomersController.php:**
- `getIterator($class, $criteria, $options)` → `newQuery()` + `$c->sortby()` + `$c->limit()`
- Accept `sort`/`dir` URL parameters
- `mapSortField()` whitelist for safe ORDER BY (prevents SQL injection)
- `strpos` → `str_starts_with` (PHP 8.2+)

**CustomersGrid.vue:**
- Add `sortField`/`sortOrder` refs, `onSort` handler
- Bind `:sort-field`/`:sort-order` and `@sort` on DataTable
- Pass `sort`/`dir` in API request params

## Test plan

- [ ] Click sortable column headers in customers grid — data should re-sort
- [ ] Verify sort direction toggles (ASC/DESC) with repeated clicks
- [ ] Verify pagination works correctly after sorting
- [ ] Verify non-sortable columns (e.g. template fields) don't trigger sort
- [ ] Verify search + sort work together