### PR TITLE
fix: absolute URLs in customer orders filter and pagination

### DIFF
--- a/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
@@ -2,7 +2,7 @@
     {* Навигация назад *}
     <div class="mb-3">
         <a href="{'ms3_customer_orders_page_id' | option | url}" class="btn btn-sm btn-outline-secondary">
-            <svg width="16" height="16" fill="currentColor" class="me-1">
+            <svg width="16" height="16" fill="none" stroke="currentColor" class="me-1">
                 <use xlink:href="#icon-arrow-left"/>
             </svg>
             {'ms3_customer_orders_back' | lexicon}
@@ -84,7 +84,7 @@
                         {if $total.delivery_cost}
                         <tr>
                             <td colspan="3" class="text-end">
-                                <svg class="me-1" width="16" height="16" fill="currentColor">
+                                <svg class="me-1" width="16" height="16" fill="none" stroke="currentColor">
                                     <use xlink:href="#icon-truck"/>
                                 </svg>
                                 {'ms3_frontend_delivery' | lexicon}:
@@ -107,7 +107,7 @@
     <div class="card shadow-sm mb-4">
         <div class="card-header bg-light">
             <h6 class="mb-0">
-                <svg class="me-1" width="16" height="16" fill="currentColor">
+                <svg class="me-1" width="16" height="16" fill="none" stroke="currentColor">
                     <use xlink:href="#icon-map-pin"/>
                 </svg>
                 {'ms3_frontend_delivery_address' | lexicon}
@@ -139,7 +139,7 @@
             <div class="card shadow-sm mb-4">
                 <div class="card-header bg-light">
                     <h6 class="mb-0">
-                        <svg class="me-1" width="16" height="16" fill="currentColor">
+                        <svg class="me-1" width="16" height="16" fill="none" stroke="currentColor">
                             <use xlink:href="#icon-truck"/>
                         </svg>
                         {'ms3_frontend_delivery_method' | lexicon}
@@ -160,7 +160,7 @@
             <div class="card shadow-sm mb-4">
                 <div class="card-header bg-light">
                     <h6 class="mb-0">
-                        <svg class="me-1" width="16" height="16" fill="currentColor">
+                        <svg class="me-1" width="16" height="16" fill="none" stroke="currentColor">
                             <use xlink:href="#icon-credit-card"/>
                         </svg>
                         {'ms3_frontend_payment_method' | lexicon}
@@ -182,7 +182,7 @@
     <div class="card shadow-sm mb-4">
         <div class="card-header bg-light">
             <h6 class="mb-0">
-                <svg class="me-1" width="16" height="16" fill="currentColor">
+                <svg class="me-1" width="16" height="16" fill="none" stroke="currentColor">
                     <use xlink:href="#icon-message"/>
                 </svg>
                 {'ms3_frontend_comment' | lexicon}

--- a/core/components/minishop3/elements/chunks/ms3_customer_orders.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_orders.tpl
@@ -65,7 +65,7 @@
                 <ul class="pagination justify-content-center">
                     {if $pagination.has_prev}
                     <li class="page-item">
-                        <a class="page-link" href="{$page_url}?offset={$pagination.prev_offset}">
+                        <a class="page-link" href="{$pagination.prev_url}">
                             {'ms3_customer_orders_prev' | lexicon}
                         </a>
                     </li>
@@ -73,7 +73,7 @@
 
                     {foreach $pagination.pages as $page}
                     <li class="page-item {if $page.active}active{/if}">
-                        <a class="page-link" href="{$page_url}?offset={$page.offset}">
+                        <a class="page-link" href="{$page.url}">
                             {$page.num}
                         </a>
                     </li>
@@ -81,7 +81,7 @@
 
                     {if $pagination.has_next}
                     <li class="page-item">
-                        <a class="page-link" href="{$page_url}?offset={$pagination.next_offset}">
+                        <a class="page-link" href="{$pagination.next_url}">
                             {'ms3_customer_orders_next' | lexicon}
                         </a>
                     </li>

--- a/core/components/minishop3/elements/chunks/ms3_customer_orders.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_orders.tpl
@@ -16,7 +16,7 @@
         <div class="card-body">
             {* Фильтр по статусу *}
             {if $statuses}
-            <form class="mb-4" method="get" action="">
+            <form class="mb-4" method="get" action="{$page_url}">
                 <div class="row align-items-end">
                     <div class="col-md-4">
                         <label for="status-filter" class="form-label">
@@ -32,7 +32,7 @@
                         </select>
                     </div>
                     <div class="col-md-2">
-                        <button type="button" class="btn btn-secondary" onclick="location.href='?'">
+                        <button type="button" class="btn btn-secondary" onclick="location.href='{$page_url}'">
                             {'ms3_customer_orders_reset_filter' | lexicon}
                         </button>
                     </div>
@@ -65,7 +65,7 @@
                 <ul class="pagination justify-content-center">
                     {if $pagination.has_prev}
                     <li class="page-item">
-                        <a class="page-link" href="?offset={$pagination.prev_offset}">
+                        <a class="page-link" href="{$page_url}?offset={$pagination.prev_offset}">
                             {'ms3_customer_orders_prev' | lexicon}
                         </a>
                     </li>
@@ -73,7 +73,7 @@
 
                     {foreach $pagination.pages as $page}
                     <li class="page-item {if $page.active}active{/if}">
-                        <a class="page-link" href="?offset={$page.offset}">
+                        <a class="page-link" href="{$page_url}?offset={$page.offset}">
                             {$page.num}
                         </a>
                     </li>
@@ -81,7 +81,7 @@
 
                     {if $pagination.has_next}
                     <li class="page-item">
-                        <a class="page-link" href="?offset={$pagination.next_offset}">
+                        <a class="page-link" href="{$page_url}?offset={$pagination.next_offset}">
                             {'ms3_customer_orders_next' | lexicon}
                         </a>
                     </li>

--- a/core/components/minishop3/elements/templates/customer.tpl
+++ b/core/components/minishop3/elements/templates/customer.tpl
@@ -39,5 +39,22 @@
         <line x1="12" y1="8" x2="12" y2="12"></line>
         <line x1="12" y1="16" x2="12.01" y2="16"></line>
     </symbol>
+    <symbol id="icon-arrow-left" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="19" y1="12" x2="5" y2="12"></line>
+        <polyline points="12 19 5 12 12 5"></polyline>
+    </symbol>
+    <symbol id="icon-truck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="1" y="3" width="15" height="13"></rect>
+        <polygon points="16 8 20 8 23 11 23 16 16 16 16 8"></polygon>
+        <circle cx="5.5" cy="18.5" r="2.5"></circle>
+        <circle cx="18.5" cy="18.5" r="2.5"></circle>
+    </symbol>
+    <symbol id="icon-credit-card" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="1" y="4" width="22" height="16" rx="2" ry="2"></rect>
+        <line x1="1" y1="10" x2="23" y2="10"></line>
+    </symbol>
+    <symbol id="icon-message" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+    </symbol>
 </svg>
 {/block}

--- a/core/components/minishop3/src/Services/Customer/OrdersPageService.php
+++ b/core/components/minishop3/src/Services/Customer/OrdersPageService.php
@@ -147,6 +147,8 @@ class OrdersPageService extends CustomerPageService
 
         $pagination = $this->buildPagination($total, $limit, $offset);
 
+        $pageUrl = $this->modx->makeUrl($this->modx->resource->get('id'), '', '', 'full');
+
         $data = [
             'orders' => implode("\n", $ordersData),
             'orders_count' => count($ordersData),
@@ -156,6 +158,7 @@ class OrdersPageService extends CustomerPageService
             'customer' => $this->customer->toArray(),
             'api_url' => $this->getCustomerApiUrl(),
             'assets_url' => $this->ms3->config['assetsUrl'],
+            'page_url' => $pageUrl,
         ];
 
         $chunk = $this->pdoFetch->getChunk($tpl, $data);
@@ -357,6 +360,8 @@ class OrdersPageService extends CustomerPageService
 
         $pagination = $this->buildPagination($total, $limit, $offset);
 
+        $pageUrl = $this->modx->makeUrl($this->modx->resource->get('id'), '', '', 'full');
+
         return [
             'orders' => $ordersData,
             'orders_count' => count($ordersData),
@@ -364,6 +369,7 @@ class OrdersPageService extends CustomerPageService
             'statuses' => $statusesData,
             'pagination' => $pagination,
             'customer' => $this->customer->toArray(),
+            'page_url' => $pageUrl,
         ];
     }
 

--- a/core/components/minishop3/src/Services/Customer/OrdersPageService.php
+++ b/core/components/minishop3/src/Services/Customer/OrdersPageService.php
@@ -145,9 +145,11 @@ class OrdersPageService extends CustomerPageService
             $ordersData[] = is_string($chunk) ? $chunk : '';
         }
 
-        $pagination = $this->buildPagination($total, $limit, $offset);
+        $resourceId = $this->modx->resource->get('id');
+        $pageUrl = $this->modx->makeUrl($resourceId, '', '', 'full');
 
-        $pageUrl = $this->modx->makeUrl($this->modx->resource->get('id'), '', '', 'full');
+        $pagination = $this->buildPagination($total, $limit, $offset);
+        $this->enrichPaginationWithUrls($pagination, $resourceId, $statusFilter);
 
         $data = [
             'orders' => implode("\n", $ordersData),
@@ -358,9 +360,11 @@ class OrdersPageService extends CustomerPageService
             $ordersData[] = $orderData;
         }
 
-        $pagination = $this->buildPagination($total, $limit, $offset);
+        $resourceId = $this->modx->resource->get('id');
+        $pageUrl = $this->modx->makeUrl($resourceId, '', '', 'full');
 
-        $pageUrl = $this->modx->makeUrl($this->modx->resource->get('id'), '', '', 'full');
+        $pagination = $this->buildPagination($total, $limit, $offset);
+        $this->enrichPaginationWithUrls($pagination, $resourceId, $statusFilter);
 
         return [
             'orders' => $ordersData,
@@ -423,6 +427,44 @@ class OrdersPageService extends CustomerPageService
             'api_url' => $this->getCustomerApiUrl(),
             'assets_url' => $this->ms3->config['assetsUrl'],
         ];
+    }
+
+    /**
+     * Add absolute URLs to pagination entries
+     *
+     * Builds URLs via makeUrl() so that:
+     * - active status filter is preserved across pages
+     * - URLs are valid regardless of friendly_urls setting
+     *
+     * @param array $pagination Pagination data from buildPagination()
+     * @param int $resourceId Current resource ID
+     * @param int|null $statusFilter Active status filter ID
+     */
+    private function enrichPaginationWithUrls(array &$pagination, int $resourceId, ?int $statusFilter): void
+    {
+        $filterParams = $statusFilter ? ['status' => $statusFilter] : [];
+
+        foreach ($pagination['pages'] as &$page) {
+            $params = $page['offset'] > 0 ? array_merge($filterParams, ['offset' => $page['offset']]) : $filterParams;
+            $page['url'] = $this->modx->makeUrl($resourceId, '', http_build_query($params), 'full');
+        }
+        unset($page);
+
+        if ($pagination['has_prev']) {
+            $params = $pagination['prev_offset'] > 0
+                ? array_merge($filterParams, ['offset' => $pagination['prev_offset']])
+                : $filterParams;
+            $pagination['prev_url'] = $this->modx->makeUrl($resourceId, '', http_build_query($params), 'full');
+        }
+
+        if ($pagination['has_next']) {
+            $pagination['next_url'] = $this->modx->makeUrl(
+                $resourceId,
+                '',
+                http_build_query(array_merge($filterParams, ['offset' => $pagination['next_offset']])),
+                'full'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Кнопка «Сбросить» фильтра по статусу на странице заказов клиента редиректила на корень сайта (`/?`) вместо текущей страницы — из-за `<base href>` тега в шаблоне MODX
- Та же проблема у ссылок пагинации — относительные `?offset=...` резолвились от корня
- Добавлен плейсхолдер `page_url` (абсолютный URL через `makeUrl`) в `OrdersPageService`, используется в чанке для form action, кнопки сброса и пагинации

## Test plan
- [ ] Открыть страницу заказов клиента
- [ ] Выбрать статус в фильтре — URL должен быть `/zakazyi-klienta.html?status=2`
- [ ] Нажать «Сбросить» — должен вернуться на `/zakazyi-klienta.html` (не на `/`)
- [ ] Проверить пагинацию — ссылки должны вести на `/zakazyi-klienta.html?offset=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)