### PR TITLE
feat: add _formatted placeholders for currency and weight display

### DIFF
--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -480,6 +480,11 @@ return [
         'xtype' => 'textfield',
         'area' => 'ms3_product',
     ],
+    'ms3_weight_unit' => [
+        'value' => 'kg',
+        'xtype' => 'textfield',
+        'area' => 'ms3_product',
+    ],
 
     // API Settings
     'ms3_api_debug' => [

--- a/core/components/minishop3/elements/chunks/ms3_cart.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_cart.tpl
@@ -90,16 +90,16 @@
                         </form>
                     </td>
                     <td class="ms-weight">
-                        <span class="text-nowrap">{$product.weight} {'ms3_frontend_weight_unit' | lexicon}</span>
+                        <span class="text-nowrap">{$product.weight_formatted}</span>
                     </td>
                     <td class="ms-price">
-                        <span class="mr-2 text-nowrap">{$product.price} {'ms3_frontend_currency' | lexicon}</span>
+                        <span class="mr-2 text-nowrap">{$product.price_formatted}</span>
                         {if $product.old_price?}
-                            <span class="old_price text-nowrap">{$product.old_price} {'ms3_frontend_currency' | lexicon}</span>
+                            <span class="old_price text-nowrap">{$product.old_price_formatted}</span>
                         {/if}
                     </td>
                     <td class="ms-cost">
-                        <span class="mr-2 text-nowrap"><span class="ms3_cost">{$product.cost}</span> {'ms3_frontend_currency' | lexicon}</span>
+                        <span class="mr-2 text-nowrap ms3_cost">{$product.cost_formatted}</span>
                     </td>
                     <td class="ms-remove">
                         <form method="post" class="ms3_form text-md-right" data-ms3-form>
@@ -118,12 +118,10 @@
                     {'ms3_frontend_count_unit' | lexicon}
                 </th>
                 <th class="total_weight text-nowrap" colspan="2">
-                    <span class="ms3_total_weight">{$total.weight}</span>
-                    {'ms3_frontend_weight_unit' | lexicon}
+                    <span class="ms3_total_weight">{$total.weight_formatted}</span>
                 </th>
                 <th class="total_cost text-nowrap" colspan="2">
-                    <span class="ms3_total_cost">{$total.cost}</span>
-                    {'ms3_frontend_currency' | lexicon}
+                    <span class="ms3_total_cost">{$total.cost_formatted}</span>
                 </th>
             </tr>
         </table>

--- a/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
@@ -67,11 +67,10 @@
                                 {if $product.old_price && $product.old_price > $product.price}
                                 <div class="text-decoration-line-through text-muted small">{$product.old_price}</div>
                                 {/if}
-                                <div class="fw-semibold">{$product.price}</div>
-                                <small class="text-muted">{'ms3_frontend_currency' | lexicon}</small>
+                                <div class="fw-semibold">{$product.price_formatted}</div>
                             </td>
                             <td class="text-end text-nowrap fw-bold">
-                                {$product.cost} {'ms3_frontend_currency' | lexicon}
+                                {$product.cost_formatted}
                             </td>
                         </tr>
                         {/foreach}
@@ -79,7 +78,7 @@
                     <tfoot class="table-light">
                         <tr>
                             <td colspan="3" class="text-end fw-bold">{'ms3_frontend_cart_total' | lexicon}:</td>
-                            <td class="text-end fw-bold">{$total.cart_cost} {'ms3_frontend_currency' | lexicon}</td>
+                            <td class="text-end fw-bold">{$total.cart_cost_formatted}</td>
                         </tr>
                         {if $total.delivery_cost}
                         <tr>
@@ -89,12 +88,12 @@
                                 </svg>
                                 {'ms3_frontend_delivery' | lexicon}:
                             </td>
-                            <td class="text-end">{$total.delivery_cost} {'ms3_frontend_currency' | lexicon}</td>
+                            <td class="text-end">{$total.delivery_cost_formatted}</td>
                         </tr>
                         {/if}
                         <tr class="fw-bold">
                             <td colspan="3" class="text-end fs-5">{'ms3_frontend_total' | lexicon}:</td>
-                            <td class="text-end fs-5">{$total.cost} {'ms3_frontend_currency' | lexicon}</td>
+                            <td class="text-end fs-5">{$total.cost_formatted}</td>
                         </tr>
                     </tfoot>
                 </table>

--- a/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_order_details.tpl
@@ -64,8 +64,8 @@
                                 <span class="badge bg-secondary">{$product.count} {'ms3_frontend_count_unit' | lexicon}</span>
                             </td>
                             <td class="text-end text-nowrap">
-                                {if $product.old_price && $product.old_price > $product.price}
-                                <div class="text-decoration-line-through text-muted small">{$product.old_price}</div>
+                                {if $product.old_price_formatted?}
+                                <div class="text-decoration-line-through text-muted small">{$product.old_price_formatted}</div>
                                 {/if}
                                 <div class="fw-semibold">{$product.price_formatted}</div>
                             </td>

--- a/core/components/minishop3/elements/chunks/ms3_customer_order_row.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_order_row.tpl
@@ -13,7 +13,7 @@
         </span>
     </td>
     <td class="text-end text-nowrap fw-bold">
-        {$cost_with_currency}
+        {$cost_formatted}
     </td>
     <td class="text-end">
         <div class="d-flex gap-2 justify-content-end" role="group">

--- a/core/components/minishop3/elements/chunks/ms3_customer_order_row.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_order_row.tpl
@@ -13,7 +13,7 @@
         </span>
     </td>
     <td class="text-end text-nowrap fw-bold">
-        {$cost_formatted} {'ms3_frontend_currency' | lexicon}
+        {$cost_with_currency}
     </td>
     <td class="text-end">
         <div class="d-flex gap-2 justify-content-end" role="group">

--- a/core/components/minishop3/elements/chunks/ms3_email.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_email.tpl
@@ -85,8 +85,8 @@
                                                     {/if}
                                                 </td>
                                                 <td style="{$style.th}">{$product.count} {'ms3_frontend_count_unit' | lexicon}</td>
-                                                <td style="{$style.th}">{$product.weight} {'ms3_frontend_weight_unit' | lexicon}</td>
-                                                <td style="{$style.th}">{$product.price} {'ms3_frontend_currency' | lexicon}</td>
+                                                <td style="{$style.th}">{$product.weight_formatted}</td>
+                                                <td style="{$style.th}">{$product.price_formatted}</td>
                                             </tr>
                                         {/foreach}
                                         <tfoot>
@@ -96,10 +96,10 @@
                                                 {$total.cart_count} {'ms3_frontend_count_unit' | lexicon}
                                             </th>
                                             <th style="{$style.th}">
-                                                {$total.cart_weight} {'ms3_frontend_weight_unit' | lexicon}
+                                                {$total.cart_weight_formatted}
                                             </th>
                                             <th style="{$style.th}">
-                                                {$total.cart_cost} {'ms3_frontend_currency' | lexicon}
+                                                {$total.cart_cost_formatted}
                                             </th>
                                         </tr>
                                         </tfoot>
@@ -107,10 +107,9 @@
                                     <h3 style="{$style.h}{$style.h3}">
                                         {'ms3_frontend_order_cost' | lexicon}:
                                         {if $total.delivery_cost}
-                                            {$total.cart_cost} {'ms3_frontend_currency' | lexicon} + {$total.delivery_cost}
-                                            {'ms3_frontend_currency' | lexicon} =
+                                            {$total.cart_cost_formatted} + {$total.delivery_cost_formatted} =
                                         {/if}
-                                        <strong>{$total.cost}</strong> {'ms3_frontend_currency' | lexicon}
+                                        <strong>{$total.cost_formatted}</strong>
                                     </h3>
                                 {/block}
                             </td>

--- a/core/components/minishop3/elements/chunks/ms3_get_order.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_get_order.tpl
@@ -69,8 +69,8 @@
                                 <span class="badge bg-secondary">{$product.count} {'ms3_frontend_count_unit' | lexicon}</span>
                             </td>
                             <td class="text-end text-nowrap">
-                                {if $product.old_price > $product.price}
-                                    <div class="text-decoration-line-through text-muted small">{$product.old_price}</div>
+                                {if $product.old_price_formatted?}
+                                    <div class="text-decoration-line-through text-muted small">{$product.old_price_formatted}</div>
                                 {/if}
                                 <div class="fw-semibold">{$product.price_formatted}</div>
                             </td>

--- a/core/components/minishop3/elements/chunks/ms3_get_order.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_get_order.tpl
@@ -72,11 +72,10 @@
                                 {if $product.old_price > $product.price}
                                     <div class="text-decoration-line-through text-muted small">{$product.old_price}</div>
                                 {/if}
-                                <div class="fw-semibold">{$product.price}</div>
-                                <small class="text-muted">{'ms3_frontend_currency' | lexicon}</small>
+                                <div class="fw-semibold">{$product.price_formatted}</div>
                             </td>
                             <td class="text-end text-nowrap fw-bold">
-                                {$product.cost} {'ms3_frontend_currency' | lexicon}
+                                {$product.cost_formatted}
                             </td>
                         </tr>
                     {/foreach}
@@ -84,7 +83,7 @@
                 <tfoot class="table-light">
                     <tr>
                         <td colspan="3" class="text-end fw-bold">Товары:</td>
-                        <td class="text-end fw-bold">{$total.cart_cost} {'ms3_frontend_currency' | lexicon}</td>
+                        <td class="text-end fw-bold">{$total.cart_cost_formatted}</td>
                     </tr>
                     {if $total.delivery_cost}
                         <tr>
@@ -94,12 +93,12 @@
                                 </svg>
                                 Доставка:
                             </td>
-                            <td class="text-end">{$total.delivery_cost} {'ms3_frontend_currency' | lexicon}</td>
+                            <td class="text-end">{$total.delivery_cost_formatted}</td>
                         </tr>
                     {/if}
                     <tr class="table-primary">
                         <td colspan="3" class="text-end fw-bold fs-5">Итого:</td>
-                        <td class="text-end fw-bold fs-5 text-primary">{$total.cost} {'ms3_frontend_currency' | lexicon}</td>
+                        <td class="text-end fw-bold fs-5 text-primary">{$total.cost_formatted}</td>
                     </tr>
                 </tfoot>
             </table>

--- a/core/components/minishop3/elements/chunks/ms3_minicart.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_minicart.tpl
@@ -24,9 +24,9 @@
                             <div class="d-flex">
                                 <div class="col-12 col-md-6 d-flex flex-column justify-content-around justify-content-md-start">
                                     <a href="/{$product.product_id | url}" class="font-weight-bold">{$product.pagetitle}</a>
-                                    <span class="price ml-md-3">{$product.price} x {$product.count} = {$product.cost} {'ms3_frontend_currency' | lexicon}</span>
+                                    <span class="price ml-md-3">{$product.price_formatted} x {$product.count} = {$product.cost_formatted}</span>
                                     {if $old_price > 0?}
-                                        <span class="old_price ml-md-3 text-decoration-line-through">{$old_price} x {$product.count} = {$product.old_cost} {'ms3_frontend_currency' | lexicon}</span>
+                                        <span class="old_price ml-md-3 text-decoration-line-through">{$old_price} x {$product.count} = {$product.old_cost}</span>
                                     {/if}
                                 </div>
                                 <div class="col-12 col-md-6">

--- a/core/components/minishop3/elements/chunks/ms3_minicart.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_minicart.tpl
@@ -25,8 +25,8 @@
                                 <div class="col-12 col-md-6 d-flex flex-column justify-content-around justify-content-md-start">
                                     <a href="/{$product.product_id | url}" class="font-weight-bold">{$product.pagetitle}</a>
                                     <span class="price ml-md-3">{$product.price_formatted} x {$product.count} = {$product.cost_formatted}</span>
-                                    {if $old_price > 0?}
-                                        <span class="old_price ml-md-3 text-decoration-line-through">{$old_price} x {$product.count} = {$product.old_cost}</span>
+                                    {if $product.old_price_formatted?}
+                                        <span class="old_price ml-md-3 text-decoration-line-through">{$product.old_price_formatted} x {$product.count} = {$product.old_cost_formatted}</span>
                                     {/if}
                                 </div>
                                 <div class="col-12 col-md-6">

--- a/core/components/minishop3/elements/chunks/ms3_order.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_order.tpl
@@ -260,20 +260,20 @@
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Товары:</span>
                     <span class="fw-semibold">
-                        <span id="ms3_order_cart_cost">{$order.cart_cost ?: 0}</span> {'ms3_frontend_currency' | lexicon}
+                        <span id="ms3_order_cart_cost">{$order.cart_cost ?: 0}</span> {$order.currency_symbol}
                     </span>
                 </div>
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Доставка:</span>
                     <span class="fw-semibold">
-                        <span id="ms3_order_delivery_cost">{$order.delivery_cost ?: 0}</span> {'ms3_frontend_currency' | lexicon}
+                        <span id="ms3_order_delivery_cost">{$order.delivery_cost ?: 0}</span> {$order.currency_symbol}
                     </span>
                 </div>
                 <hr class="my-2">
                 <div class="d-flex justify-content-between">
                     <span class="h5 mb-0">{'ms3_frontend_order_cost' | lexicon}:</span>
                     <span class="h4 mb-0 text-primary">
-                        <span id="ms3_order_cost">{$order.cost ?: 0}</span> {'ms3_frontend_currency' | lexicon}
+                        <span id="ms3_order_cost">{$order.cost ?: 0}</span> {$order.currency_symbol}
                     </span>
                 </div>
             </div>

--- a/core/components/minishop3/elements/chunks/ms3_order_total.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_order_total.tpl
@@ -1,6 +1,6 @@
 <span class="ms3-order-total">
     <span class="ms3-order-total__count">{$total_count}</span>
     {if $total_count > 0}
-        <span class="ms3-order-total__cost">{$total_cost} {'ms3_frontend_currency' | lexicon}</span>
+        <span class="ms3-order-total__cost">{$total_cost_formatted}</span>
     {/if}
 </span>

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -163,9 +163,13 @@ foreach ($cart as $key => $entry) {
     $product['discount_cost'] = $entry['count'] * $discount_price;
 
     // Pre-formatted fields with currency/unit for display in chunks
+    $product['old_cost'] = $old_price > 0 ? $entry['count'] * $old_price : 0;
     $product['price_formatted'] = $ms3->format->price($entry['price'], true);
     $product['old_price_formatted'] = $old_price > 0 ? $ms3->format->price($old_price, true) : '';
     $product['cost_formatted'] = $ms3->format->price($entry['count'] * $entry['price'], true);
+    $product['old_cost_formatted'] = $old_price > 0 ? $ms3->format->price($entry['count'] * $old_price, true) : '';
+    $product['discount_price_formatted'] = $discount_price > 0 ? $ms3->format->price($discount_price, true) : '';
+    $product['discount_cost_formatted'] = $discount_price > 0 ? $ms3->format->price($entry['count'] * $discount_price, true) : '';
     $product['weight_formatted'] = $ms3->format->weightWithUnit($entry['weight']);
 
     // Additional properties of product in cart

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -162,6 +162,12 @@ foreach ($cart as $key => $entry) {
     $product['discount_price'] = $ms3->format->price($discount_price);
     $product['discount_cost'] = $entry['count'] * $discount_price;
 
+    // Pre-formatted fields with currency/unit for display in chunks
+    $product['price_formatted'] = $ms3->format->price($entry['price'], true);
+    $product['old_price_formatted'] = $old_price > 0 ? $ms3->format->price($old_price, true) : '';
+    $product['cost_formatted'] = $ms3->format->price($entry['count'] * $entry['price'], true);
+    $product['weight_formatted'] = $ms3->format->weightWithUnit($entry['weight']);
+
     // Additional properties of product in cart
     if (!empty($entry['options']) && is_array($entry['options'])) {
         $product['options'] = $entry['options'];
@@ -186,6 +192,10 @@ $outputData = [
     'total' => $total,
     'products' => $products,
 ];
+
+// Pre-formatted totals with currency/unit for display in chunks
+$outputData['total']['cost_formatted'] = $ms3->format->price($total['cost'], true);
+$outputData['total']['weight_formatted'] = $ms3->format->weightWithUnit($total['weight']);
 
 if ($return === 'data') {
     return $outputData;

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -188,12 +188,21 @@ foreach ($rows as $product) {
 
     $discount_price = $old_price > 0 ? $old_price - $product['price'] : 0;
 
+    $rawPrice = (float)$product['price'];
+    $rawCost = (float)$product['cost'];
+    $rawWeight = (float)$product['weight'];
+
     $product['old_price'] = $ms3->format->price($old_price);
-    $product['price'] = $ms3->format->price($product['price']);
-    $product['cost'] = $ms3->format->price($product['cost']);
-    $product['weight'] = $ms3->format->weight($product['weight']);
+    $product['price'] = $ms3->format->price($rawPrice);
+    $product['cost'] = $ms3->format->price($rawCost);
+    $product['weight'] = $ms3->format->weight($rawWeight);
     $product['discount_price'] = $ms3->format->price($discount_price);
     $product['discount_cost'] = $ms3->format->price($product['count'] * $discount_price);
+
+    // Pre-formatted fields with currency/unit for display in chunks
+    $product['price_formatted'] = $ms3->format->price($rawPrice, true);
+    $product['cost_formatted'] = $ms3->format->price($rawCost, true);
+    $product['weight_formatted'] = $ms3->format->weightWithUnit($rawWeight);
 
     $product['id'] = (int)$product['id'];
     if (empty($product['name'])) {
@@ -238,10 +247,15 @@ try {
             : [],
         'total' => [
             'cost' => $ms3->format->price($msOrder->get('cost')),
+            'cost_formatted' => $ms3->format->price($msOrder->get('cost'), true),
             'cart_cost' => $ms3->format->price($msOrder->get('cart_cost')),
+            'cart_cost_formatted' => $ms3->format->price($msOrder->get('cart_cost'), true),
             'delivery_cost' => $ms3->format->price($msOrder->get('delivery_cost')),
+            'delivery_cost_formatted' => $ms3->format->price($msOrder->get('delivery_cost'), true),
             'weight' => $ms3->format->weight($msOrder->get('weight')),
+            'weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
             'cart_weight' => $ms3->format->weight($msOrder->get('weight')),
+            'cart_weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
             'cart_count' => $cart_count,
             'cart_discount' => $cart_discount_cost
         ],

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -201,7 +201,19 @@ foreach ($rows as $product) {
 
     // Pre-formatted fields with currency/unit for display in chunks
     $product['price_formatted'] = $ms3->format->price($rawPrice, true);
+    $product['old_price_formatted'] = $old_price > 0 && $old_price > $rawPrice
+        ? $ms3->format->price($old_price, true)
+        : '';
     $product['cost_formatted'] = $ms3->format->price($rawCost, true);
+    $product['old_cost_formatted'] = $old_price > 0 && $old_price > $rawPrice
+        ? $ms3->format->price($product['count'] * $old_price, true)
+        : '';
+    $product['discount_price_formatted'] = $discount_price > 0
+        ? $ms3->format->price($discount_price, true)
+        : '';
+    $product['discount_cost_formatted'] = $discount_price > 0
+        ? $ms3->format->price($product['count'] * $discount_price, true)
+        : '';
     $product['weight_formatted'] = $ms3->format->weightWithUnit($rawWeight);
 
     $product['id'] = (int)$product['id'];

--- a/core/components/minishop3/elements/snippets/ms3_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_order.php
@@ -59,6 +59,12 @@ if ($response['success']) {
     $order['cart_cost'] = $ms3->format->price($cost['cart_cost']);
     $order['delivery_cost'] = $ms3->format->price($cost['delivery_cost']);
     $order['discount_cost'] = $ms3->format->price($cost['total_discount']);
+    // Pre-formatted fields with currency symbol for display in chunks
+    $order['cost_formatted'] = $ms3->format->price($cost['cost'], true);
+    $order['cart_cost_formatted'] = $ms3->format->price($cost['cart_cost'], true);
+    $order['delivery_cost_formatted'] = $ms3->format->price($cost['delivery_cost'], true);
+    $order['discount_cost_formatted'] = $ms3->format->price($cost['total_discount'], true);
+    $order['currency_symbol'] = $ms3->format->getCurrencySymbol();
 }
 
 // Check if cart is empty

--- a/core/components/minishop3/elements/snippets/ms3_order_total.php
+++ b/core/components/minishop3/elements/snippets/ms3_order_total.php
@@ -58,13 +58,14 @@ if (!empty($scriptProperties['formatPrices'])) {
 }
 
 // Pre-formatted fields with currency/unit — always available for chunks
-$total['cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['cost'] ?? 0 : 0, true);
-$total['cart_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['cart_cost'] ?? 0 : 0, true);
-$total['delivery_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['delivery_cost'] ?? 0 : 0, true);
-$total['payment_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['payment_cost'] ?? 0 : 0, true);
-$total['total_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['total_cost'] ?? 0 : 0, true);
-$total['total_discount_formatted'] = $ms3->format->price($response['success'] ? $response['data']['total_discount'] ?? 0 : 0, true);
-$total['total_weight_formatted'] = $ms3->format->weightWithUnit($response['success'] ? $response['data']['total_weight'] ?? 0 : 0);
+$data = $response['success'] ? ($response['data'] ?? []) : [];
+$total['cost_formatted'] = $ms3->format->price($data['cost'] ?? 0, true);
+$total['cart_cost_formatted'] = $ms3->format->price($data['cart_cost'] ?? 0, true);
+$total['delivery_cost_formatted'] = $ms3->format->price($data['delivery_cost'] ?? 0, true);
+$total['payment_cost_formatted'] = $ms3->format->price($data['payment_cost'] ?? 0, true);
+$total['total_cost_formatted'] = $ms3->format->price($data['total_cost'] ?? 0, true);
+$total['total_discount_formatted'] = $ms3->format->price($data['total_discount'] ?? 0, true);
+$total['total_weight_formatted'] = $ms3->format->weightWithUnit($data['total_weight'] ?? 0);
 
 if ($return === 'data') {
     return $total;

--- a/core/components/minishop3/elements/snippets/ms3_order_total.php
+++ b/core/components/minishop3/elements/snippets/ms3_order_total.php
@@ -57,6 +57,15 @@ if (!empty($scriptProperties['formatPrices'])) {
     $total['total_weight'] = $ms3->format->weight($total['total_weight']);
 }
 
+// Pre-formatted fields with currency/unit — always available for chunks
+$total['cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['cost'] ?? 0 : 0, true);
+$total['cart_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['cart_cost'] ?? 0 : 0, true);
+$total['delivery_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['delivery_cost'] ?? 0 : 0, true);
+$total['payment_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['payment_cost'] ?? 0 : 0, true);
+$total['total_cost_formatted'] = $ms3->format->price($response['success'] ? $response['data']['total_cost'] ?? 0 : 0, true);
+$total['total_discount_formatted'] = $ms3->format->price($response['success'] ? $response['data']['total_discount'] ?? 0 : 0, true);
+$total['total_weight_formatted'] = $ms3->format->weightWithUnit($response['success'] ? $response['data']['total_weight'] ?? 0 : 0);
+
 if ($return === 'data') {
     return $total;
 }

--- a/core/components/minishop3/lexicon/en/setting.inc.php
+++ b/core/components/minishop3/lexicon/en/setting.inc.php
@@ -182,6 +182,8 @@ $_lang['setting_ms3_currency_symbol'] = 'Currency symbol';
 $_lang['setting_ms3_currency_symbol_desc'] = 'Currency symbol for price display. Default is "₽" (ruble). Examples: $, €, £, ₽, ₴, ¥, ₸.';
 $_lang['setting_ms3_currency_position'] = 'Currency symbol position';
 $_lang['setting_ms3_currency_position_desc'] = 'Where to display currency symbol relative to price. Valid values: "before" (before price: $ 100) or "after" (after price: 100 ₽). Default is "after".';
+$_lang['setting_ms3_weight_unit'] = 'Weight unit';
+$_lang['setting_ms3_weight_unit_desc'] = 'Weight unit label displayed next to the value. Examples: kg, g, lbs, oz. Default is "kg".';
 
 // Customer Authentication & Registration
 $_lang['setting_ms3_customer_login_page_id'] = 'Login page ID';

--- a/core/components/minishop3/lexicon/ru/setting.inc.php
+++ b/core/components/minishop3/lexicon/ru/setting.inc.php
@@ -182,6 +182,8 @@ $_lang['setting_ms3_currency_symbol'] = 'Символ валюты';
 $_lang['setting_ms3_currency_symbol_desc'] = 'Символ валюты для отображения цен. По умолчанию "₽" (рубль). Примеры: $, €, £, ₽, ₴, ¥, ₸.';
 $_lang['setting_ms3_currency_position'] = 'Позиция символа валюты';
 $_lang['setting_ms3_currency_position_desc'] = 'Где показывать символ валюты относительно цены. Допустимые значения: "before" (до цены: $ 100) или "after" (после цены: 100 ₽). По умолчанию "after".';
+$_lang['setting_ms3_weight_unit'] = 'Единица измерения веса';
+$_lang['setting_ms3_weight_unit_desc'] = 'Обозначение единицы измерения веса для отображения рядом со значением. Например: kg, г, кг, lbs. По умолчанию "kg".';
 
 // Customer Authentication & Registration
 $_lang['setting_ms3_customer_login_page_id'] = 'ID страницы входа';

--- a/core/components/minishop3/src/Notifications/Notification.php
+++ b/core/components/minishop3/src/Notifications/Notification.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Notifications;
 use MODX\Revolution\modX;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msProductData;
 use MiniShop3\Notifications\Messages\EmailMessage;
 use MiniShop3\Notifications\Messages\TelegramMessage;
 use MiniShop3\Notifications\Messages\SmsMessage;
@@ -204,10 +205,31 @@ abstract class Notification
     protected function getOrderProducts(): array
     {
         $products = [];
+        $productIds = [];
+
+        /** @var \MiniShop3\Model\msOrderProduct $orderProduct */
+        foreach ($this->order->getMany('Products') as $orderProduct) {
+            $productIds[] = (int) $orderProduct->get('product_id');
+        }
+        $productIds = array_unique($productIds);
+
+        // Batch load product data for old_price
+        $dataMap = [];
+        if (!empty($productIds)) {
+            $dataQuery = $this->modx->newQuery(msProductData::class);
+            $dataQuery->where(['id:IN' => $productIds]);
+            foreach ($this->modx->getIterator(msProductData::class, $dataQuery) as $data) {
+                $dataMap[$data->get('id')] = [
+                    'original_price' => (float) $data->get('price'),
+                    'old_price' => (float) $data->get('old_price'),
+                ];
+            }
+        }
 
         /** @var \MiniShop3\Model\msOrderProduct $orderProduct */
         foreach ($this->order->getMany('Products') as $orderProduct) {
             $productData = $orderProduct->toArray();
+            $pid = (int) $productData['product_id'];
 
             // Add product resource data if available
             if ($product = $orderProduct->getOne('Product')) {
@@ -220,11 +242,28 @@ abstract class Notification
             $rawCost = (float) ($productData['cost'] ?? 0);
             $rawWeight = (float) ($productData['weight'] ?? 0);
 
+            $originalPrice = $dataMap[$pid]['original_price'] ?? 0;
+            $catalogOldPrice = $dataMap[$pid]['old_price'] ?? 0;
+            $old_price = $originalPrice > $rawPrice ? $originalPrice : $catalogOldPrice;
+            $discount_price = $old_price > 0 ? $old_price - $rawPrice : 0;
+
             $productData['price'] = $this->ms3->format->price($rawPrice);
             $productData['cost'] = $this->ms3->format->price($rawCost);
             $productData['weight'] = $this->ms3->format->weight($rawWeight);
             $productData['price_formatted'] = $this->ms3->format->price($rawPrice, true);
+            $productData['old_price_formatted'] = $old_price > 0 && $old_price > $rawPrice
+                ? $this->ms3->format->price($old_price, true)
+                : '';
             $productData['cost_formatted'] = $this->ms3->format->price($rawCost, true);
+            $productData['old_cost_formatted'] = $old_price > 0 && $old_price > $rawPrice
+                ? $this->ms3->format->price(($productData['count'] ?? 0) * $old_price, true)
+                : '';
+            $productData['discount_price_formatted'] = $discount_price > 0
+                ? $this->ms3->format->price($discount_price, true)
+                : '';
+            $productData['discount_cost_formatted'] = $discount_price > 0
+                ? $this->ms3->format->price(($productData['count'] ?? 0) * $discount_price, true)
+                : '';
             $productData['weight_formatted'] = $this->ms3->format->weightWithUnit($rawWeight);
 
             // Parse options if stored as JSON

--- a/core/components/minishop3/src/Notifications/Notification.php
+++ b/core/components/minishop3/src/Notifications/Notification.php
@@ -126,12 +126,22 @@ abstract class Notification
         $formattedDeliveryCost = $this->ms3->format->price($orderData['delivery_cost'] ?? 0);
         $formattedWeight = $this->ms3->format->weight($orderData['weight'] ?? 0);
 
+        // Pre-formatted with currency/unit for use in email templates
+        $formattedCostWithCurrency = $this->ms3->format->price($orderData['cost'] ?? 0, true);
+        $formattedCartCostWithCurrency = $this->ms3->format->price($orderData['cart_cost'] ?? 0, true);
+        $formattedDeliveryCostWithCurrency = $this->ms3->format->price($orderData['delivery_cost'] ?? 0, true);
+        $formattedWeightWithUnit = $this->ms3->format->weightWithUnit($orderData['weight'] ?? 0);
+
         // Start with order data spread (for backwards compatibility)
         $pls = $orderData;
         $pls['cost'] = $formattedCost;
         $pls['cart_cost'] = $formattedCartCost;
         $pls['delivery_cost'] = $formattedDeliveryCost;
         $pls['weight'] = $formattedWeight;
+        $pls['cost_formatted'] = $formattedCostWithCurrency;
+        $pls['cart_cost_formatted'] = $formattedCartCostWithCurrency;
+        $pls['delivery_cost_formatted'] = $formattedDeliveryCostWithCurrency;
+        $pls['weight_formatted'] = $formattedWeightWithUnit;
 
         // Also add as nested 'order' array (for templates using {$order.num} syntax)
         $pls['order'] = $orderData;
@@ -139,6 +149,10 @@ abstract class Notification
         $pls['order']['cart_cost'] = $formattedCartCost;
         $pls['order']['delivery_cost'] = $formattedDeliveryCost;
         $pls['order']['weight'] = $formattedWeight;
+        $pls['order']['cost_formatted'] = $formattedCostWithCurrency;
+        $pls['order']['cart_cost_formatted'] = $formattedCartCostWithCurrency;
+        $pls['order']['delivery_cost_formatted'] = $formattedDeliveryCostWithCurrency;
+        $pls['order']['weight_formatted'] = $formattedWeightWithUnit;
 
         // Add customer data
         if ($customer = $this->order->getOne('Customer')) {
@@ -166,10 +180,14 @@ abstract class Notification
         // Add totals for email template
         $pls['total'] = [
             'cost' => $formattedCost,
+            'cost_formatted' => $formattedCostWithCurrency,
             'cart_cost' => $formattedCartCost,
+            'cart_cost_formatted' => $formattedCartCostWithCurrency,
             'cart_count' => $orderData['cart_count'] ?? 0,
             'cart_weight' => $formattedWeight,
+            'cart_weight_formatted' => $formattedWeightWithUnit,
             'delivery_cost' => $formattedDeliveryCost,
+            'delivery_cost_formatted' => $formattedDeliveryCostWithCurrency,
         ];
 
         // Merge custom data
@@ -198,8 +216,16 @@ abstract class Notification
             }
 
             // Format price
-            $productData['price'] = $this->ms3->format->price($productData['price'] ?? 0);
-            $productData['cost'] = $this->ms3->format->price($productData['cost'] ?? 0);
+            $rawPrice = (float) ($productData['price'] ?? 0);
+            $rawCost = (float) ($productData['cost'] ?? 0);
+            $rawWeight = (float) ($productData['weight'] ?? 0);
+
+            $productData['price'] = $this->ms3->format->price($rawPrice);
+            $productData['cost'] = $this->ms3->format->price($rawCost);
+            $productData['weight'] = $this->ms3->format->weight($rawWeight);
+            $productData['price_formatted'] = $this->ms3->format->price($rawPrice, true);
+            $productData['cost_formatted'] = $this->ms3->format->price($rawCost, true);
+            $productData['weight_formatted'] = $this->ms3->format->weightWithUnit($rawWeight);
 
             // Parse options if stored as JSON
             if (!empty($productData['options']) && is_string($productData['options'])) {

--- a/core/components/minishop3/src/Services/Customer/OrdersPageService.php
+++ b/core/components/minishop3/src/Services/Customer/OrdersPageService.php
@@ -134,6 +134,7 @@ class OrdersPageService extends CustomerPageService
 
             $orderData['createdon_formatted'] = date('d.m.Y H:i', strtotime($orderData['createdon']));
             $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost']);
+            $orderData['cost_with_currency'] = $this->ms3->format->price($orderData['cost'], true);
 
             $statusId = (int) $orderData['status_id'];
             $orderData['status_name'] = $statusMap[$statusId]['name'] ?? '';
@@ -214,9 +215,13 @@ class OrdersPageService extends CustomerPageService
             'address' => $address ? $address->toArray() : [],
             'total' => [
                 'cost' => $this->ms3->format->price($order->get('cost')),
+                'cost_formatted' => $this->ms3->format->price($order->get('cost'), true),
                 'cart_cost' => $this->ms3->format->price($order->get('cart_cost')),
+                'cart_cost_formatted' => $this->ms3->format->price($order->get('cart_cost'), true),
                 'delivery_cost' => $this->ms3->format->price($order->get('delivery_cost')),
+                'delivery_cost_formatted' => $this->ms3->format->price($order->get('delivery_cost'), true),
                 'weight' => $this->ms3->format->weight($order->get('weight')),
+                'weight_formatted' => $this->ms3->format->weightWithUnit($order->get('weight')),
             ],
             'customer' => $this->customer->toArray(),
             'api_url' => $this->getCustomerApiUrl(),
@@ -291,12 +296,21 @@ class OrdersPageService extends CustomerPageService
 
             $discount_price = $old_price > 0 ? $old_price - $productData['price'] : 0;
 
+            $rawPrice = (float) $productData['price'];
+            $rawCost = (float) $productData['cost'];
+            $rawWeight = (float) $productData['weight'];
+
             $productData['old_price'] = $this->ms3->format->price($old_price);
-            $productData['price'] = $this->ms3->format->price($productData['price']);
-            $productData['cost'] = $this->ms3->format->price($productData['cost']);
-            $productData['weight'] = $this->ms3->format->weight($productData['weight']);
+            $productData['price'] = $this->ms3->format->price($rawPrice);
+            $productData['cost'] = $this->ms3->format->price($rawCost);
+            $productData['weight'] = $this->ms3->format->weight($rawWeight);
             $productData['discount_price'] = $this->ms3->format->price($discount_price);
             $productData['discount_cost'] = $this->ms3->format->price($productData['count'] * $discount_price);
+
+            // Pre-formatted fields with currency/unit for display in chunks
+            $productData['price_formatted'] = $this->ms3->format->price($rawPrice, true);
+            $productData['cost_formatted'] = $this->ms3->format->price($rawCost, true);
+            $productData['weight_formatted'] = $this->ms3->format->weightWithUnit($rawWeight);
 
             if (!empty($productData['options']) && is_array($productData['options'])) {
                 foreach ($productData['options'] as $option => $value) {
@@ -350,6 +364,7 @@ class OrdersPageService extends CustomerPageService
 
             $orderData['createdon_formatted'] = date('d.m.Y H:i', strtotime($orderData['createdon']));
             $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost']);
+            $orderData['cost_with_currency'] = $this->ms3->format->price($orderData['cost'], true);
 
             $statusId = (int) $orderData['status_id'];
             $orderData['status_name'] = $statusMap[$statusId]['name'] ?? '';
@@ -419,9 +434,13 @@ class OrdersPageService extends CustomerPageService
             'address' => $address ? $address->toArray() : [],
             'total' => [
                 'cost' => $this->ms3->format->price($order->get('cost')),
+                'cost_formatted' => $this->ms3->format->price($order->get('cost'), true),
                 'cart_cost' => $this->ms3->format->price($order->get('cart_cost')),
+                'cart_cost_formatted' => $this->ms3->format->price($order->get('cart_cost'), true),
                 'delivery_cost' => $this->ms3->format->price($order->get('delivery_cost')),
+                'delivery_cost_formatted' => $this->ms3->format->price($order->get('delivery_cost'), true),
                 'weight' => $this->ms3->format->weight($order->get('weight')),
+                'weight_formatted' => $this->ms3->format->weightWithUnit($order->get('weight')),
             ],
             'customer' => $this->customer->toArray(),
             'api_url' => $this->getCustomerApiUrl(),

--- a/core/components/minishop3/src/Services/Customer/OrdersPageService.php
+++ b/core/components/minishop3/src/Services/Customer/OrdersPageService.php
@@ -133,8 +133,7 @@ class OrdersPageService extends CustomerPageService
             $orderData = $order->toArray();
 
             $orderData['createdon_formatted'] = date('d.m.Y H:i', strtotime($orderData['createdon']));
-            $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost']);
-            $orderData['cost_with_currency'] = $this->ms3->format->price($orderData['cost'], true);
+            $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost'], true);
 
             $statusId = (int) $orderData['status_id'];
             $orderData['status_name'] = $statusMap[$statusId]['name'] ?? '';
@@ -309,7 +308,19 @@ class OrdersPageService extends CustomerPageService
 
             // Pre-formatted fields with currency/unit for display in chunks
             $productData['price_formatted'] = $this->ms3->format->price($rawPrice, true);
+            $productData['old_price_formatted'] = $old_price > 0 && $old_price > $rawPrice
+                ? $this->ms3->format->price($old_price, true)
+                : '';
             $productData['cost_formatted'] = $this->ms3->format->price($rawCost, true);
+            $productData['old_cost_formatted'] = $old_price > 0 && $old_price > $rawPrice
+                ? $this->ms3->format->price($productData['count'] * $old_price, true)
+                : '';
+            $productData['discount_price_formatted'] = $discount_price > 0
+                ? $this->ms3->format->price($discount_price, true)
+                : '';
+            $productData['discount_cost_formatted'] = $discount_price > 0
+                ? $this->ms3->format->price($productData['count'] * $discount_price, true)
+                : '';
             $productData['weight_formatted'] = $this->ms3->format->weightWithUnit($rawWeight);
 
             if (!empty($productData['options']) && is_array($productData['options'])) {
@@ -363,8 +374,7 @@ class OrdersPageService extends CustomerPageService
             $orderData = $order->toArray();
 
             $orderData['createdon_formatted'] = date('d.m.Y H:i', strtotime($orderData['createdon']));
-            $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost']);
-            $orderData['cost_with_currency'] = $this->ms3->format->price($orderData['cost'], true);
+            $orderData['cost_formatted'] = $this->ms3->format->price($orderData['cost'], true);
 
             $statusId = (int) $orderData['status_id'];
             $orderData['status_name'] = $statusMap[$statusId]['name'] ?? '';

--- a/core/components/minishop3/src/Utils/Format.php
+++ b/core/components/minishop3/src/Utils/Format.php
@@ -165,6 +165,7 @@ class Format
     }
 
     /**
+     * Calculate discount percentage
      *
      * @param float|int $oldPrice Old price
      * @param float|int $newPrice New price

--- a/core/components/minishop3/src/Utils/Format.php
+++ b/core/components/minishop3/src/Utils/Format.php
@@ -42,6 +42,9 @@ class Format
     /** @var string Currency symbol position (before/after) */
     private $currencyPosition;
 
+    /** @var string Weight unit label */
+    private $weightUnit;
+
     /**
      * @param MiniShop3 $ms3
      */
@@ -73,6 +76,7 @@ class Format
 
         $this->currencySymbol = $this->modx->getOption('ms3_currency_symbol', null, '₽');
         $this->currencyPosition = $this->modx->getOption('ms3_currency_position', null, 'after');
+        $this->weightUnit = $this->modx->getOption('ms3_weight_unit', null, 'kg');
     }
 
     /**
@@ -134,7 +138,33 @@ class Format
     }
 
     /**
-     * Calculate discount percentage
+     * Format weight with unit suffix
+     *
+     * @param float|int $weight Weight
+     * @return string Formatted weight with unit (e.g. "1.5 kg")
+     */
+    public function weightWithUnit($weight = 0): string
+    {
+        $formatted = $this->formatNumber($weight, $this->weightFormat, $this->weightNoZeros);
+
+        if (!empty($this->weightUnit)) {
+            $formatted .= ' ' . $this->weightUnit;
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Get weight unit label
+     *
+     * @return string
+     */
+    public function getWeightUnit(): string
+    {
+        return $this->weightUnit;
+    }
+
+    /**
      *
      * @param float|int $oldPrice Old price
      * @param float|int $newPrice New price
@@ -224,6 +254,7 @@ class Format
                 'symbol' => $this->currencySymbol,
                 'position' => $this->currencyPosition,
             ],
+            'weight_unit' => $this->weightUnit,
         ];
     }
 }


### PR DESCRIPTION
## Описание

Системные настройки становятся единственным источником истины для символа
валюты и единиц веса. Сниппеты теперь предварительно форматируют значения
через `Format::price($value, true)` и `Format::weightWithUnit()` и передают
результат в чанки через новые `*_formatted` плейсхолдеры. Чанки используют
готовые строки без лексиконных вызовов для валюты и веса.

Ранее символ валюты и единица веса отображались в чанках через лексиконы
(`{'ms3_frontend_currency'|lexicon}`, `{'ms3_frontend_weight_unit'|lexicon}`),
хотя системные настройки (`ms3_currency_symbol`, `ms3_currency_position`) уже
управляли форматированием в PHP. Изменение символа валюты в системной
настройке не затрагивало вывод в чанках.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #144

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3:
- MODX:
- PHP:

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

**Обратная совместимость:**
- Сырые числовые поля (`price`, `cost`, `weight`) не удалены — JS-логика не затронута
- Лексиконные ключи `ms3_frontend_currency` и `ms3_frontend_weight_unit` сохранены,
  но не используются core-чанками
- Пользовательские чанки продолжат работать; рекомендуется обновить их по образцу
  обновлённых чанков, заменив лексиконные вызовы на `*_formatted` плейсхолдеры

**Особые места кода:**
- `ms3_order.tpl` — JS динамически обновляет span'ы `#ms3_order_cost` и др., поэтому
  лексикон заменён на `{$order.currency_symbol}` (передаётся из сниппета), а не на
  `_formatted` плейсхолдер
- `ms3_get_order.php` — сохраняются raw-числа до форматирования, чтобы `_formatted`
  поля получали корректный числовой вход