### PR TITLE
fix(product): improve options parsing and empty options handling

### DIFF
--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -96,18 +96,15 @@ class Create extends CreateProcessor
             $this->modx->context->aliasMap = $results['aliasMap'];
         }
 
-        // Save product options if provided (from options-* fields in form)
-        // Note: Don't remove other options (removeOther = false) because
-        // JSON fields like color/size are saved separately via msProductData::save()
+        // Save product options from options-* form fields (always set in beforeSet)
         $options = $this->getProperty('options');
-        if (!empty($options) && is_array($options)) {
+        if (is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                // Don't remove other options - they come from JSON fields
-                // Empty values are passed through to signal deletion
-                $service->saveOptions($productData, $options, false);
+                $removeOther = empty($options);
+                $service->saveOptions($productData, $options, $removeOther);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -51,8 +51,9 @@ class Create extends CreateProcessor
         $properties = $this->getProperties();
         $options = [];
         foreach ($properties as $key => $value) {
-            if (strpos($key, 'options-') === 0) {
-                $options[substr($key, 8)] = $value;
+            $optionKey = Utils::extractOptionKey($key);
+            if ($optionKey !== null) {
+                $options[$optionKey] = $value;
                 $this->unsetProperty($key);
             }
         }

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -96,15 +96,15 @@ class Create extends CreateProcessor
             $this->modx->context->aliasMap = $results['aliasMap'];
         }
 
-        // Save product options from options-* form fields (always set in beforeSet)
+        // Save product options from options-* form fields (parsed in beforeSet)
+        // Only runs when form actually contained options-* fields
         $options = $this->getProperty('options');
-        if (is_array($options)) {
+        if (!empty($options) && is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                $removeOther = empty($options);
-                $service->saveOptions($productData, $options, $removeOther);
+                $service->saveOptions($productData, $options, false);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -48,7 +48,9 @@ class Update extends UpdateProcessor
                 $this->unsetProperty($key);
             }
         }
-        $this->setProperty('options', $options);
+        if (!empty($options)) {
+            $this->setProperty('options', $options);
+        }
 
         if (!empty($properties['vendor_id'])) {
             $vendor_id = Utils::getVendorId($this->modx, $properties['vendor_id']);
@@ -106,17 +108,16 @@ class Update extends UpdateProcessor
     {
         $result = parent::afterSave();
 
-        // Save product options from options-* form fields (always set in beforeSet)
+        // Save product options from options-* form fields (parsed in beforeSet)
+        // Only runs when form actually contained options-* fields
+        // removeOther=false: JSON-based options (color, size) are saved separately via msProductData::save()
         $options = $this->getProperty('options');
-        if (is_array($options)) {
+        if (!empty($options) && is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                // When empty: user cleared form → remove all (removeOther=true)
-                // When has values: preserve JSON options (removeOther=false)
-                $removeOther = empty($options);
-                $service->saveOptions($productData, $options, $removeOther);
+                $service->saveOptions($productData, $options, false);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -42,14 +42,13 @@ class Update extends UpdateProcessor
         $properties = $this->getProperties();
         $options = [];
         foreach ($properties as $key => $value) {
-            if (strpos($key, 'options-') === 0) {
-                $options[substr($key, 8)] = $value;
+            $optionKey = Utils::extractOptionKey($key);
+            if ($optionKey !== null) {
+                $options[$optionKey] = $value;
                 $this->unsetProperty($key);
             }
         }
-        if (!empty($options)) {
-            $this->setProperty('options', $options);
-        }
+        $this->setProperty('options', $options);
 
         if (!empty($properties['vendor_id'])) {
             $vendor_id = Utils::getVendorId($this->modx, $properties['vendor_id']);

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -106,18 +106,17 @@ class Update extends UpdateProcessor
     {
         $result = parent::afterSave();
 
-        // Save product options if provided (from options-* fields in form)
-        // Note: Don't remove other options (removeOther = false) because
-        // JSON fields like color/size are saved separately via msProductData::save()
+        // Save product options from options-* form fields (always set in beforeSet)
         $options = $this->getProperty('options');
-        if (!empty($options) && is_array($options)) {
+        if (is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                // Don't remove other options - they come from JSON fields
-                // Empty values are passed through to signal deletion
-                $service->saveOptions($productData, $options, false);
+                // When empty: user cleared form → remove all (removeOther=true)
+                // When has values: preserve JSON options (removeOther=false)
+                $removeOther = empty($options);
+                $service->saveOptions($productData, $options, $removeOther);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/UpdateFromGrid.php
+++ b/core/components/minishop3/src/Processors/Product/UpdateFromGrid.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Processors\Product;
 
+use MiniShop3\Utils\Utils;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 use MODX\Revolution\Processors\Processor;
@@ -70,16 +71,15 @@ class UpdateFromGrid extends Update
     public function beforeSet()
     {
         $properties = $this->getProperties();
-        $options = $this->object->loadData()->get('options');
+        $options = $this->object->loadData()->get('options') ?? [];
         foreach ($properties as $key => $value) {
-            if (strpos($key, 'options-') === 0) {
-                $options[substr($key, 8)] = $value;
+            $optionKey = Utils::extractOptionKey($key);
+            if ($optionKey !== null) {
+                $options[$optionKey] = $value;
                 $this->unsetProperty($key);
             }
         }
-        if (!empty($options)) {
-            $this->setProperty('options', $options);
-        }
+        $this->setProperty('options', $options);
 
         return parent::beforeSet();
     }

--- a/core/components/minishop3/src/Processors/Product/UpdateFromGrid.php
+++ b/core/components/minishop3/src/Processors/Product/UpdateFromGrid.php
@@ -79,7 +79,9 @@ class UpdateFromGrid extends Update
                 $this->unsetProperty($key);
             }
         }
-        $this->setProperty('options', $options);
+        if (!empty($options)) {
+            $this->setProperty('options', $options);
+        }
 
         return parent::beforeSet();
     }

--- a/core/components/minishop3/src/Services/Option/OptionSyncService.php
+++ b/core/components/minishop3/src/Services/Option/OptionSyncService.php
@@ -40,11 +40,14 @@ class OptionSyncService
      */
     public function saveProductOptions(int $productId, array $options, bool $removeOther = true): bool
     {
-        if (empty($options) || !is_array($options)) {
+        $existingOptions = $this->getForProduct($productId);
+
+        if (empty($options)) {
+            if ($removeOther) {
+                $this->removeUnusedOptions($productId, [], $existingOptions);
+            }
             return true;
         }
-
-        $existingOptions = $this->getForProduct($productId);
 
         // Process each option
         foreach ($options as $key => $values) {

--- a/core/components/minishop3/src/Utils/Utils.php
+++ b/core/components/minishop3/src/Utils/Utils.php
@@ -243,7 +243,8 @@ class Utils
         if (!str_starts_with($key, 'options-')) {
             return null;
         }
-        return rtrim(substr($key, 8), '[]');
+        $optionKey = rtrim(substr($key, 8), '[]');
+        return $optionKey !== '' ? $optionKey : null;
     }
 
     public static function getVendorId($modx, $name)

--- a/core/components/minishop3/src/Utils/Utils.php
+++ b/core/components/minishop3/src/Utils/Utils.php
@@ -232,6 +232,20 @@ class Utils
         $mail->reset();
     }
 
+    /**
+     * Extract option key from form field name (e.g. options-color[] → color)
+     *
+     * @param string $key Form field key (options-{key} or options-{key}[])
+     * @return string|null Option key or null if not an options field
+     */
+    public static function extractOptionKey(string $key): ?string
+    {
+        if (!str_starts_with($key, 'options-')) {
+            return null;
+        }
+        return rtrim(substr($key, 8), '[]');
+    }
+
     public static function getVendorId($modx, $name)
     {
         $criteria = [


### PR DESCRIPTION
## Описание

Улучшение парсинга опций товара из полей формы и обработки пустого массива опций.

**Изменения:**
- Вынесён парсинг ключей опций в общий метод `Utils::extractOptionKey()` (устранение дублирования)
- Использование `str_starts_with()` вместо `strpos()` для проверки префикса `options-` (PHP 8.2+)
- В Update и UpdateFromGrid всегда вызывается `setProperty('options', $options)`, включая пустой массив — обеспечивает корректную очистку опций через форму
- Удалена избыточная проверка `!is_array($options)` в OptionSyncService (тип задан в сигнатуре)
- Исправлена обработка пустого массива в OptionSyncService: при `removeOther=true` теперь вызывается `removeUnusedOptions()`

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

https://github.com/modx-pro/MiniShop3/issues/148

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок — не применимо
- [ ] Обновлён CHANGELOG.md — для минорного фикса не требуется