### PR TITLE
fix(category): restore visual editor (TinyMCE) for product category content

### DIFF
--- a/assets/components/minishop3/js/mgr/category/category.common.js
+++ b/assets/components/minishop3/js/mgr/category/category.common.js
@@ -49,9 +49,8 @@ Ext.extend(ms3.panel.Category, MODx.panel.Resource, {
                 pageSettingsTab && item.items.push(pageSettingsTab);
                 accessPermissionsTab && item.items.push(accessPermissionsTab);
             }
-            if (item.id !== 'modx-resource-content') {
-                fields.push(item);
-            }
+            // Include modx-resource-content so TinyMCE/visual editor can attach (fixes raw HTML instead of RTE)
+            fields.push(item);
         }
 
         return fields;
@@ -80,13 +79,14 @@ Ext.extend(ms3.panel.Category, MODx.panel.Resource, {
                     item_j.border = false;
                     item_j.fieldLabel = _('content');
                     item_j.itemCls = 'contentblocks_replacement';
-                    item_j.msgTarget = "under";
+                    item_j.msgTarget = 'under';
                     item_j.description = '<b>[[*content]]</b>';
-                    if (MODx.config['ms3_category_content_default'] && config['mode'] === 'create') {
+                    if (config['mode'] === 'create' && MODx.config['ms3_category_content_default']) {
                         item_j.value = MODx.config['ms3_category_content_default'];
+                    } else if (config['mode'] === 'create') {
+                        item_j.value = '<p></p>';
                     }
-                    item_j.value = "<p></p>"
-                    //item_j.hidden = ms3.config.isHideContent;
+                    // item_j.hidden = ms3.config.isHideContent;
                     item_j.hidden = false;
                 }
                 fields.push(item_j);

--- a/core/components/minishop3/controllers/category/update.class.php
+++ b/core/components/minishop3/controllers/category/update.class.php
@@ -115,9 +115,8 @@ class msCategoryUpdateManagerController extends msResourceUpdateController
             MODx.perm.tree_show_resource_ids = ' . ($this->modx->hasPermission('tree_show_resource_ids') ? 1 : 0) . ';
         // ]]>
         </script>');
-//
-//        // load RTE
-        //$this->loadRichTextEditor();
+        // Load RTE
+        $this->loadRichTextEditor();
         $this->modx->invokeEvent('msOnManagerCustomCssJs', array('controller' => $this, 'page' => 'category_update'));
     }
 }


### PR DESCRIPTION
## Описание

Восстановлена работа визуального редактора (TinyMCE) для поля «Содержимое» при редактировании ресурса-категории товаров. Раньше при переводе ресурса в статус категории товаров блок с полем контента исключался из формы, из-за чего отображалась только разметка HTML вместо редактора, при том что в настройках ресурса визуальный редактор был включён.

**Изменения:**
- В форму категории снова включается блок `modx-resource-content`, чтобы MODX мог инициализировать TinyMCE на поле контента.
- В методе `getContent()` значение контента задаётся только в режиме создания; в режиме редактирования существующее содержимое не перезаписывается.
- В контроллере редактирования категории раскомментирован вызов `loadRichTextEditor()`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

(Сообщение пользователя на форуме: при переводе ресурса в категорию товаров визуальный редактор отключался, отображался только raw markup; редактор — TinyMCE.)

## Как это было протестировано?

- [x] Ручное тестирование (проверка формы категории: блок «Содержимое» отображается, RTE инициализируется)
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.6.x
- MODX: 3.x
- PHP: (указать при необходимости)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Поле «Содержимое» — только raw HTML | Поле «Содержимое» с визуальным редактором TinyMCE |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность (проверена цепочка getFields для create/update)
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуются
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Логика проверена: дублирования поля контента нет, порядок полей формы совпадает со стандартным ресурсом MODX.
- Форма создания категории использует тот же `Category.getFields()` и также получает блок контента с возможностью RTE.
