### PR TITLE
fix(category): persist hide_children_in_tree checkbox

### DIFF
--- a/core/components/minishop3/src/Processors/Category/Create.php
+++ b/core/components/minishop3/src/Processors/Category/Create.php
@@ -31,6 +31,15 @@ class Create extends CreateProcessor
 
 
     /**
+     * @return void
+     */
+    public function handleCheckBoxes()
+    {
+        parent::handleCheckBoxes();
+        $this->setCheckbox('hide_children_in_tree');
+    }
+
+    /**
      * @return bool
      */
     public function beforeSave()

--- a/core/components/minishop3/src/Processors/Category/Update.php
+++ b/core/components/minishop3/src/Processors/Category/Update.php
@@ -54,6 +54,15 @@ class Update extends UpdateProcessor
 
 
     /**
+     * @return void
+     */
+    public function handleCheckBoxes()
+    {
+        parent::handleCheckBoxes();
+        $this->setCheckbox('hide_children_in_tree');
+    }
+
+    /**
      * @return bool
      */
     public function beforeSave()


### PR DESCRIPTION
## Описание

Исправлено сохранение настройки «Скрыть дочерние ресурсы» (`hide_children_in_tree`) при редактировании и создании категории товаров. В процессорах `Category/Update` и `Category/Create` добавлена обработка чекбокса через `handleCheckBoxes()` и `setCheckbox('hide_children_in_tree')`, чтобы значение корректно записывалось в БД при включении и выключении переключателя (неотмеченные чекбоксы в HTML не передают значение в запросе).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #161

## Как это было протестировано?

- [x] Ручное тестирование: открытие категории, включение «Скрыть дочерние ресурсы», сохранение, перезагрузка страницы — значение сохраняется; дочерние элементы не отображаются в дереве.
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: актуальная из репозитория
- MODX: —
- PHP: —

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Значение не сохранялось после «Сохранить» | Переключатель сохраняет положение, дочерние скрыты в дереве |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (не требуются — метод аналогичен Product/Update)
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется, ключи уже есть
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Оранжевый цвет переключателя в интерфейсе задаётся стилями MODX/VueTools или темой и не связан с логикой сохранения; исправление касается только персистентности значения.
