### PR TITLE
feat(grid): add duplicate and publish actions to category-products grid

### DIFF
--- a/core/components/minishop3/migrations/20260317120000_add_duplicate_publish_to_category_products_actions.php
+++ b/core/components/minishop3/migrations/20260317120000_add_duplicate_publish_to_category_products_actions.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add duplicate and publish actions to category-products grid (issue #143)
+ *
+ * The initial seed had only view, edit, delete. This migration updates the actions
+ * column config so that "Duplicate" and "Publish" buttons appear in the category
+ * products grid, matching the behavior of the Vue component's default actions.
+ */
+final class AddDuplicatePublishToCategoryProductsActions extends AbstractMigration
+{
+    private string $prefix;
+
+    public function up(): void
+    {
+        $this->prefix = $this->getAdapter()->getOption('table_prefix') ?? '';
+        $table = $this->prefix . 'ms3_grid_fields';
+        $now = date('Y-m-d H:i:s');
+
+        $config = [
+            'type' => 'actions',
+            'actions' => [
+                ['name' => 'view', 'handler' => 'view', 'icon' => 'pi-eye', 'label' => 'view'],
+                ['name' => 'edit', 'handler' => 'edit', 'icon' => 'pi-pencil', 'label' => 'edit'],
+                [
+                    'name' => 'publish',
+                    'handler' => 'publish',
+                    'icon' => 'pi-check',
+                    'iconOff' => 'pi-times',
+                    'label' => 'publish',
+                    'labelOff' => 'unpublish',
+                    'toggleField' => 'published',
+                ],
+                ['name' => 'duplicate', 'handler' => 'duplicate', 'icon' => 'pi-copy', 'label' => 'duplicate'],
+                [
+                    'name' => 'delete',
+                    'handler' => 'delete',
+                    'icon' => 'pi-trash',
+                    'label' => 'delete',
+                    'severity' => 'danger',
+                    'confirm' => true,
+                    'confirmMessage' => 'product_delete_confirm_message',
+                ],
+            ],
+        ];
+
+        $configJson = json_encode($config, JSON_UNESCAPED_UNICODE);
+        $quoted = $this->getAdapter()->getConnection()->quote($configJson);
+
+        $this->execute(
+            "UPDATE `{$table}` SET config = {$quoted}, updated_at = '{$now}' " .
+            "WHERE grid_key = 'category-products' AND field_name = 'actions'"
+        );
+    }
+
+    public function down(): void
+    {
+        $this->prefix = $this->getAdapter()->getOption('table_prefix') ?? '';
+        $table = $this->prefix . 'ms3_grid_fields';
+        $now = date('Y-m-d H:i:s');
+
+        $config = [
+            'type' => 'actions',
+            'actions' => [
+                ['name' => 'view', 'handler' => 'view', 'icon' => 'pi-eye', 'label' => 'view'],
+                ['name' => 'edit', 'handler' => 'edit', 'icon' => 'pi-pencil', 'label' => 'edit'],
+                [
+                    'name' => 'delete',
+                    'handler' => 'delete',
+                    'icon' => 'pi-trash',
+                    'label' => 'delete',
+                    'severity' => 'danger',
+                    'confirm' => true,
+                    'confirmMessage' => 'product_delete_confirm_message',
+                ],
+            ],
+        ];
+
+        $configJson = json_encode($config, JSON_UNESCAPED_UNICODE);
+        $quoted = $this->getAdapter()->getConnection()->quote($configJson);
+
+        $this->execute(
+            "UPDATE `{$table}` SET config = {$quoted}, updated_at = '{$now}' " .
+            "WHERE grid_key = 'category-products' AND field_name = 'actions'"
+        );
+    }
+}


### PR DESCRIPTION
## Описание

Добавлена миграция, которая обновляет конфигурацию колонки actions грида товаров категории: в конфиг добавляются действия **duplicate** (Копировать) и **publish** (Опубликовать/Снять). После применения миграции в гриде товаров на странице категории отображаются кнопки копирования и переключения публикации. Логика уже была в коде (duplicateProduct, togglePublish, msProduct::duplicate); исправление только раскрывает кнопки через конфигурацию в БД.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #143

## Как это было протестировано?

- [x] Ручное тестирование (после применения миграции — проверка отображения кнопок в гриде)
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: —
- PHP: —

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| В гриде только view, edit, delete | В гриде view, edit, publish, duplicate, delete |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (docblock миграции)
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется (ключи уже есть)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Миграция обновляет только поле `config` для записи с `grid_key = category-products` и `field_name = actions` в таблице `ms3_grid_fields`. Откат (down) восстанавливает конфиг с тремя действиями (view, edit, delete).