### PR TITLE
fix: приведение типов для extra fields в msProductData

### DIFF
--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -35,7 +35,7 @@ class ProductDataService
      * Performs comprehensive product data preparation:
      * - Prepare array fields (tags, color, size etc.) - remove duplicates, empty values
      * - Set source_id for new products
-     * - Cast numeric fields (price, old_price, weight) to float type
+     * - Cast numeric and boolean fields to proper types (including extra fields)
      *
      * @param msProductData $productData
      * @return void
@@ -54,28 +54,18 @@ class ProductDataService
         // Cast all numeric and boolean fields (including extra fields) to proper types
         // Prevents MySQL errors when empty string '' is sent for decimal/int/tinyint columns
         foreach ($productData->_fieldMeta as $key => $meta) {
+            if ($key === 'id') {
+                continue;
+            }
             $phptype = $meta['phptype'] ?? '';
+            $value = $productData->get($key);
+
             if ($phptype === 'float') {
-                $value = $productData->get($key);
-                if ($value === '' || $value === null) {
-                    $productData->set($key, 0.0);
-                } else {
-                    $productData->set($key, (float)$value);
-                }
+                $productData->set($key, ($value === '' || $value === null) ? 0.0 : (float)$value);
             } elseif ($phptype === 'integer') {
-                $value = $productData->get($key);
-                if ($value === '' || $value === null) {
-                    $productData->set($key, 0);
-                } else {
-                    $productData->set($key, (int)$value);
-                }
+                $productData->set($key, ($value === '' || $value === null) ? 0 : (int)$value);
             } elseif ($phptype === 'boolean') {
-                $value = $productData->get($key);
-                if ($value === '' || $value === null) {
-                    $productData->set($key, false);
-                } else {
-                    $productData->set($key, (bool)$value);
-                }
+                $productData->set($key, ($value === '' || $value === null) ? false : (bool)$value);
             }
         }
     }

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -51,9 +51,33 @@ class ProductDataService
             $productData->set('source_id', $this->modx->getOption('ms3_product_source_default', null, 1));
         }
 
-        $productData->set('price', (float)$productData->get('price'));
-        $productData->set('old_price', (float)$productData->get('old_price'));
-        $productData->set('weight', (float)$productData->get('weight'));
+        // Cast all numeric and boolean fields (including extra fields) to proper types
+        // Prevents MySQL errors when empty string '' is sent for decimal/int/tinyint columns
+        foreach ($productData->_fieldMeta as $key => $meta) {
+            $phptype = $meta['phptype'] ?? '';
+            if ($phptype === 'float') {
+                $value = $productData->get($key);
+                if ($value === '' || $value === null) {
+                    $productData->set($key, 0.0);
+                } else {
+                    $productData->set($key, (float)$value);
+                }
+            } elseif ($phptype === 'integer') {
+                $value = $productData->get($key);
+                if ($value === '' || $value === null) {
+                    $productData->set($key, 0);
+                } else {
+                    $productData->set($key, (int)$value);
+                }
+            } elseif ($phptype === 'boolean') {
+                $value = $productData->get($key);
+                if ($value === '' || $value === null) {
+                    $productData->set($key, false);
+                } else {
+                    $productData->set($key, (bool)$value);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- При сохранении товара с decimal/int/tinyint Extra Fields (например `wholesale_price`) пустая строка из формы вызывала MySQL ошибку `Incorrect decimal value: '' for column`
- Из-за этого `msProductData::save()` возвращал `false`, и `saveCategories()` / `saveOptions()` / `saveLinks()` молча не выполнялись — пользователь терял дополнительные категории без какой-либо ошибки в UI
- Заменяет хардкод каста `price`/`old_price`/`weight` на универсальный цикл по `_fieldMeta`, покрывающий все поля включая Extra Fields (`float`, `integer`, `boolean`)

## Test plan

- [ ] Создать Extra Field с типом `decimal` (например `wholesale_price`)
- [ ] Открыть товар, оставить это поле пустым, отметить дополнительные категории
- [ ] Сохранить — категории должны сохраниться, ошибок в логе быть не должно
- [ ] Проверить что стандартные поля (`price`, `old_price`, `weight`) по-прежнему корректно кастятся

🤖 Generated with [Claude Code](https://claude.com/claude-code)