### PR TITLE
fix: use msPayment type hints in Payment Sort processor

### DIFF
--- a/core/components/minishop3/src/Processors/Settings/Payment/Sort.php
+++ b/core/components/minishop3/src/Processors/Settings/Payment/Sort.php
@@ -2,7 +2,6 @@
 
 namespace MiniShop3\Processors\Settings\Payment;
 
-use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msPayment;
 use MODX\Revolution\Processors\ModelProcessor;
 
@@ -26,9 +25,9 @@ class Sort extends ModelProcessor
             return $this->failure();
         }
         foreach ($sources as $id) {
-            /** @var msDelivery $source */
+            /** @var msPayment $source */
             $source = $this->modx->getObject($this->classKey, compact('id'));
-            /** @var msDelivery $target */
+            /** @var msPayment $target */
             $target = $this->modx->getObject($this->classKey, ['id' => $this->getProperty('target')]);
             $this->sort($source, $target);
         }
@@ -39,12 +38,12 @@ class Sort extends ModelProcessor
 
 
     /**
-     * @param msDelivery $source
-     * @param msDelivery $target
+     * @param msPayment $source
+     * @param msPayment $target
      *
      * @return void
      */
-    public function sort(msDelivery $source, msDelivery $target)
+    public function sort(msPayment $source, msPayment $target)
     {
         $c = $this->modx->newQuery($this->classKey);
         $c->command('UPDATE');


### PR DESCRIPTION
## Описание

В процессоре `MiniShop3\Processors\Settings\Payment\Sort` метод `sort()` и связанные `@var` в `process()` ошибочно указывали `msDelivery` (копипаста из `Delivery\Sort`), хотя `$classKey = msPayment::class`. Исправлены сигнатура метода, PHPDoc `@param` и `@var` на `msPayment`, удалён неиспользуемый `use MiniShop3\Model\msDelivery`. Логика и поведение в рантайме не меняются; восстанавливается корректная статическая типизация для IDE и PHPStan.

Связано с обнаружением в PR #174, см. [issue #175](https://github.com/modx-pro/MiniShop3/issues/175).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #175

## Как это было протестировано?

Проверка синтаксиса PHP (`php -l`) для изменённого файла. Убедился, что `sort()` вызывается только из `process()` этого процессора и объекты загружаются через `$this->classKey` (то есть `msPayment`). `Status/Sort.php` использует `msOrderStatus` корректно, правки не требуются.

- [ ] Ручное тестирование в менеджере
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/payment-sort-mspayment-typehints-175`
- MODX: —
- PHP: проверка `php -l`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Изменения только в PHP-процессоре: лексиконы, ESLint и CHANGELOG не затрагиваются. PHPStan на стороне ревьюера/CI.
