### PR TITLE
fix(options): фильтр групп опций в сетке настроек

### DIFF
--- a/assets/components/minishop3/js/mgr/settings/option/grid.js
+++ b/assets/components/minishop3/js/mgr/settings/option/grid.js
@@ -1,5 +1,6 @@
-/** Combo page size: option-group filter must list all distinct modCategories (default 20 hides groups). */
-var MS3_OPTION_GRID_MODCATEGORY_PAGE_SIZE = 500;
+Ext.ns('ms3.grid');
+/** Page size for modcategory filter combo: many option groups; default store page (20) hides entries. */
+ms3.grid.OPTION_MODCATEGORY_COMBO_PAGE_SIZE = 500;
 
 ms3.grid.Option = function (config) {
     config = config || {};
@@ -90,7 +91,7 @@ Ext.extend(ms3.grid.Option, ms3.grid.Default, {
         }, '->', {
             xtype: 'ms3-combo-modcategory',
             id: config.id + '-modcategory',
-            pageSize: MS3_OPTION_GRID_MODCATEGORY_PAGE_SIZE,
+            pageSize: ms3.grid.OPTION_MODCATEGORY_COMBO_PAGE_SIZE,
             listeners: {
                 select: {
                     fn: function (field) {

--- a/assets/components/minishop3/js/mgr/settings/option/grid.js
+++ b/assets/components/minishop3/js/mgr/settings/option/grid.js
@@ -1,3 +1,6 @@
+/** Combo page size: option-group filter must list all distinct modCategories (default 20 hides groups). */
+var MS3_OPTION_GRID_MODCATEGORY_PAGE_SIZE = 500;
+
 ms3.grid.Option = function (config) {
     config = config || {};
     if (!config.id) {
@@ -87,7 +90,7 @@ Ext.extend(ms3.grid.Option, ms3.grid.Default, {
         }, '->', {
             xtype: 'ms3-combo-modcategory',
             id: config.id + '-modcategory',
-            pageSize: 500,
+            pageSize: MS3_OPTION_GRID_MODCATEGORY_PAGE_SIZE,
             listeners: {
                 select: {
                     fn: function (field) {

--- a/assets/components/minishop3/js/mgr/settings/option/grid.js
+++ b/assets/components/minishop3/js/mgr/settings/option/grid.js
@@ -87,6 +87,7 @@ Ext.extend(ms3.grid.Option, ms3.grid.Default, {
         }, '->', {
             xtype: 'ms3-combo-modcategory',
             id: config.id + '-modcategory',
+            pageSize: 500,
             listeners: {
                 select: {
                     fn: function (field) {

--- a/core/components/minishop3/src/Processors/Settings/Option/GetCategories.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/GetCategories.php
@@ -24,6 +24,8 @@ class GetCategories extends GetListProcessor
     {
 
         $c->innerJoin(msOption::class, 'msOption', 'msOption.modcategory_id=modCategory.id');
+        // One row per MODX category (inner join multiplies rows when many options share a group)
+        $c->groupby('modCategory.id');
 
         return $c;
     }

--- a/core/components/minishop3/src/Processors/Settings/Option/GetCategories.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/GetCategories.php
@@ -16,6 +16,8 @@ class GetCategories extends GetListProcessor
 
 
     /**
+     * Inner join lists only modCategories used as option groups; GROUP BY collapses join duplicates.
+     *
      * @param xPDOQuery $c
      *
      * @return xPDOQuery
@@ -24,7 +26,6 @@ class GetCategories extends GetListProcessor
     {
 
         $c->innerJoin(msOption::class, 'msOption', 'msOption.modcategory_id=modCategory.id');
-        // One row per MODX category (inner join multiplies rows when many options share a group)
         $c->groupby('modCategory.id');
 
         return $c;


### PR DESCRIPTION
## Описание

В комбо фильтра по группе опций (modCategory) устранены дубликаты строк из-за `INNER JOIN` с `ms3_options` и увеличен размер страницы подгрузки, чтобы в списке отображались все используемые группы, а не только первые 20 записей.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #183

## Как это было протестировано?

Проверка вручную в менеджере: сетка «Настройки → Опции», фильтр по группе — все группы, назначенные опциям, доступны без «потери» из-за пагинации и дублей.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: по окружению ревьюера
- PHP: по окружению ревьюера

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [ ] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- `GROUP BY modCategory.id` после join с опциями убирает множественные строки на одну категорию.
- Размер страницы комбо вынесен в `ms3.grid.OPTION_MODCATEGORY_COMBO_PAGE_SIZE` (без глобального `var` в корне файла).

Ревьюерам: при `ONLY_FULL_GROUP_BY` убедиться, что выборка полей `modCategory` согласована с `GROUP BY` на вашей версии MySQL.