### PR TITLE
fix(options): массовое назначение опций категориям

### DIFF
--- a/assets/components/minishop3/js/mgr/settings/option/tree.js
+++ b/assets/components/minishop3/js/mgr/settings/option/tree.js
@@ -55,6 +55,9 @@ Ext.extend(ms3.tree.OptionCategories, MODx.tree.Tree, {
         this.cm.removeAll();
 
         function bulkToggleChecks(root, checked, treePanel) {
+            if (!root || typeof root.expand !== 'function') {
+                return;
+            }
             var sync = treePanel.getListeners().checkchange;
             root.expand(true, false, function () {
                 root.cascade(function (node) {

--- a/assets/components/minishop3/js/mgr/settings/option/tree.js
+++ b/assets/components/minishop3/js/mgr/settings/option/tree.js
@@ -53,6 +53,18 @@ Ext.extend(ms3.tree.OptionCategories, MODx.tree.Tree, {
         n.select();
         this.cm.activeNode = n;
         this.cm.removeAll();
+
+        function bulkToggleChecks(root, checked, treePanel) {
+            var sync = treePanel.getListeners().checkchange;
+            root.expand(true, false, function () {
+                root.cascade(function (node) {
+                    node.getUI().toggleCheck(checked);
+                    return true;
+                });
+                sync.call(treePanel);
+            });
+        }
+
         const m = [];
         m.push({
             text: '<i class="x-menu-item-icon icon icon-refresh"></i> ' + _('directory_refresh'),
@@ -72,35 +84,12 @@ Ext.extend(ms3.tree.OptionCategories, MODx.tree.Tree, {
         },{
             text: '<i class="x-menu-item-icon icon icon-check-square-o"></i> ' + _('ms3_menu_select_all'),
             handler: function () {
-                const activeNode = this.cm.activeNode;
-                const checkchange = this.getListeners().checkchange;
-                const tree = this;
-
-                // Expand subtree first so lazy/async children exist, then check all nodes once.
-                // The previous expand(false,false,callback) fired checkchange before deep children finished.
-                activeNode.expand(true, false, function () {
-                    activeNode.cascade(function (n) {
-                        n.getUI().toggleCheck(true);
-                        return true;
-                    });
-                    checkchange.call(tree);
-                });
+                bulkToggleChecks(this.cm.activeNode, true, this);
             }
         },{
             text: '<i class="x-menu-item-icon icon icon-square-o"></i> ' + _('ms3_menu_clear_all'),
             handler: function () {
-                const activeNode = this.cm.activeNode;
-                const checkchange = this.getListeners().checkchange;
-
-                function massUncheck(node)
-                {
-                    node.getUI().toggleCheck(false);
-                    node.eachChild(massUncheck);
-                    if (node == activeNode) {
-                        checkchange();
-                    }
-                }
-                massUncheck(activeNode);
+                bulkToggleChecks(this.cm.activeNode, false, this);
             }
         });
         this.addContextMenuItem(m);

--- a/assets/components/minishop3/js/mgr/settings/option/tree.js
+++ b/assets/components/minishop3/js/mgr/settings/option/tree.js
@@ -74,18 +74,17 @@ Ext.extend(ms3.tree.OptionCategories, MODx.tree.Tree, {
             handler: function () {
                 const activeNode = this.cm.activeNode;
                 const checkchange = this.getListeners().checkchange;
+                const tree = this;
 
-                function massCheck(node)
-                {
-                    node.getUI().toggleCheck(true);
-                    node.expand(false,false,function (node) {
-                        node.eachChild(massCheck);
-                        if (node == activeNode) {
-                            checkchange();
-                        }
+                // Expand subtree first so lazy/async children exist, then check all nodes once.
+                // The previous expand(false,false,callback) fired checkchange before deep children finished.
+                activeNode.expand(true, false, function () {
+                    activeNode.cascade(function (n) {
+                        n.getUI().toggleCheck(true);
+                        return true;
                     });
-                }
-                massCheck(activeNode);
+                    checkchange.call(tree);
+                });
             }
         },{
             text: '<i class="x-menu-item-icon icon icon-square-o"></i> ' + _('ms3_menu_clear_all'),

--- a/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
@@ -30,7 +30,7 @@ class Multiple extends ModelProcessor
             if ($categories && $options) {
                 foreach ($options as $option) {
                     foreach ($categories as $category) {
-                        $ms3->utils->runProcessor('MiniShop3\\Processors\\Settings\\Delivery\\Assign', [
+                        $ms3->utils->runProcessor('MiniShop3\\Processors\\Settings\\Option\\Assign', [
                             'option_id' => $option,
                             'category_id' => $category,
                         ]);

--- a/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Processors\Settings\Option;
 
 use MiniShop3\MiniShop3;
 use MODX\Revolution\Processors\ModelProcessor;
+use MODX\Revolution\Processors\ProcessorResponse;
 
 class Multiple extends ModelProcessor
 {
@@ -12,39 +13,58 @@ class Multiple extends ModelProcessor
      */
     public function process()
     {
-        $method = $this->getProperty('method', false);
-        if (!$method) {
+        $methodRaw = $this->getProperty('method', false);
+        if (!$methodRaw) {
             return $this->failure();
         }
-        $method = ucfirst($method);
+
+        if (strcasecmp($methodRaw, 'assign') === 0) {
+            return $this->processAssign();
+        }
+
         $ids = json_decode($this->getProperty('ids'), true);
         if (empty($ids)) {
             return $this->success();
         }
 
-        if ($method == 'assign') {
-            /** @var MiniShop3 $ms3 */
-            $ms3 = $this->modx->services->get('ms3');
-            $categories = json_decode($this->getProperty('categories'), true);
-            $options = json_decode($this->getProperty('options'), true);
-            if ($categories && $options) {
-                foreach ($options as $option) {
-                    foreach ($categories as $category) {
-                        $ms3->utils->runProcessor('MiniShop3\\Processors\\Settings\\Option\\Assign', [
-                            'option_id' => $option,
-                            'category_id' => $category,
-                        ]);
-                    }
+        $method = ucfirst($methodRaw);
+        foreach ($ids as $id) {
+            /** @var ProcessorResponse $response */
+            $response = $this->modx->runProcessor('MiniShop3\\Processors\\Settings\\Option\\' . $method, [
+                'id' => $id,
+            ]);
+            if ($response->isError()) {
+                return $response->getResponse();
+            }
+        }
+
+        return $this->success();
+    }
+
+    /**
+     * @return array|string
+     */
+    protected function processAssign()
+    {
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+        $categories = json_decode($this->getProperty('categories', '[]'), true);
+        $options = json_decode($this->getProperty('options', '[]'), true);
+        if (empty($categories) || empty($options)) {
+            return $this->success();
+        }
+
+        foreach ($options as $option) {
+            foreach ($categories as $category) {
+                /** @var ProcessorResponse $response */
+                $response = $ms3->utils->runProcessor('MiniShop3\\Processors\\Settings\\Option\\Assign', [
+                    'option_id' => $option,
+                    'category_id' => $category,
+                ]);
+                if ($response->isError()) {
+                    return $response->getResponse();
                 }
             }
-        } elseif ($ids = json_decode($this->getProperty('ids'), true)) {
-            foreach ($ids as $id) {
-                $this->modx->runProcessor('MiniShop3\Processors\Settings\Option\\' . $method, [
-                    'id' => $id,
-                ]);
-            }
-
-            return $this->success();
         }
 
         return $this->success();

--- a/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
+++ b/core/components/minishop3/src/Processors/Settings/Option/Multiple.php
@@ -23,18 +23,18 @@ class Multiple extends ModelProcessor
         }
 
         $ids = json_decode($this->getProperty('ids'), true);
-        if (empty($ids)) {
+        if (!is_array($ids) || $ids === []) {
             return $this->success();
         }
 
         $method = ucfirst($methodRaw);
         foreach ($ids as $id) {
-            /** @var ProcessorResponse $response */
             $response = $this->modx->runProcessor('MiniShop3\\Processors\\Settings\\Option\\' . $method, [
                 'id' => $id,
             ]);
-            if ($response->isError()) {
-                return $response->getResponse();
+            $failure = $this->failureFromProcessorResponse($response);
+            if ($failure !== null) {
+                return $failure;
             }
         }
 
@@ -50,23 +50,40 @@ class Multiple extends ModelProcessor
         $ms3 = $this->modx->services->get('ms3');
         $categories = json_decode($this->getProperty('categories', '[]'), true);
         $options = json_decode($this->getProperty('options', '[]'), true);
-        if (empty($categories) || empty($options)) {
+        if (!is_array($categories) || !is_array($options) || $categories === [] || $options === []) {
             return $this->success();
         }
 
         foreach ($options as $option) {
             foreach ($categories as $category) {
-                /** @var ProcessorResponse $response */
                 $response = $ms3->utils->runProcessor('MiniShop3\\Processors\\Settings\\Option\\Assign', [
-                    'option_id' => $option,
-                    'category_id' => $category,
+                    'option_id' => (int) $option,
+                    'category_id' => (int) $category,
                 ]);
-                if ($response->isError()) {
-                    return $response->getResponse();
+                $failure = $this->failureFromProcessorResponse($response);
+                if ($failure !== null) {
+                    return $failure;
                 }
             }
         }
 
         return $this->success();
+    }
+
+    /**
+     * @param mixed $response
+     *
+     * @return array|string|null null if OK
+     */
+    protected function failureFromProcessorResponse($response)
+    {
+        if (!$response instanceof ProcessorResponse) {
+            return $this->failure();
+        }
+        if ($response->isError()) {
+            return $response->getResponse();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Описание

Исправлено массовое назначение опций категориям товаров: вызывался несуществующий процессор `Delivery\\Assign` вместо `Option\\Assign`. Дополнительно исправлена логика ветки `assign` (сравнение метода до `ucfirst`), обработка ответов вложенных процессоров, валидация массивов из JSON и симметричное «Выбрать всё» / «Снять всё» в дереве категорий с полным раскрытием поддерева.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #184

## Как это было протестировано?

Сценарий из issue: несколько опций → «Назначить» → контекстное меню «Выбрать всё» на родительских категориях → сохранить; проверить связи опция–категория. Автотесты в PR не запускались.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: по окружению ревьюера
- PHP: по окружению ревьюера

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [ ] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Повторное назначение уже существующей пары опция–категория по-прежнему может возвращать ошибку из `Option\\Assign` (`_err_ae`) — это поведение вложенного процессора; при необходимости идемпотентность можно обсудить отдельно.
- `bulkToggleChecks` защищён от отсутствия `root.expand`.