### PR TITLE
fix(vue): вкладки групп опций в карточке товара

### DIFF
--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -200,45 +200,38 @@ function mountOptionsTab() {
         return
       }
 
-      // Build option groups from config (group by modcategory_id from msOption, not legacy `category`)
-      const options = props.config.option_fields || []
-      const optionGroups = []
+      const optionFields = props.config.option_fields || []
+      const groupsByModCategoryId = new Map()
 
-      for (let i = 0; i < options.length; i++) {
-        const option = options[i]
+      for (const option of optionFields) {
         const field = ms3.utils.getExtField(
           { record: props.record, mode: 'update' },
           option.key,
           option,
           'extra-field'
         )
-
-        if (!field) continue
-
-        const groupId = option.modcategory_id ?? 0
-
-        let found = false
-        for (let j = 0; j < optionGroups.length; j++) {
-          if (optionGroups[j].groupId === groupId) {
-            optionGroups[j].items.push(field)
-            found = true
-            break
-          }
+        if (!field) {
+          continue
         }
 
-        if (!found) {
-          optionGroups.push({
-            id: 'ms3-options-tab-' + groupId,
+        const modCategoryId = option.modcategory_id ?? 0
+        let panel = groupsByModCategoryId.get(modCategoryId)
+        if (!panel) {
+          panel = {
+            id: 'ms3-options-tab-' + modCategoryId,
             layout: 'form',
             labelAlign: 'top',
-            groupId,
+            groupId: modCategoryId,
             title: option.category_name || _('ms3_ft_nogroup'),
             bodyCssClass: 'main-wrapper',
-            items: [field],
-          })
+            items: [],
+          }
+          groupsByModCategoryId.set(modCategoryId, panel)
         }
+        panel.items.push(field)
       }
 
+      const optionGroups = Array.from(groupsByModCategoryId.values())
       if (optionGroups.length === 0) {
         return
       }

--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -200,7 +200,7 @@ function mountOptionsTab() {
         return
       }
 
-      // Build option groups from config
+      // Build option groups from config (group by modcategory_id from msOption, not legacy `category`)
       const options = props.config.option_fields || []
       const optionGroups = []
 
@@ -215,9 +215,11 @@ function mountOptionsTab() {
 
         if (!field) continue
 
+        const groupId = option.modcategory_id ?? 0
+
         let found = false
         for (let j = 0; j < optionGroups.length; j++) {
-          if (optionGroups[j].category === option.category) {
+          if (optionGroups[j].groupId === groupId) {
             optionGroups[j].items.push(field)
             found = true
             break
@@ -226,10 +228,10 @@ function mountOptionsTab() {
 
         if (!found) {
           optionGroups.push({
-            id: 'ms3-options-tab-' + option.category,
+            id: 'ms3-options-tab-' + groupId,
             layout: 'form',
             labelAlign: 'top',
-            category: option.category,
+            groupId,
             title: option.category_name || _('ms3_ft_nogroup'),
             bodyCssClass: 'main-wrapper',
             items: [field],

--- a/vueManager/src/components/product/ProductTabs.vue
+++ b/vueManager/src/components/product/ProductTabs.vue
@@ -204,6 +204,9 @@ function mountOptionsTab() {
       const groupsByModCategoryId = new Map()
 
       for (const option of optionFields) {
+        if (!option?.key) {
+          continue
+        }
         const field = ms3.utils.getExtField(
           { record: props.record, mode: 'update' },
           option.key,
@@ -214,7 +217,7 @@ function mountOptionsTab() {
           continue
         }
 
-        const modCategoryId = option.modcategory_id ?? 0
+        const modCategoryId = Number(option.modcategory_id) || 0
         let panel = groupsByModCategoryId.get(modCategoryId)
         if (!panel) {
           panel = {


### PR DESCRIPTION
## Описание

Во Vue-менеджере опции товара группировались по несуществующему полю `category`, из‑за чего все поля попадали в одну вертикальную вкладку. Группировка переведена на `modcategory_id` из `option_fields`, сбор панелей через `Map`, нормализация id и пропуск строк без `key`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #185

## Как это было протестировано?

Ручная проверка: карточка товара во Vue-менеджере, вкладка опций — несколько групп (modCategory) отображаются отдельными вертикальными вкладками. ESLint для изменённого файла не запускался в рамках PR.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: по окружению ревьюера
- PHP: по окружению ревьюера

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [ ] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Заголовок вкладки для группы берётся из `category_name` первой опции в группе (как и ранее при корректной группировке по id).