### PR TITLE
fix(order-form): перевести lexicon labels в dropdown заказа

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 #### 🐛 Исправлено
 
+- **В форме заказа manager UI показывались raw lexicon keys в списках статусов, оплат и доставок (#193):** `GET /api/mgr/model-fields/visible/msOrder` загружал только `minishop3:vue`, из-за чего `comboOptions` не переводили значения из `minishop3:default` и `minishop3:manager`; дополнительно исправлены order-form dropdown routes для статусов и активных доставок
 - **Пустая строка в decimal/int Extra Fields ломала сохранение товара (#170):** пустое значение кастомного поля (например `wholesale_price`) вызывало MySQL ошибку `Incorrect decimal value`, `save()` возвращал `false` и категории/опции/ссылки молча не сохранялись — хардкод каста `price`/`old_price`/`weight` заменён на универсальный цикл по `_fieldMeta` для всех `float`, `integer` и `boolean` полей
 - **Чекбокс «Скрыть дочерние ресурсы» не сохранялся в категориях (#161, #160):** `hide_children_in_tree` не обрабатывался в `handleCheckBoxes()` процессоров `Category/Update` и `Category/Create` — unchecked-состояние не передавалось в POST и значение сбрасывалось
 - **`publish_document` передавался как bool вместо int в контроллерах (#160):** `canPublish` не приводился к `(int)` в массиве JS-конфига — MODX JS использует строгое сравнение `=== 1`, из-за чего флаг мог не срабатывать. Исправлено во всех 4 контроллерах

--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -794,6 +794,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
     // Statuses dropdown (with translated names for order forms)
     $router->get('/statuses-dropdown', function($params) use ($modx) {
+        $modx->lexicon->load('minishop3:manager');
         $results = [];
         $collection = $modx->getIterator(\MiniShop3\Model\msOrderStatus::class);
         foreach ($collection as $item) {
@@ -811,10 +812,18 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
     // Dropdown list of active deliveries (for order forms)
     $router->get('/deliveries-active', function($params) use ($modx) {
+        $modx->lexicon->load('minishop3:default');
         $results = [];
         $collection = $modx->getIterator(\MiniShop3\Model\msDelivery::class, ['active' => 1]);
         foreach ($collection as $item) {
-            $results[] = $item->toArray();
+            $data = $item->toArray();
+            if (!empty($data['name']) && str_starts_with($data['name'], 'ms3_')) {
+                $translated = $modx->lexicon($data['name']);
+                if ($translated !== $data['name']) {
+                    $data['name'] = $translated;
+                }
+            }
+            $results[] = $data;
         }
         return \MiniShop3\Router\Response::success(['results' => $results])->getData();
     });

--- a/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
@@ -307,8 +307,11 @@ class ModelFieldsController
             return Response::error('Invalid model type', 400)->getData();
         }
 
-        // Load lexicon topics for label translation
+        // `comboOptions` may include status/payment/delivery names stored as lexicon keys.
+        // Load all topics needed both for field labels (`vue`) and option labels.
         $this->modx->lexicon->load('minishop3:vue');
+        $this->modx->lexicon->load('minishop3:default');
+        $this->modx->lexicon->load('minishop3:manager');
 
         // Get sections for the model
         $sections = $this->getSectionsForModel($model);


### PR DESCRIPTION
## Описание

Исправляет баг, из-за которого в manager-форме заказа в dropdown/select полях отображались raw lexicon keys (`ms3_payment_cash`, `ms3_delivery_self_pickup`, `ms3_order_status_new`) вместо переведённых подписей.

Причина была в том, что `GET /api/mgr/model-fields/visible/msOrder` загружал только `minishop3:vue`, а `comboOptions` для `status_id`, `delivery_id` и `payment_id` переводятся через lexicon topics `minishop3:manager` и `minishop3:default`. Дополнительно приведены в соответствие order-form routes для dropdown статусов и активных доставок.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Fixes #193

## Как это было протестировано?

Опишите тесты, которые вы провели для проверки изменений.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `beta`
- MODX: `3.x`
- PHP: `8.2+` локальный CLI / `php -l`

Проверка через bootstrap MODX и вызов модифицированного `ModelFieldsController::getVisibleFields(['model' => 'msOrder'])` показала корректные labels в `comboOptions`:
- `status_id`: `Черновик`, `Новый`, `Оплачен`
- `delivery_id`: `Самовывоз`, `Почта России`, `ПЭК`
- `payment_id`: `Наличные`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| <img width="1260" height="742" alt="image" src="https://github.com/user-attachments/assets/191467a7-719c-4d2a-8a1c-78fd8e53b8c8" /> | переведённые labels из lexicon topics |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Фикс намеренно ограничен order-form API путями и не меняет CRUD-контроллеры оплат/доставок, чтобы не подменять raw stored lexicon keys в экранах их редактирования.