### PR TITLE
fix(api): не перезаписывать properties заказа данными адреса

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,15 @@
 - Метод `Router::loadRoutesFromDirectory()`, путь `Router::coreAddonRoutesDirectory('manager'|'web')` с проверкой аргумента; `api.php` и `Processors\Api\Index` грузят web-фрагменты; `Processors\Api\Router` (встроенная админка) — только manager-фрагменты
 - Resolver создаёт каталоги при установке; примеры `example-addon.php.dist` в компоненте для копирования в `core/config/`
 
+#### 🔧 Качество кода
+
+- **PHPStan baseline сокращён с 277 до 169 ошибок (#174):** исправлены PHPDoc-аннотации (`@throws`, `@return`, `@var`, `@param`), типы параметров `failure()`, `print_r()`, `save()`, `get()`, `set()`; добавлены недостающие `return` в `sort()`/`afterSave()` процессорах; удалены redundant проверки `is_null()`/`instanceof`/`is_array()`
+- **Баг: undefined `$cartCost` в расчёте процентной стоимости доставки (#174):** переменная `$cartCost` не существовала в `Delivery.php` — заменена на параметр `$cost`
+- **`handleCheckBoxes()` вызывал несуществующий parent в `Category\Create` (#174):** метод есть только в `Resource\Update`, не в `Resource\Create`
+
 #### 🐛 Исправлено
 
+- **Manager API затирал `msOrder.properties` данными адреса (#191):** `array_merge($order->toArray(), $address->toArray())` перезаписывал `properties` заказа значением `null` из `msOrderAddress` — выделен `mergeAddressIntoOrderData()` с исключением конфликтующих полей
 - **В форме заказа manager UI показывались raw lexicon keys в списках статусов, оплат и доставок (#193):** `GET /api/mgr/model-fields/visible/msOrder` загружал только `minishop3:vue`, из-за чего `comboOptions` не переводили значения из `minishop3:default` и `minishop3:manager`; дополнительно исправлены order-form dropdown routes для статусов и активных доставок
 - **Пустая строка в decimal/int Extra Fields ломала сохранение товара (#170):** пустое значение кастомного поля (например `wholesale_price`) вызывало MySQL ошибку `Incorrect decimal value`, `save()` возвращал `false` и категории/опции/ссылки молча не сохранялись — хардкод каста `price`/`old_price`/`weight` заменён на универсальный цикл по `_fieldMeta` для всех `float`, `integer` и `boolean` полей
 - **Чекбокс «Скрыть дочерние ресурсы» не сохранялся в категориях (#161, #160):** `hide_children_in_tree` не обрабатывался в `handleCheckBoxes()` процессоров `Category/Update` и `Category/Create` — unchecked-состояние не передавалось в POST и значение сбрасывалось

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,6 @@
 - Метод `Router::loadRoutesFromDirectory()`, путь `Router::coreAddonRoutesDirectory('manager'|'web')` с проверкой аргумента; `api.php` и `Processors\Api\Index` грузят web-фрагменты; `Processors\Api\Router` (встроенная админка) — только manager-фрагменты
 - Resolver создаёт каталоги при установке; примеры `example-addon.php.dist` в компоненте для копирования в `core/config/`
 
-#### 🔧 Качество кода
-
-- **PHPStan baseline сокращён с 277 до 169 ошибок (#174):** исправлены PHPDoc-аннотации (`@throws`, `@return`, `@var`, `@param`), типы параметров `failure()`, `print_r()`, `save()`, `get()`, `set()`; добавлены недостающие `return` в `sort()`/`afterSave()` процессорах; удалены redundant проверки `is_null()`/`instanceof`/`is_array()`
-- **Баг: undefined `$cartCost` в расчёте процентной стоимости доставки (#174):** переменная `$cartCost` не существовала в `Delivery.php` — заменена на параметр `$cost`
-- **`handleCheckBoxes()` вызывал несуществующий parent в `Category\Create` (#174):** метод есть только в `Resource\Update`, не в `Resource\Create`
-
 #### 🐛 Исправлено
 
 - **Manager API затирал `msOrder.properties` данными адреса (#191):** `array_merge($order->toArray(), $address->toArray())` перезаписывал `properties` заказа значением `null` из `msOrderAddress` — выделен `mergeAddressIntoOrderData()` с исключением конфликтующих полей

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -60,6 +60,28 @@ class OrdersController
     }
 
     /**
+     * Merge address fields into order payload without overwriting order-level fields.
+     *
+     * msOrderAddress has its own `id`, `properties`, `createdon`, `updatedon` which
+     * must not overwrite the corresponding msOrder fields in the API response.
+     */
+    protected function mergeAddressIntoOrderData(array $orderData, ?\xPDO\Om\xPDOObject $address): array
+    {
+        if (!$address) {
+            return $orderData;
+        }
+
+        $excludeFields = ['id', 'order_id', 'createdon', 'updatedon', 'properties'];
+        foreach ($address->toArray() as $key => $value) {
+            if (!in_array($key, $excludeFields, true)) {
+                $orderData[$key] = $value;
+            }
+        }
+
+        return $orderData;
+    }
+
+    /**
      * Load extra fields into xPDO map
      * This ensures dynamic columns added via Object Extension are available
      */
@@ -238,7 +260,7 @@ class OrdersController
         $status = $order->getOne('Status');
         $delivery = $order->getOne('Delivery');
         $payment = $order->getOne('Payment');
-        $address = $this->modx->getObject(msOrderAddress::class, ['order_id' => $id]);
+        $address = $order->getOne('Address');
 
         $data = $order->toArray();
         $data['status_name'] = $status ? $status->get('name') : '';
@@ -252,17 +274,10 @@ class OrdersController
             $data[$fieldKey] = $order->get($fieldKey);
         }
 
-        // Load all address fields dynamically
-        if ($address) {
-            $addressData = $address->toArray();
-            // Exclude system fields that should not be exposed
-            $excludeFields = ['id', 'order_id', 'createdon', 'updatedon'];
-            foreach ($addressData as $key => $value) {
-                if (!in_array($key, $excludeFields)) {
-                    $data[$key] = $value;
-                }
-            }
+        // Merge address fields (excluding conflicting keys like properties)
+        $data = $this->mergeAddressIntoOrderData($data, $address);
 
+        if ($address) {
             // Load extra fields for msOrderAddress (stored as real DB columns)
             $addressExtraFields = $this->getExtraFieldKeys('MiniShop3\\Model\\msOrderAddress');
             foreach ($addressExtraFields as $fieldKey) {
@@ -530,7 +545,7 @@ class OrdersController
 
         // Return created order with address data
         $orderData = $order->toArray();
-        $orderData = array_merge($orderData, $address->toArray());
+        $orderData = $this->mergeAddressIntoOrderData($orderData, $address);
         $orderData['customer_created'] = $createCustomer && $customerId > 0;
 
         return Response::success($this->formatOrder($orderData), 'Order draft created')->getData();
@@ -599,9 +614,7 @@ class OrdersController
 
         // Get address data
         $address = $order->getOne('Address');
-        if ($address) {
-            $orderData = array_merge($orderData, $address->toArray());
-        }
+        $orderData = $this->mergeAddressIntoOrderData($orderData, $address);
 
         return Response::success($this->formatOrder($orderData), 'ms3_order_finalized')->getData();
     }

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -64,6 +64,10 @@ class OrdersController
      *
      * msOrderAddress has its own `id`, `properties`, `createdon`, `updatedon` which
      * must not overwrite the corresponding msOrder fields in the API response.
+     *
+     * Note: extra fields for msOrderAddress are loaded separately in get() since
+     * they require explicit column reads; create()/finalize() return transient
+     * responses where the address is either empty or just created.
      */
     protected function mergeAddressIntoOrderData(array $orderData, ?\xPDO\Om\xPDOObject $address): array
     {


### PR DESCRIPTION
## Summary

- `array_merge($order->toArray(), $address->toArray())` перезаписывал `msOrder.properties` значением `null` из `msOrderAddress.properties`
- Выделен `mergeAddressIntoOrderData()` с исключением конфликтующих полей (`id`, `order_id`, `createdon`, `updatedon`, `properties`)
- Заменены все `array_merge` на новый метод в `get()`, `create()`, `finalize()`
- В `get()` заменён `getObject(msOrderAddress, ...)` на `getOne('Address')`

Closes #191

## Test plan

- [ ] Создать заказ с заполненным `ms3_orders.properties` (например, через доставку с доп. данными)
- [ ] Убедиться что `msOrderAddress.properties` = `null`
- [ ] Вызвать `GET /api/mgr/orders/{id}` — `properties` должен содержать данные заказа, а не `null`
- [ ] Проверить создание черновика заказа через manager UI
- [ ] Проверить финализацию заказа — `properties` сохраняется в ответе