### PR TITLE
feat(snippet): ms3_cart — итоги из status.total_cost и передача status в чанк

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 #### 🐛 Исправлено
 
+- **Сниппет `ms3_cart` (#197):** после `msOnGetStatusCart` итоги в чанке/`return=data` выравниваются со всеми числовыми полями статуса (`total_cost`, `total_count`, `total_weight`, `total_discount`, `total_positions`), в том числе на ранних выходах при пустой корзине; `cost_formatted`/`weight_formatted` считаются от финального `$total`; без мутации `$outputData` после сборки
 - **Manager API затирал `msOrder.properties` данными адреса (#191):** `array_merge($order->toArray(), $address->toArray())` перезаписывал `properties` заказа значением `null` из `msOrderAddress` — выделен `mergeAddressIntoOrderData()` с исключением конфликтующих полей
 - **В форме заказа manager UI показывались raw lexicon keys в списках статусов, оплат и доставок (#193):** `GET /api/mgr/model-fields/visible/msOrder` загружал только `minishop3:vue`, из-за чего `comboOptions` не переводили значения из `minishop3:default` и `minishop3:manager`; дополнительно исправлены order-form dropdown routes для статусов и активных доставок
 - **Пустая строка в decimal/int Extra Fields ломала сохранение товара (#170):** пустое значение кастомного поля (например `wholesale_price`) вызывало MySQL ошибку `Incorrect decimal value`, `save()` возвращал `false` и категории/опции/ссылки молча не сохранялись — хардкод каста `price`/`old_price`/`weight` заменён на универсальный цикл по `_fieldMeta` для всех `float`, `integer` и `boolean` полей

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -50,13 +50,45 @@ $status = $response['data']['status'];
 $products = [];
 $total = ['count' => 0, 'weight' => 0, 'cost' => 0, 'discount' => 0, 'positions' => 0];
 
+/**
+ * Overwrite snippet totals with cart status (after msOnGetStatusCart). Keys match CartItemManager::calculateStatus().
+ *
+ * If a plugin only overrides part of $status (e.g. only total_cost), line-derived total.discount may no longer
+ * match total.cost; treat matching keys in $status as canonical for header totals — row-level discount_* on products
+ * still reflect per-position math.
+ */
+$applyStatusToTotal = static function (array &$total, array $status): void {
+    $map = [
+        'total_cost' => ['cost', 'float'],
+        'total_count' => ['count', 'int'],
+        'total_weight' => ['weight', 'float'],
+        'total_discount' => ['discount', 'float'],
+        'total_positions' => ['positions', 'int'],
+    ];
+    foreach ($map as $statusKey => [$totalKey, $type]) {
+        if (!isset($status[$statusKey]) || !is_numeric($status[$statusKey])) {
+            continue;
+        }
+        $total[$totalKey] = $type === 'int' ? (int) $status[$statusKey] : (float) $status[$statusKey];
+    }
+};
+
+$formatTotalForDisplay = static function (array &$total, MiniShop3 $ms3): void {
+    $total['cost_formatted'] = $ms3->format->price($total['cost'], true);
+    $total['weight_formatted'] = $ms3->format->weightWithUnit($total['weight']);
+};
+
 if (empty($status['total_count'])) {
+    $applyStatusToTotal($total, $status);
+    $formatTotalForDisplay($total, $ms3);
     if ($scriptProperties['return'] === 'tpl') {
         return $pdoFetch->getChunk($tpl, compact('total', 'products', 'status'));
     }
     return compact('total', 'products', 'status');
 }
 if (empty($cart)) {
+    $applyStatusToTotal($total, $status);
+    $formatTotalForDisplay($total, $ms3);
     if ($scriptProperties['return'] === 'tpl') {
         return $pdoFetch->getChunk($tpl, compact('total', 'products', 'status'));
     }
@@ -192,21 +224,14 @@ foreach ($cart as $key => $entry) {
     $total['positions']++;
 }
 
+$applyStatusToTotal($total, $status);
+$formatTotalForDisplay($total, $ms3);
+
 $outputData = [
     'total' => $total,
     'products' => $products,
     'status' => $status,
 ];
-
-// Cart line sums may differ from data.status.total_cost when plugins adjust the aggregate
-// (e.g. msOnGetStatusCart). Prefer total_cost for chunk totals when it is set.
-if (isset($status['total_cost']) && is_numeric($status['total_cost'])) {
-    $outputData['total']['cost'] = (float) $status['total_cost'];
-}
-
-// Pre-formatted totals with currency/unit for display in chunks
-$outputData['total']['cost_formatted'] = $ms3->format->price($outputData['total']['cost'], true);
-$outputData['total']['weight_formatted'] = $ms3->format->weightWithUnit($outputData['total']['weight']);
 
 if ($return === 'data') {
     return $outputData;

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -52,15 +52,15 @@ $total = ['count' => 0, 'weight' => 0, 'cost' => 0, 'discount' => 0, 'positions'
 
 if (empty($status['total_count'])) {
     if ($scriptProperties['return'] === 'tpl') {
-        return $pdoFetch->getChunk($tpl, compact('total', 'products'));
+        return $pdoFetch->getChunk($tpl, compact('total', 'products', 'status'));
     }
-    return compact('total', 'products');
+    return compact('total', 'products', 'status');
 }
 if (empty($cart)) {
     if ($scriptProperties['return'] === 'tpl') {
-        return $pdoFetch->getChunk($tpl, compact('total', 'products'));
+        return $pdoFetch->getChunk($tpl, compact('total', 'products', 'status'));
     }
-    return compact('total', 'products');
+    return compact('total', 'products', 'status');
 }
 
 // Select cart products
@@ -195,11 +195,18 @@ foreach ($cart as $key => $entry) {
 $outputData = [
     'total' => $total,
     'products' => $products,
+    'status' => $status,
 ];
 
+// Cart line sums may differ from data.status.total_cost when plugins adjust the aggregate
+// (e.g. msOnGetStatusCart). Prefer total_cost for chunk totals when it is set.
+if (isset($status['total_cost']) && is_numeric($status['total_cost'])) {
+    $outputData['total']['cost'] = (float) $status['total_cost'];
+}
+
 // Pre-formatted totals with currency/unit for display in chunks
-$outputData['total']['cost_formatted'] = $ms3->format->price($total['cost'], true);
-$outputData['total']['weight_formatted'] = $ms3->format->weightWithUnit($total['weight']);
+$outputData['total']['cost_formatted'] = $ms3->format->price($outputData['total']['cost'], true);
+$outputData['total']['weight_formatted'] = $ms3->format->weightWithUnit($outputData['total']['weight']);
 
 if ($return === 'data') {
     return $outputData;


### PR DESCRIPTION
## Описание

Сниппет `ms3_cart` после события `msOnGetStatusCart` может получать в `$data['status']` агрегаты (`total_cost`, `total_count` и т.д.), уже скорректированные плагинами. При этом сумма по строкам корзины (`$total['cost']` из позиций) не всегда совпадает с этим итогом.

Изменения:

1. **Итоги для чанка и `return=data`:** если в `status` есть числовой `total_cost`, в `total.cost` подставляется именно он, а `cost_formatted` пересчитывается от этого значения. Так подпись «к оплате» в Fenom-чанке совпадает с тем, что отдаёт `Cart::get()` после плагинов.
2. **Данные для шаблона:** в ранние выходы (пустой статус / пустая корзина) и в основной `$outputData` добавлена передача **`status`**, чтобы в чанке `ms3_cart` (и при `return=data`) были доступны те же поля статуса, что и при полной корзине — без дублирования запросов к API корзины.

### Зачем это нужно

- Плагины на `msOnGetStatusCart` часто меняют **итоговую сумму** (скидки, округления, доставка в превью и т.п.). Раньше чанк мог показывать сумму по строкам, а `Cart::get()` — уже «официальный» `total_cost` из статуса; поведение расходилось.
- Шаблоны корзины иногда должны вывести **`{$status.total_cost}`**, флаги доставки или текст из статуса — без полного набора `status` в Fenom это было невозможно на пустой корзине.

### Как использовать

**Fenom (чанк корзины, `&return=`tpl``):**

- Итог к оплате: `{$total.cost}` / `{$total.cost_formatted}` — после правки это согласовано с `status.total_cost`, если он числовой.
- Доступ к статусу в любом сценарии: `{$status.total_cost}`, `{$status.total_count}`, и т.д. (структура та же, что в `$data['status']` у сниппета).

**JSON / `&return=`data``:**

- В массиве ответа есть ключ **`status`** рядом с `total` и `products`.
- Для интеграций с фронтом используйте `total.cost` как основной итог для отображения, если полагаетесь на плагины статуса.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

NA

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Обратная совместимость: для чанков добавился ключ `status` в плейсхолдеры; старые шаблоны, которые его не используют, не ломаются.