### PR TITLE
fix: DynamicField для формы вендора, поддержка extra fields

### DIFF
--- a/core/components/minishop3/controllers/mgr/settings.class.php
+++ b/core/components/minishop3/controllers/mgr/settings.class.php
@@ -42,6 +42,7 @@ class MiniShop3MgrSettingsManagerController extends msManagerController
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         // Vue shared components CSS
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/FileBrowser.min.css');
+        $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/DynamicField.min.css');
 
         // Vue Grids CSS
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/deliveries.min.css');

--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -64,6 +64,7 @@ class msProductUpdateManagerController extends msResourceUpdateController
         // Product Tabs Vue module (contains Properties, Gallery, Categories, Links, Options tabs)
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/product-tabs.min.css');
+        $this->addCss($assetsUrl . 'css/mgr/vue-dist/DynamicField.min.css');
         $this->addVueModule($assetsUrl . 'js/mgr/vue-dist/product-tabs.min.js');
 
         $show_gallery = $this->getOption('ms3_product_tab_gallery', null, true);

--- a/core/components/minishop3/src/Controllers/Api/Manager/VendorsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/VendorsController.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Controllers\Api\Manager;
 
+use MiniShop3\Model\msExtraField;
 use MiniShop3\Model\msVendor;
 use MiniShop3\Router\Response;
 use MODX\Revolution\modX;
@@ -18,9 +19,58 @@ class VendorsController
 {
     protected modX $modx;
 
+    /** @var string[] Cached extra field keys for msVendor */
+    protected array $extraFieldKeys = [];
+
     public function __construct(modX $modx)
     {
         $this->modx = $modx;
+        $this->loadExtraFieldsMap();
+        $this->extraFieldKeys = $this->getExtraFieldKeys();
+    }
+
+    /**
+     * Load extra fields into xPDO map
+     */
+    protected function loadExtraFieldsMap(): void
+    {
+        $ms3 = $this->modx->services->get('ms3');
+        if ($ms3) {
+            $ms3->loadMap();
+        }
+    }
+
+    /**
+     * Get active extra field keys for msVendor
+     *
+     * @return string[]
+     */
+    protected function getExtraFieldKeys(): array
+    {
+        $keys = [];
+        $query = $this->modx->newQuery(msExtraField::class);
+        $query->where([
+            'class' => 'MiniShop3\\Model\\msVendor',
+            'active' => true,
+        ]);
+
+        foreach ($this->modx->getIterator(msExtraField::class, $query) as $field) {
+            $keys[] = $field->get('key');
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Get allowed fields for create/update including extra fields
+     *
+     * @return string[]
+     */
+    protected function getAllowedFields(): array
+    {
+        $baseFields = ['name', 'description', 'country', 'logo', 'address', 'phone', 'email', 'resource_id', 'position', 'properties'];
+
+        return array_merge($baseFields, $this->extraFieldKeys);
     }
 
     /**
@@ -113,7 +163,7 @@ class VendorsController
 
         $vendor = $this->modx->newObject(msVendor::class);
 
-        $allowedFields = ['name', 'description', 'country', 'logo', 'address', 'phone', 'email', 'resource_id', 'position', 'properties'];
+        $allowedFields = $this->getAllowedFields();
 
         foreach ($allowedFields as $field) {
             if (isset($data[$field])) {
@@ -149,7 +199,7 @@ class VendorsController
             return Response::error('Vendor not found', 404)->getData();
         }
 
-        $allowedFields = ['name', 'description', 'country', 'logo', 'address', 'phone', 'email', 'resource_id', 'position', 'properties'];
+        $allowedFields = $this->getAllowedFields();
 
         foreach ($allowedFields as $field) {
             if (isset($data[$field])) {
@@ -282,19 +332,11 @@ class VendorsController
      */
     protected function formatVendor(msVendor $vendor): array
     {
-        return [
-            'id' => $vendor->get('id'),
-            'name' => $vendor->get('name'),
-            'description' => $vendor->get('description'),
-            'country' => $vendor->get('country'),
-            'logo' => $vendor->get('logo'),
-            'address' => $vendor->get('address'),
-            'phone' => $vendor->get('phone'),
-            'email' => $vendor->get('email'),
-            'resource_id' => $vendor->get('resource_id'),
-            'position' => $vendor->get('position'),
-            'pagetitle' => $vendor->get('pagetitle'),
-            'properties' => $vendor->get('properties'),
-        ];
+        $data = $vendor->toArray();
+
+        // pagetitle comes from JOIN, not from msVendor fields
+        $data['pagetitle'] = $vendor->get('pagetitle');
+
+        return $data;
     }
 }

--- a/core/components/minishop3/src/Services/ExtraFieldsService.php
+++ b/core/components/minishop3/src/Services/ExtraFieldsService.php
@@ -63,7 +63,10 @@ class ExtraFieldsService
         $this->extraFieldsUtil->loadMap();
         $this->extraFieldsUtil->clearCache();
 
-        $this->createProductFieldFromExtra($field);
+        // Only create msProductField for product-related models
+        if ($field->get('class') === 'MiniShop3\\Model\\msProductData') {
+            $this->createProductFieldFromExtra($field);
+        }
 
         return [
             'success' => true,
@@ -102,7 +105,10 @@ class ExtraFieldsService
         @unlink($migrationFile);
         $this->modx->log(modX::LOG_LEVEL_INFO, "[ExtraFieldsService] Migration file deleted: " . basename($migrationFile));
 
-        $this->deleteProductFieldsByName($field->get('key'));
+        // Only delete msProductField for product-related models
+        if ($field->get('class') === 'MiniShop3\\Model\\msProductData') {
+            $this->deleteProductFieldsByName($field->get('key'));
+        }
 
         $field->remove();
 
@@ -300,7 +306,10 @@ class ExtraFieldsService
             return ['success' => false, 'message' => 'Failed to update field in database'];
         }
 
-        $this->updateProductFieldFromExtra($field);
+        // Only update msProductField for product-related models
+        if ($field->get('class') === 'MiniShop3\\Model\\msProductData') {
+            $this->updateProductFieldFromExtra($field);
+        }
 
         $this->extraFieldsUtil->clearCache();
 

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -3,8 +3,9 @@
     <!-- Text field -->
     <InputText
       v-if="fieldConfig.xtype === 'textfield'"
-      :id="fieldConfig.id"
+      :id="fieldHtmlId"
       v-model="localValue"
+      class="w-full"
       :name="fieldConfig.name"
       :placeholder="fieldConfig.placeholder"
       :disabled="disabled"
@@ -15,8 +16,10 @@
     <!-- Number field -->
     <InputNumber
       v-else-if="fieldConfig.xtype === 'numberfield'"
-      :id="fieldConfig.id"
       v-model="localValue"
+      :input-id="fieldHtmlId"
+      class="w-full"
+      fluid
       :name="fieldConfig.name"
       :placeholder="fieldConfig.placeholder"
       :disabled="disabled"
@@ -37,7 +40,7 @@
     <div v-else-if="fieldConfig.xtype === 'xcheckbox' || fieldConfig.xtype === 'checkbox'">
       <Checkbox
         v-model="localValue"
-        :input-id="fieldConfig.name"
+        :input-id="fieldHtmlId"
         :disabled="disabled"
         :binary="true"
         :true-value="fieldConfig.inputValue ?? 1"
@@ -52,7 +55,7 @@
     <ToggleSwitch
       v-else-if="fieldConfig.xtype === 'switch'"
       v-model="localValue"
-      :input-id="fieldConfig.id"
+      :input-id="fieldHtmlId"
       :disabled="disabled"
       :true-value="fieldConfig.props?.trueValue ?? true"
       :false-value="fieldConfig.props?.falseValue ?? false"
@@ -62,8 +65,9 @@
     <!-- Textarea -->
     <Textarea
       v-else-if="fieldConfig.xtype === 'textarea'"
-      :id="fieldConfig.id"
+      :id="fieldHtmlId"
       v-model="localValue"
+      class="w-full"
       :name="fieldConfig.name"
       :placeholder="fieldConfig.placeholder"
       :disabled="disabled"
@@ -75,8 +79,9 @@
     <!-- Combobox / Select -->
     <Select
       v-else-if="fieldConfig.xtype === 'combobox'"
-      :id="fieldConfig.id"
+      :id="fieldHtmlId"
       v-model="localValue"
+      class="w-full"
       :options="fieldConfig.props?.options ?? []"
       :option-label="fieldConfig.props?.optionLabel ?? 'label'"
       :option-value="fieldConfig.props?.optionValue ?? 'value'"
@@ -90,7 +95,8 @@
     <DatePicker
       v-else-if="fieldConfig.xtype === 'datefield'"
       v-model="localValue"
-      :input-id="fieldConfig.id"
+      class="w-full"
+      :input-id="fieldHtmlId"
       :placeholder="fieldConfig.placeholder"
       :disabled="disabled"
       show-icon
@@ -103,7 +109,7 @@
     <!-- Color picker -->
     <ColorPicker
       v-else-if="fieldConfig.xtype === 'colorpicker'"
-      :id="fieldConfig.id"
+      :id="fieldHtmlId"
       v-model="localValue"
       :disabled="disabled"
       :inline="fieldConfig.props?.inline ?? false"
@@ -114,7 +120,7 @@
     <template v-else-if="fieldConfig.xtype === 'ms3-combo-vendor'">
       <VendorCombo
         v-model="localValue"
-        :input-id="fieldConfig.name"
+        :input-id="fieldHtmlId"
         :placeholder="fieldConfig.placeholder || 'Select vendor'"
         :disabled="disabled"
         @change="handleBlur"
@@ -127,7 +133,7 @@
     <template v-else-if="fieldConfig.xtype === 'ms3-combo-autocomplete'">
       <AutocompleteCombo
         v-model="localValue"
-        :input-id="fieldConfig.name"
+        :input-id="fieldHtmlId"
         :field-name="fieldConfig.name"
         :placeholder="fieldConfig.placeholder || 'Start typing...'"
         :disabled="disabled"
@@ -141,7 +147,7 @@
     <template v-else-if="fieldConfig.xtype === 'ms3-combo-options'">
       <OptionsChips
         v-model="localValue"
-        :input-id="fieldConfig.name"
+        :input-id="fieldHtmlId"
         :option-key="fieldConfig.name"
         :placeholder="fieldConfig.placeholder || 'Add options...'"
         :disabled="disabled"
@@ -163,7 +169,7 @@
     <template v-else-if="fieldConfig.xtype === 'ms3-combo-select'">
       <Select
         v-model="localValue"
-        :input-id="fieldConfig.name"
+        :input-id="fieldHtmlId"
         :options="selectOptions"
         option-label="label"
         option-value="value"
@@ -183,6 +189,15 @@
         {{ getExtJSComboLabel(fieldConfig.xtype) }}
       </Message>
     </div>
+
+    <!-- FileBrowser for image/file fields -->
+    <FileBrowser
+      v-else-if="isFileBrowserXtype"
+      v-model="localValue"
+      :placeholder="fieldConfig.placeholder || ''"
+      :allowed-file-types="fieldConfig.config?.allowedTypes || fieldConfig.allowedFileTypes || ''"
+      :disabled="disabled"
+    />
 
     <!-- Unknown field type -->
     <div v-else class="unknown-field">
@@ -208,6 +223,7 @@ import ToggleSwitch from 'primevue/toggleswitch'
 import { computed, ref, watch } from 'vue'
 
 import AutocompleteCombo from './AutocompleteCombo.vue'
+import FileBrowser from './FileBrowser.vue'
 import OptionsChips from './OptionsChips.vue'
 import VendorCombo from './VendorCombo.vue'
 
@@ -246,6 +262,22 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+})
+
+/**
+ * Stable HTML id for label association (for/id).
+ * Prefer explicit fieldConfig.htmlId, otherwise generate from name.
+ */
+const fieldHtmlId = computed(() => {
+  return props.fieldConfig.htmlId || `vendor-field-${props.fieldConfig.name}`
+})
+
+/**
+ * Determine if field should use FileBrowser (image/file fields)
+ */
+const isFileBrowserXtype = computed(() => {
+  const xtype = props.fieldConfig.xtype?.toLowerCase()
+  return ['file', 'image', 'filebrowser', 'imagebrowser'].includes(xtype)
 })
 
 /**
@@ -356,10 +388,6 @@ const handleBlur = () => {
 
 <style scoped>
 .field-wrapper {
-  width: 100%;
-}
-
-.field-wrapper :deep(.w-full) {
   width: 100%;
 }
 

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -262,14 +262,23 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+
+  /**
+   * Prefix for generating HTML id (for label association).
+   * Each form should pass a unique prefix to avoid id collisions.
+   */
+  idPrefix: {
+    type: String,
+    default: 'df',
+  },
 })
 
 /**
  * Stable HTML id for label association (for/id).
- * Prefer explicit fieldConfig.htmlId, otherwise generate from name.
+ * Prefer explicit fieldConfig.htmlId, otherwise generate from prefix + name.
  */
 const fieldHtmlId = computed(() => {
-  return props.fieldConfig.htmlId || `vendor-field-${props.fieldConfig.name}`
+  return props.fieldConfig.htmlId || `${props.idPrefix}-field-${props.fieldConfig.name}`
 })
 
 /**

--- a/vueManager/src/components/OptionsChips.vue
+++ b/vueManager/src/components/OptionsChips.vue
@@ -234,13 +234,14 @@ onMounted(() => {
 })
 </script>
 
-<style scoped>
-.options-chips-wrapper {
+<style>
+/* Non-scoped: prevents Vite code-splitting from generating different scoped hashes per chunk */
+.vueApp .options-chips-wrapper {
   position: relative;
   width: 100%;
 }
 
-.chips-container {
+.vueApp .chips-container {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -254,17 +255,17 @@ onMounted(() => {
   transition: border-color 0.2s;
 }
 
-.chips-container:hover {
+.vueApp .chips-container:hover {
   border-color: var(--ms3-text-light);
 }
 
-.chips-container:focus-within {
+.vueApp .chips-container:focus-within {
   border-color: var(--ms3-accent-primary);
   outline: none;
   box-shadow: 0 0 0 0.2rem var(--ms3-accent-focus);
 }
 
-.chip-item {
+.vueApp .chip-item {
   display: inline-flex;
   align-items: center;
   background: var(--ms3-accent-primary);
@@ -275,11 +276,11 @@ onMounted(() => {
   white-space: nowrap;
 }
 
-.chip-text {
+.vueApp .chip-text {
   margin-right: 0.25rem;
 }
 
-.chip-remove {
+.vueApp .chip-remove {
   cursor: pointer;
   margin-left: 0.375rem;
   opacity: 0.9;
@@ -297,17 +298,17 @@ onMounted(() => {
   font-size: 0.65rem;
 }
 
-.chip-remove i {
+.vueApp .chip-remove i {
   font-size: inherit;
 }
 
-.chip-remove:hover {
+.vueApp .chip-remove:hover {
   opacity: 1;
   background: rgba(255, 255, 255, 0.4);
   transform: scale(1.15);
 }
 
-.chip-input {
+.vueApp .chip-input {
   flex: 1;
   border: none;
   outline: none;
@@ -317,12 +318,12 @@ onMounted(() => {
   background: transparent;
 }
 
-.chip-input:disabled {
+.vueApp .chip-input:disabled {
   background: var(--ms3-bg-neutral);
   cursor: not-allowed;
 }
 
-.suggestions-panel {
+.vueApp .suggestions-panel {
   position: absolute;
   top: 100%;
   left: 0;
@@ -337,13 +338,13 @@ onMounted(() => {
   box-shadow: var(--ms3-shadow-dropdown);
 }
 
-.suggestion-item {
+.vueApp .suggestion-item {
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
-.suggestion-item:hover {
+.vueApp .suggestion-item:hover {
   background: var(--ms3-bg-slate-alt);
 }
 </style>

--- a/vueManager/src/components/VendorsGrid.vue
+++ b/vueManager/src/components/VendorsGrid.vue
@@ -5,7 +5,6 @@ import Card from 'primevue/card'
 import Checkbox from 'primevue/checkbox'
 import ConfirmDialog from 'primevue/confirmdialog'
 import Dialog from 'primevue/dialog'
-import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import Paginator from 'primevue/paginator'
 import Tab from 'primevue/tab'
@@ -23,6 +22,7 @@ import draggable from 'vuedraggable'
 import { useSelection } from '../composables/useSelection.js'
 import request from '../request.js'
 import ActionsColumn from './ActionsColumn.vue'
+import DynamicField from './DynamicField.vue'
 import FileBrowser from './FileBrowser.vue'
 
 const toast = useToast()
@@ -107,26 +107,29 @@ const fieldsBySection = computed(() => {
 })
 
 /**
- * Check if field should use FileBrowser (for image/file fields)
+ * Build field config for DynamicField component.
+ * Converts legacy fields (e.g. logo) to proper xtypes.
  */
-function isFileBrowserField(field) {
-  // Logo field always uses FileBrowser
-  if (field.name === 'logo') return true
-
-  // Check xtype for file-related types
-  const fileXtypes = ['file', 'image', 'filebrowser', 'imagebrowser']
-  return fileXtypes.includes(field.xtype?.toLowerCase())
-}
-
-/**
- * Get allowed file types for FileBrowser field
- */
-function getAllowedFileTypes(field) {
-  if (field.name === 'logo') {
-    return 'jpg,jpeg,png,gif,webp,svg'
+function getDynamicFieldConfig(field) {
+  // Logo and other file fields → filebrowser xtype
+  if (
+    field.name === 'logo' ||
+    ['file', 'image', 'filebrowser', 'imagebrowser'].includes(field.xtype?.toLowerCase())
+  ) {
+    return {
+      ...field,
+      xtype: 'filebrowser',
+      allowedFileTypes:
+        field.name === 'logo' ? 'jpg,jpeg,png,gif,webp,svg' : field.config?.allowedTypes || '',
+    }
   }
-  // Default for file fields
-  return field.config?.allowedTypes || ''
+
+  // Default xtype for fields without one
+  if (!field.xtype) {
+    return { ...field, xtype: 'textfield' }
+  }
+
+  return field
 }
 
 /**
@@ -771,47 +774,15 @@ onMounted(async () => {
                         class="form-row mb-3"
                         :style="{ gridColumn: `span ${field.width || 6}` }"
                       >
-                        <label>
+                        <label :for="`vendor-field-${field.name}`">
                           {{ getFieldLabel(field) }}
                           <span v-if="isFieldRequired(field)" class="required">*</span>
                         </label>
 
-                        <!-- FileBrowser for logo and file fields -->
-                        <template v-if="isFileBrowserField(field)">
-                          <FileBrowser
-                            v-model="editingVendor[field.name]"
-                            :placeholder="field.placeholder || ''"
-                            :allowed-file-types="getAllowedFileTypes(field)"
-                          />
-                        </template>
-
-                        <!-- Textarea for text fields -->
-                        <template v-else-if="field.xtype === 'textarea'">
-                          <Textarea
-                            v-model="editingVendor[field.name]"
-                            class="w-full"
-                            :rows="3"
-                            :placeholder="field.placeholder || ''"
-                          />
-                        </template>
-
-                        <!-- Number field -->
-                        <template v-else-if="field.xtype === 'numberfield'">
-                          <InputNumber
-                            v-model="editingVendor[field.name]"
-                            class="w-full"
-                            :placeholder="field.placeholder || ''"
-                          />
-                        </template>
-
-                        <!-- Default: text field -->
-                        <template v-else>
-                          <InputText
-                            v-model="editingVendor[field.name]"
-                            class="w-full"
-                            :placeholder="field.placeholder || ''"
-                          />
-                        </template>
+                        <DynamicField
+                          v-model="editingVendor[field.name]"
+                          :field-config="getDynamicFieldConfig(field)"
+                        />
 
                         <!-- Description/help text -->
                         <small v-if="field.description_display" class="form-hint">

--- a/vueManager/src/components/VendorsGrid.vue
+++ b/vueManager/src/components/VendorsGrid.vue
@@ -782,6 +782,7 @@ onMounted(async () => {
                         <DynamicField
                           v-model="editingVendor[field.name]"
                           :field-config="getDynamicFieldConfig(field)"
+                          id-prefix="vendor"
                         />
 
                         <!-- Description/help text -->


### PR DESCRIPTION
## Summary

- **VendorsGrid**: заменена ручная цепочка `v-if` (3 типа) на компонент `DynamicField` (13+ типов полей, включая checkbox)
- **DynamicField**: добавлена поддержка FileBrowser для файловых полей, `w-full` на всех инпутах, `fluid` на InputNumber, связка label/id для accessibility
- **VendorsController**: поддержка extra fields — загрузка xPDO map, динамический allowedFields, `toArray()` в formatVendor
- **ExtraFieldsService**: создание msProductField только для msProductData (не для msVendor и других моделей)
- **OptionsChips**: стили вынесены из scoped в non-scoped с `.vueApp` префиксом (фикс несовпадения Vite scoped хешей между чанками)
- **PHP-контроллеры**: добавлен `DynamicField.min.css` в product и settings контроллеры

## Проблема

Кастомное поле msVendor с типом Checkbox отображалось как text input. Причина — VendorsGrid рендерил поля через хардкод цепочку `v-if`, поддерживая только textarea, numberfield и FileBrowser.

## Test plan

- [ ] Добавить свое поле типа Checkbox для msVendor → должно отображаться как чекбокс
- [ ] Клик по label чекбокса → переключает состояние
- [ ] Сохранить вендора с отмеченным чекбоксом → значение сохраняется и восстанавливается при перезагрузке
- [ ] Проверить что свои поля msVendor НЕ появляются в форме товара
- [ ] Проверить что chips (Цвет, Размеры) на странице товара отображаются корректно
- [ ] Проверить форму вендора: все поля растянуты на свою ширину, FileBrowser работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)