### PR TITLE
fix(product): удаление опции из товара при сохранении формы

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 #### 🐛 Исправлено
 
+- **Удалённая опция товара в админке снова появлялась после сохранения (#199):** при сохранении из полей `options-*` использовался `removeOther=false`, из‑за чего строки в `msProductOption` для ключей, которых больше нет в POST (после удаления опции в форме, в т.ч. после копирования товара), не удалялись — для явного массива опций из процессора теперь `removeOther=true`; автосинхронизация только JSON-полей по-прежнему через `saveOptions(null)` с принудительным `removeOther=false` (#153, #158)
 - **Manager API затирал `msOrder.properties` данными адреса (#191):** `array_merge($order->toArray(), $address->toArray())` перезаписывал `properties` заказа значением `null` из `msOrderAddress` — выделен `mergeAddressIntoOrderData()` с исключением конфликтующих полей
 - **В форме заказа manager UI показывались raw lexicon keys (#193):** `GET /api/mgr/model-fields/visible/msOrder` загружал только `minishop3:vue`, из-за чего `comboOptions` не переводили значения из `minishop3:default` и `minishop3:manager`; дополнительно исправлены order-form dropdown routes для статусов и активных доставок
 - **Удаление клиента из грида не работало (#179):** DELETE-запрос выполнялся только после подтверждения в диалоге, но сетевой запрос не отправлялся

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -98,13 +98,16 @@ class Create extends CreateProcessor
 
         // Save product options from options-* form fields (parsed in beforeSet)
         // Only runs when form actually contained options-* fields
+        // removeOther=true: POST is the full set of options from the form — keys missing after removal must be
+        // deleted from DB (#199). JSON-only sync uses saveOptions(null) in msProductData::save() →
+        // removeOther=false (#153, #158)
         $options = $this->getProperty('options');
         if (!empty($options) && is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                $service->saveOptions($productData, $options, false);
+                $service->saveOptions($productData, $options, true);
             }
         }
 

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -109,14 +109,16 @@ class Update extends UpdateProcessor
 
         // Save product options from options-* form fields (parsed in beforeSet)
         // Only runs when form actually contained options-* fields
-        // removeOther=false: JSON-based options (color, size) are saved separately via msProductData::save()
+        // removeOther=true: POST contains the full set of options shown on the form — keys missing after
+        // user removal must be deleted from DB (see #199). JSON-only sync still uses saveOptions(null)
+        // in msProductData::save(), which forces removeOther=false (#153, #158).
         $options = $this->getProperty('options');
         if (!empty($options) && is_array($options)) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                $service->saveOptions($productData, $options, false);
+                $service->saveOptions($productData, $options, true);
             }
         }
 

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -121,8 +121,11 @@ class ProductDataService
      * via msProductOption::saveProductOptions() method
      *
      * @param msProductData $productData
-     * @param array|null $options Options to save (if null - collected from JSON fields)
-     * @param bool $removeOther Remove options not in $options array (default true for JSON fields, false for custom options)
+     * @param array|null $options If null: built from non-empty JSON fields on $productData only. If array: explicit
+     *                           keys/values (e.g. manager POST options-*); then $removeOther is honored.
+     * @param bool $removeOther When $options is non-null: if true, delete msProductOption rows whose keys are absent
+     *                         from $options. When $options is null: ignored — always treated as false so category-only
+     *                         options not mirrored in JSON fields are preserved (#153, #158).
      * @return void
      */
     public function saveOptions(msProductData $productData, ?array $options = null, bool $removeOther = true): void


### PR DESCRIPTION
## Описание

При сохранении товара в менеджере опции из POST (`options-*`) синхронизировались с `removeOther=false`, поэтому строки в `msProductOption` для ключей, которых больше нет в отправленной форме (после удаления опции пользователем, в том числе после копирования товара), не удалялись и снова появлялись после перезагрузки.

Вызовы `saveOptions` из процессоров `Product/Create` и `Product/Update` переведены на `removeOther=true`. Путь `saveOptions(null)` из `msProductData::save()` не менялся: при автосборе только JSON-полей по-прежнему принудительно `removeOther=false`, чтобы не повторить регрессию #153/#158 (кастомные опции категорий).

Дополнительно уточнён PHPDoc `ProductDataService::saveOptions()` и комментарии в процессорах.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #199

## Как это было протестировано?

Локально не запускалось в этом PR; рекомендуется проверить сценарий: копирование товара → удаление опции на вкладке опций → сохранение → перезагрузка карточки — опция не должна возвращаться. Дополнительно — сохранение товара с опциями только из категории (не в JSON), без открытия полной формы опций, чтобы убедиться в отсутствии регрессии #153.

- [ ] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3:
- MODX:
- PHP:

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Ревьюеру: сравнить с логикой `OptionSyncService::removeUnusedOptions` и принудительным `removeOther=false` в `ProductDataService` при `options === null`.
