### PR TITLE
chore(release): v1.10.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,32 +19,38 @@
 
 ### 🚀 Версия 1.10.0-beta1
 
-**Тип релиза:** MINOR (beta) — полный перевод управления опциями с ExtJS на Vue
+**Тип релиза:** MINOR (beta) — полный перевод управления опциями с ExtJS на Vue, рефакторинг карточки заказа, self-heal миграция
 
 ---
 
 #### ✨ Добавлено
 
-**Управление опциями товара полностью на Vue (несколько PR):**
+**Управление опциями товара полностью на Vue (#205, в т.ч. #200, #203):**
 - `Настройки → Опции` — грид (DataTable), дерево категорий MODX (`PrimeVue Tree`) с независимыми чекбоксами и контекстным меню (обновить / развернуть / свернуть / выделить все вложенные / снять все), диалог создания-редактирования с формой и деревом категорий для привязки, редактор значений для `combobox` / `comboMultiple` / `comboColors` (drag-drop сортировка через `vuedraggable`, `PrimeVue ColorPicker` для цветов)
 - `Категория товара → вкладка Опции` — Vue-грид привязок: drag-drop сортировка (`rowReorder`), inline-редактор поля «Значение по умолчанию», массовые действия (активировать / деактивировать / обязательная / необязательная / удалить), диалоги «Добавить опцию» и «Копировать опции из другой категории»
-- `Карточка товара → вкладка Опции товара` — универсальный рендер всех 10 типов (textfield, numberfield, textarea, checkbox, comboBoolean, combobox, comboMultiple, comboColors, comboOptions, datefield); `comboOptions` работает как чипы (PrimeVue `InputChips`) с автодобавлением по Enter / запятой / blur
+- `Карточка товара → вкладка Опции товара` — универсальный рендер всех 10 типов (textfield, numberfield, textarea, checkbox, comboBoolean, combobox, comboMultiple, comboColors, comboOptions, datefield); `comboOptions` работает как чипы (PrimeVue `InputChips`) с автодобавлением по Enter / запятой / blur + клик-подсказки под полем из `/api/mgr/options/suggestions`
+- Per-category caption/description override в `ms3_category_options` (#200): при непустом значении показывается вместо глобального `msOption.caption/description` и на витрине, и в админке; inline-редактор в гриде категории + поля в диалоге «Добавить опцию»; пакетная подгрузка без N+1 для `loadForProducts`
 - REST API `/api/mgr/options/*` и `/api/mgr/categories/{id}/options/*` заменил legacy `Processors/Settings/Option/*` и `Processors/Category/Option/*`
-- Decl. schema API в `msOptionType::getSchema()` — backend отдаёт декларативное описание типа вместо ExtJS JS-строк
+- Декларативный schema API в `msOptionType::getSchema()` — backend отдаёт декларативное описание типа вместо ExtJS JS-строк
+
+**Self-heal миграция `msOrder` / `msOrderAddress` (#201):** если seed `ms3_model_fields` / `ms3_model_field_sections` частично не применился (админка показывала `ms3_model_fields_empty`), миграция `20260420120000_repair_order_model_fields_if_missing` добавляет только отсутствующие записи — пользовательские настройки секций/ширин не затирает (update ограничен `WHERE section_id IS NULL`).
 
 #### ♻️ Рефакторинг
 
-- Удалены 7 ExtJS-файлов (`settings/option/*`, `category/option.*`) и 22 PHP-процессора (~2600 строк устаревшего кода)
+- **Опции:** удалены 7 ExtJS-файлов (`settings/option/*`, `category/option.*`) и 22 PHP-процессора (~2600 строк устаревшего кода)
+- **Карточка заказа — provide/inject вместо props-цепочки (#196, #204):** `provide(ORDER_CONTEXT_KEY)` в `OrderView`, composables `useOrderFormatters`, `useOrderFieldHelpers`, `useOrderLogFormatters`; вкладки получают только специфичные данные через props; безопасный `inject` до деструктуризации
 - `OptionLoaderService::convertPreloadedValue` — case-insensitive матч типов; multi-значения теперь корректно восстанавливаются при reload для `comboMultiple`, `comboColors`, `comboOptions` (раньше возвращалось только первое)
 - Multi-value опции товара отправляются одним hidden input с JSON-массивом + декодирование на сервере через `Utils::decodeOptionValue()` — обход ограничения `ExtJS BasicForm.getValues()`, который читал только последний input при нескольких hidden с одинаковым name
 - `ProductTabs.vue` — вкладка опций больше не монтирует `Ext.create('modx-vtabs')` + `ms3.utils.getExtField()`, всё рендерится Vue-компонентом `ProductOptionsTab` с вертикальными группами по `modcategory_id`
 
 #### 🐛 Исправлено
 
+- **Удалённая опция товара снова появлялась после сохранения (#199, #202):** при сохранении из полей `options-*` теперь используется `removeOther=true` — ключи, которых нет в POST (после ручного удаления или копирования), удаляются из `msProductOption`. Автосинхронизация только JSON-полей по-прежнему через `saveOptions(null)` с принудительным `removeOther=false`, чтобы не повторить регрессию #153/#158.
 - Checkbox-опции товара `boolean`/`modx-combo-boolean`/`combo-boolean` отображались узкой полоской («V\|») при `labelAlign: 'top'` — регрессия `anchor: '25%'` из `ms3.utils.js`; старый путь удалён вместе с ExtJS UI, опции теперь рендерятся через PrimeVue
-- Дерево категорий в старом ExtJS-диалоге опций выводило все resource'ы и ориентировалось на `isfolder` — в Vue-дереве фильтр `class_key LIKE '%msCategory'` и leaf по `COUNT(Child.id)`
+- Дерево категорий в старом ExtJS-диалоге опций выводило все resource'ы и ориентировалось на `isfolder` — в Vue-дереве точный фильтр `class_key = MiniShop3\\Model\\msCategory` и leaf по `COUNT(Child.id)`
 - Множественный выбор в `comboMultiple`/`comboColors` в старом коде терял все значения кроме последнего при сохранении товара
 - `modcategory_id` опции можно очистить (null коэрсится в 0, поле больше не обязательно)
+- DatePicker для `datefield` отправлял UTC-сдвиг (`toISOString()` давал дату на день раньше в TZ восточнее UTC) — теперь формат через `getFullYear/getMonth/getDate`
 
 ---
 

--- a/core/components/minishop3/docs/changelog.txt
+++ b/core/components/minishop3/docs/changelog.txt
@@ -8,24 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.10.0-beta1]
 
 ### Added
-- Full Vue migration of product options management (Settings → Options, Category → Options tab, Product → Options tab) replacing the legacy ExtJS UI.
+- Full Vue migration of product options management (Settings → Options, Category → Options tab, Product → Options tab) replacing the legacy ExtJS UI (#205).
 - REST API for options: `/api/mgr/options` (CRUD + tree, types, modcategories, suggestions, bulk assign/delete) and `/api/mgr/categories/{id}/options` (CRUD + sort + bulk + duplicate from another category).
 - Settings → Options Vue screen: DataTable grid, MODX category tree (PrimeVue Tree) with independent checkboxes and context menu (refresh, expand/collapse subtree, select/clear all), create/edit dialog with category assignment tree and values editor for combobox/comboMultiple/comboColors (drag-drop sort, PrimeVue ColorPicker).
 - Category → Options Vue tab: link grid with drag-drop reorder, inline default-value editor, bulk activate/deactivate/require/unrequire/remove, `Add option` and `Copy from category` dialogs.
-- Product → Options Vue tab: universal ProductOptionField that renders all 10 option types; comboOptions now uses PrimeVue InputChips (Enter / comma / blur commit) with a `/api/mgr/options/suggestions` backend endpoint for other-product value reuse.
-- `msOptionType::getSchema()` — declarative schema API replacing ExtJS JS-string output; option_fields now ship both legacy `ext_field` and new `schema`.
+- Product → Options Vue tab: universal ProductOptionField that renders all 10 option types; comboOptions uses PrimeVue InputChips (Enter / comma / blur commit) with a suggestions strip below the field powered by `/api/mgr/options/suggestions`.
+- Per-category caption/description override on `ms3_category_options` (#200): non-empty override wins over the global `msOption.caption/description` both in the storefront overlay and the admin. Inline-editable column in the category options grid + fields in the Add Option dialog. Batch prefetch avoids N+1 for `loadForProducts`.
+- `msOptionType::getSchema()` — declarative schema API replacing ExtJS JS-string output; option_fields ship both legacy `ext_field` and new `schema`.
+- Self-heal migration `20260420120000_repair_order_model_fields_if_missing` (#201): if `SeedModelFields` / `SeedModelFieldSections` did not fully complete (admin showed `ms3_model_fields_empty`), the migration re-seeds only the missing `msOrder` / `msOrderAddress` records. User customizations are preserved — the update is guarded by `WHERE section_id IS NULL`.
 
 ### Refactored
 - Deleted 7 ExtJS UI files (settings/option/* + category/option.*) and 22 PHP processors (Settings/Option, Category/Option), ~2600 lines of legacy code.
+- Order edit screen: provide/inject instead of props chain (#196, #204). `ORDER_CONTEXT_KEY` symbol provides the shared ref/action/helpers set to all tabs; composables `useOrderFormatters`, `useOrderFieldHelpers`, `useOrderLogFormatters` extract what used to be inline helpers. Tabs receive only tab-specific data via props.
 - Product form multi-value option POST: single hidden JSON field instead of `name[]` siblings (ExtJS BasicForm.getValues() only kept the last DOM match, silently dropping extras). Server-side decoding via `Utils::decodeOptionValue()` in `Processors\\Product\\Update` and `Processors\\Product\\Create`.
 - `OptionLoaderService::convertPreloadedValue()` match is now case-insensitive and covers all three multi-value types (comboMultiple, comboColors, comboOptions) — previously only strict `ComboMultiple` matched, truncating reloaded arrays to their first value.
 
 ### Fixed
-- Checkbox-type options on the product form no longer render as a 25%-wide sliver on top-aligned labels (the root cause, `anchor: '25%'` in legacy ms3.utils.js, is gone along with the ExtJS UI).
-- Category tree in the options dialog no longer lists non-category resources; filters by `class_key LIKE '%msCategory'` and uses an accurate COUNT-based leaf flag instead of `isfolder`.
-- Independent checkboxes in category tree: selecting/deselecting a parent no longer cascades to children (PrimeVue Tree's default propagation was replaced by a custom checkbox render).
+- Removed product option reappeared on save (#199, #202): `removeOther=true` is now used for the explicit options array from the form POST so keys absent after deletion/copy are removed from `msProductOption`. JSON-only auto-sync still forces `removeOther=false` to preserve category-only options (regression guard for #153/#158).
+- Checkbox-type options on the product form no longer render as a 25%-wide sliver on top-aligned labels (root cause `anchor: '25%'` in legacy ms3.utils.js is gone along with the ExtJS UI).
+- Category tree in the options dialog no longer lists non-category resources; filters by `class_key = MiniShop3\\Model\\msCategory` (exact) and uses an accurate COUNT-based leaf flag instead of `isfolder`.
+- Independent checkboxes in category tree: selecting/deselecting a parent no longer cascades to children (PrimeVue Tree's default propagation replaced by a custom checkbox render).
 - Optional `modcategory_id` on option create/update (null/empty payload is coerced to 0 for the NOT NULL column).
-- Dialog styles now apply in teleported PrimeVue Dialog markup (class='ms3-option-dialog vueApp' on the dialog root + .ms3-option-dialog-scoped selectors).
+- Dialog styles now apply in teleported PrimeVue Dialog markup (class='ms3-option-dialog vueApp' on the dialog root + .ms3-option-dialog scoped selectors).
+- DatePicker for `datefield` no longer sends a day-early value — `toISOString()` (UTC) replaced by local `getFullYear/getMonth/getDate` when serializing into the hidden POST field.
 
 ## [1.9.0-beta1]
 


### PR DESCRIPTION
## Summary

Релиз 1.10.0-beta1. Дополняет CHANGELOG записями за всё, что вмерджено после тега `v1.9.0-beta1`, а не только рефакторинг опций:

- **#205** — полный Vue-рефакторинг управления опциями (включает смысл #200 / #203)
- **#200** — per-category caption/description override (через #205)
- **#199 / #202** — удалённая опция больше не возвращается при сохранении
- **#196 / #204** — refactor карточки заказа (provide/inject, composables)
- **#201** — self-heal миграция `msOrder` / `msOrderAddress`
- TZ-фикс DatePicker в форме опций товара (часть #205)

Версия в `_build/config.inc.php` и `src/MiniShop3.php` уже на `1.10.0-beta1` (поднята в рамках #205 коммитом `0f7e064`) — отдельного bump'а нет.

## Test plan

- [ ] После мержа PR поставить тег `v1.10.0-beta1`, GitHub Actions выпустит релиз
- [ ] Ручное тестирование в админке: настройки опций, категория→опции, карточка товара, заказ (после всех merge'ов уже проверено по ходу)