### PR TITLE
fix(manager): invoke msOrderProduct lifecycle events in Manager API

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -2,8 +2,6 @@
 
 namespace MiniShop3\Controllers\Api\Manager;
 
-use MiniShop3\Services\Order\OrderLogService;
-use MiniShop3\Services\Order\OrderStatusService;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msExtraField;
@@ -14,11 +12,13 @@ use MiniShop3\Model\msOrderLog;
 use MiniShop3\Model\msOrderStatus;
 use MiniShop3\Model\msPayment;
 use MiniShop3\Router\Response;
-use MiniShop3\Utils\Utils;
-use MODX\Revolution\modSystemEvent;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
 use MiniShop3\Services\FilterConfigManager;
+use MiniShop3\Services\Order\OrderLogService;
+use MiniShop3\Services\Order\OrderStatusService;
+use MiniShop3\Utils\Utils;
+use MODX\Revolution\modSystemEvent;
 use MODX\Revolution\modSystemSetting;
 use MODX\Revolution\modX;
 
@@ -27,9 +27,11 @@ use MODX\Revolution\modX;
  *
  * Handles CRUD operations for orders in admin panel.
  *
- * Order line items: msOnCreateOrderProduct, msOnUpdateOrderProduct, msOnRemoveOrderProduct run after
- * save/remove; a failing "after" plugin cannot roll back persistence — veto or validation belongs in the
- * matching msOnBefore* handlers or by mutating the object in before-hooks.
+ * Order line items: msOnCreateOrderProduct, msOnUpdateOrderProduct, msOnRemoveOrderProduct run AFTER
+ * save/remove. A failing "after" plugin cannot roll back persistence; we therefore log its error
+ * but never propagate a 4xx response to the client — that would mislead the user into thinking
+ * the action failed when in fact the row is already in DB. Veto or validation belongs in the
+ * matching msOnBefore* handlers, which DO short-circuit with an HTTP error before persistence.
  *
  * @package MiniShop3\Controllers\Api\Manager
  */
@@ -37,6 +39,7 @@ class OrdersController
 {
     protected modX $modx;
     protected ?OrderLogService $orderLog = null;
+    protected ?Utils $ms3Utils = null;
 
     public function __construct(modX $modx)
     {
@@ -70,10 +73,13 @@ class OrdersController
      */
     protected function getMs3Utils(): Utils
     {
-        /** @var MiniShop3 $ms3 */
-        $ms3 = $this->modx->services->get('ms3');
+        if ($this->ms3Utils === null) {
+            /** @var MiniShop3 $ms3 */
+            $ms3 = $this->modx->services->get('ms3');
+            $this->ms3Utils = $ms3->utils;
+        }
 
-        return $ms3->utils;
+        return $this->ms3Utils;
     }
 
     /**
@@ -952,6 +958,7 @@ class OrdersController
 
         $eventContext = [
             'mode' => modSystemEvent::MODE_NEW,
+            // 'object' — MS2-style alias, 'msOrderProduct' — MS3-style; both point at the same row
             'object' => $orderProduct,
             'msOrderProduct' => $orderProduct,
             'msOrder' => $order,
@@ -966,9 +973,15 @@ class OrdersController
             return Response::error('Failed to add product to order', 500)->getData();
         }
 
+        // After-event: row already persisted, a plugin error cannot roll it back. Log and continue
+        // so the client doesn't get a 4xx for a request that actually succeeded server-side.
         $response = $this->getMs3Utils()->invokeEvent('msOnCreateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[ms3] msOnCreateOrderProduct after-plugin reported error (persistence already done): '
+                . $response['message']
+            );
         }
 
         // Log product addition
@@ -1087,6 +1100,7 @@ class OrdersController
 
         $eventContext = [
             'mode' => modSystemEvent::MODE_UPD,
+            // 'object' — MS2-style alias, 'msOrderProduct' — MS3-style; both point at the same row
             'object' => $orderProduct,
             'msOrderProduct' => $orderProduct,
             'msOrder' => $order,
@@ -1101,9 +1115,15 @@ class OrdersController
             return Response::error('Failed to update order product', 500)->getData();
         }
 
+        // After-event: row already persisted, a plugin error cannot roll it back. Log and continue
+        // so the client doesn't get a 4xx for a request that actually succeeded server-side.
         $response = $this->getMs3Utils()->invokeEvent('msOnUpdateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[ms3] msOnUpdateOrderProduct after-plugin reported error (persistence already done): '
+                . $response['message']
+            );
         }
 
         // Log product update if there were changes
@@ -1178,6 +1198,7 @@ class OrdersController
 
         $eventContext = [
             'id' => $orderProduct->get('id'),
+            // 'object' — MS2-style alias, 'msOrderProduct' — MS3-style; both point at the same row
             'object' => $orderProduct,
             'msOrderProduct' => $orderProduct,
             'msOrder' => $order,
@@ -1192,9 +1213,15 @@ class OrdersController
             return Response::error('Failed to delete order product', 500)->getData();
         }
 
+        // After-event: row already removed, a plugin error cannot roll it back. Log and continue
+        // so the client doesn't get a 4xx for a request that actually succeeded server-side.
         $response = $this->getMs3Utils()->invokeEvent('msOnRemoveOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[ms3] msOnRemoveOrderProduct after-plugin reported error (persistence already done): '
+                . $response['message']
+            );
         }
 
         // Log product removal

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -14,6 +14,8 @@ use MiniShop3\Model\msOrderLog;
 use MiniShop3\Model\msOrderStatus;
 use MiniShop3\Model\msPayment;
 use MiniShop3\Router\Response;
+use MiniShop3\Utils\Utils;
+use MODX\Revolution\modSystemEvent;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
 use MiniShop3\Services\FilterConfigManager;
@@ -24,6 +26,10 @@ use MODX\Revolution\modX;
  * API controller for order management (Manager API)
  *
  * Handles CRUD operations for orders in admin panel.
+ *
+ * Order line items: msOnCreateOrderProduct, msOnUpdateOrderProduct, msOnRemoveOrderProduct run after
+ * save/remove; a failing "after" plugin cannot roll back persistence — veto or validation belongs in the
+ * matching msOnBefore* handlers or by mutating the object in before-hooks.
  *
  * @package MiniShop3\Controllers\Api\Manager
  */
@@ -57,6 +63,17 @@ class OrdersController
             }
         }
         return $this->orderLog;
+    }
+
+    /**
+     * @return Utils MiniShop3 utils (invokeEvent with success/message handling)
+     */
+    protected function getMs3Utils(): Utils
+    {
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+
+        return $ms3->utils;
     }
 
     /**
@@ -933,8 +950,25 @@ class OrdersController
         $orderProduct->set('cost', $count * $price);
         $orderProduct->set('options', !empty($options) ? json_encode($options) : null);
 
+        $eventContext = [
+            'mode' => modSystemEvent::MODE_NEW,
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeCreateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->save()) {
             return Response::error('Failed to add product to order', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnCreateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product addition
@@ -1051,8 +1085,25 @@ class OrdersController
             $changes['cost'] = ['old' => $oldValues['cost'], 'new' => $newCost];
         }
 
+        $eventContext = [
+            'mode' => modSystemEvent::MODE_UPD,
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeUpdateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->save()) {
             return Response::error('Failed to update order product', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnUpdateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product update if there were changes
@@ -1125,8 +1176,25 @@ class OrdersController
             'cost' => $orderProduct->get('cost'),
         ];
 
+        $eventContext = [
+            'id' => $orderProduct->get('id'),
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeRemoveOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->remove()) {
             return Response::error('Failed to delete order product', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnRemoveOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product removal


### PR DESCRIPTION
## Описание

В Manager API (`OrdersController::addProduct`, `updateProduct`, `deleteProduct`) добавлены вызовы событий жизненного цикла позиции заказа через `Utils::invokeEvent`, как в legacy-процессорах: `msOnBeforeCreateOrderProduct` / `msOnCreateOrderProduct`, `msOnBeforeUpdateOrderProduct` / `msOnUpdateOrderProduct`, `msOnBeforeRemoveOrderProduct` / `msOnRemoveOrderProduct`. В `scriptProperties` передаётся `object` (и данные заказа там, где это требуется для совместимости с подписчиками). Так сторонние плагины (скидки, промо, ERP и т.д.) снова срабатывают при редактировании состава заказа во Vue-админке.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #207

## Как это было протестировано?

Проверена цепочка вызовов событий по коду; сравнение с `Processors/Order/Product/*` для формата `scriptProperties`. Рекомендуется ручная проверка с плагином, подписанным на `msOnCreateOrderProduct` / `msOnUpdateOrderProduct` / `msOnRemoveOrderProduct`.

- [ ] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.10.0+
- MODX: 3.x
- PHP: 8.3+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

`msOn*OrderProduct` после успешного `save()` / `remove()` не откатывают БД при ошибке в подписчике — это соответствует поведению MODX `invokeEvent`; уточнено в docblock.
