### PR TITLE
refactor(api): HttpStatus and Response HTTP_* constants

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -85,7 +85,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $alias = $params['alias'] ?? '';
 
             if (empty($alias)) {
-                return Response::error('Model alias is required', 400);
+                return Response::error('Model alias is required', Response::HTTP_BAD_REQUEST);
             }
 
             try {
@@ -95,7 +95,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 $modelClass = $fieldConfigManager->getModelClassByAlias($alias);
 
                 if (!$modelClass) {
-                    return Response::error("Model alias not found: {$alias}", 404);
+                    return Response::error("Model alias not found: {$alias}", Response::HTTP_NOT_FOUND);
                 }
 
                 $fields = $fieldConfigManager->getModelFields($modelClass);
@@ -107,7 +107,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 ]);
             } catch (\Exception $e) {
                 $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[FieldConfigManager] ' . $e->getMessage());
-                return Response::error('Failed to load model fields: ' . $e->getMessage(), 500);
+                return Response::error('Failed to load model fields: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         });
 
@@ -177,20 +177,20 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 ]);
             } catch (\Exception $e) {
                 $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to load extra fields: ' . $e->getMessage(), 500);
+                return Response::error('Failed to load extra fields: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         });
         $router->get('/{id}', function($params) use ($modx) {
             $id = (int)($params['id'] ?? 0);
 
             if (!$id) {
-                return Response::error('Field ID is required', 400);
+                return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST);
             }
 
             $field = $modx->getObject(\MiniShop3\Model\msExtraField::class, $id);
 
             if (!$field) {
-                return Response::error('Field not found', 404);
+                return Response::error('Field not found', Response::HTTP_NOT_FOUND);
             }
 
             $data = $field->toArray();
@@ -205,7 +205,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 $data = json_decode(file_get_contents('php://input'), true);
 
                 if (empty($data)) {
-                    return Response::error('Request body is empty', 400);
+                    return Response::error('Request body is empty', Response::HTTP_BAD_REQUEST);
                 }
 
                 /** @var \MiniShop3\Services\ExtraFieldsService $service */
@@ -214,7 +214,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 $result = $service->createField($data);
 
                 if (!$result['success']) {
-                    return Response::error($result['message'], 400);
+                    return Response::error($result['message'], Response::HTTP_BAD_REQUEST);
                 }
 
                 return Response::success([
@@ -224,21 +224,21 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 ]);
             } catch (\Exception $e) {
                 $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to create field: ' . $e->getMessage(), 500);
+                return Response::error('Failed to create field: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         });
         $router->put('/{id}', function($params) use ($modx) {
             $id = (int)($params['id'] ?? 0);
 
             if (!$id) {
-                return Response::error('Field ID is required', 400);
+                return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST);
             }
 
             try {
                 $data = json_decode(file_get_contents('php://input'), true);
 
                 if (empty($data)) {
-                    return Response::error('Request body is empty', 400);
+                    return Response::error('Request body is empty', Response::HTTP_BAD_REQUEST);
                 }
 
                 /** @var \MiniShop3\Services\ExtraFieldsService $service */
@@ -247,7 +247,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 $result = $service->updateField($id, $data);
 
                 if (!$result['success']) {
-                    return Response::error($result['message'], 400);
+                    return Response::error($result['message'], Response::HTTP_BAD_REQUEST);
                 }
 
                 return Response::success([
@@ -256,14 +256,14 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 ]);
             } catch (\Exception $e) {
                 $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to update field: ' . $e->getMessage(), 500);
+                return Response::error('Failed to update field: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         });
         $router->delete('/{id}', function($params) use ($modx) {
             $id = (int)($params['id'] ?? 0);
 
             if (!$id) {
-                return Response::error('Field ID is required', 400);
+                return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST);
             }
 
             try {
@@ -273,7 +273,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 $result = $service->deleteField($id);
 
                 if (!$result['success']) {
-                    return Response::error($result['message'], 400);
+                    return Response::error($result['message'], Response::HTTP_BAD_REQUEST);
                 }
 
                 return Response::success([
@@ -282,7 +282,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
                 ]);
             } catch (\Exception $e) {
                 $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to delete field: ' . $e->getMessage(), 500);
+                return Response::error('Failed to delete field: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         });
 

--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -149,7 +149,7 @@ $router->group('/api/v1', function($router) use ($modx, $tokenMiddleware) {
             );
 
             if ($response->isError()) {
-                return Response::error($response->getMessage(), 400);
+                return Response::error($response->getMessage(), Response::HTTP_BAD_REQUEST);
             }
 
             return Response::success($response->getObject(), $response->getMessage());
@@ -178,7 +178,7 @@ $router->group('/api/v1', function($router) use ($modx, $tokenMiddleware) {
             );
 
             if ($response->isError()) {
-                return Response::error($response->getMessage(), 400);
+                return Response::error($response->getMessage(), Response::HTTP_BAD_REQUEST);
             }
 
             return Response::success($response->getObject(), $response->getMessage());

--- a/core/components/minishop3/config/routes_manager.custom.example.php
+++ b/core/components/minishop3/config/routes_manager.custom.example.php
@@ -55,7 +55,7 @@ use MiniShop3\Router\Response;
 //
 //     $resource = $modx->getObject('modResource', $id);
 //     if (!$resource) {
-//         return Response::error('Resource not found', 404);
+//         return Response::error('Resource not found', Response::HTTP_NOT_FOUND);
 //     }
 //
 //     return Response::success(['resource' => $resource->toArray()]);

--- a/core/components/minishop3/src/Controllers/Api/ConfigController.php
+++ b/core/components/minishop3/src/Controllers/Api/ConfigController.php
@@ -21,7 +21,7 @@ class ConfigController extends BaseApiController
         $pageKey = $params['page_key'] ?? '';
 
         if (empty($pageKey)) {
-            return Response::error('Page key is required', 400);
+            return Response::error('Page key is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -33,7 +33,7 @@ class ConfigController extends BaseApiController
             return Response::success($config);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to load config: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load config: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -49,7 +49,7 @@ class ConfigController extends BaseApiController
         $pageKey = $params['page_key'] ?? '';
 
         if (empty($pageKey)) {
-            return Response::error('Page key is required', 400);
+            return Response::error('Page key is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -61,7 +61,7 @@ class ConfigController extends BaseApiController
             return Response::success($result);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to load fields: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load fields: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -77,13 +77,13 @@ class ConfigController extends BaseApiController
         $pageKey = $params['page_key'] ?? '';
 
         if (empty($pageKey)) {
-            return Response::error('Page key is required', 400);
+            return Response::error('Page key is required', Response::HTTP_BAD_REQUEST);
         }
 
         $data = $this->getRequestData();
 
         if (!isset($data['fields']) || !is_array($data['fields'])) {
-            return Response::error('Fields array is required', 400);
+            return Response::error('Fields array is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -97,11 +97,11 @@ class ConfigController extends BaseApiController
                     'message' => 'Configuration saved successfully',
                 ]);
             } else{
-                return Response::error('Failed to save configuration', 500);
+                return Response::error('Failed to save configuration', Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to save config: ' . $e->getMessage(), 500);
+            return Response::error('Failed to save config: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -119,7 +119,7 @@ class ConfigController extends BaseApiController
         $fieldName = $params['field_name'] ?? '';
 
         if (empty($pageKey) || empty($fieldName)) {
-            return Response::error('Page key and field name are required', 400);
+            return Response::error('Page key and field name are required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -133,11 +133,11 @@ class ConfigController extends BaseApiController
                     'message' => 'Override removed successfully',
                 ]);
             } else {
-                return Response::error('Failed to remove override', 500);
+                return Response::error('Failed to remove override', Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to remove override: ' . $e->getMessage(), 500);
+            return Response::error('Failed to remove override: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -153,7 +153,7 @@ class ConfigController extends BaseApiController
         $pageKey = $params['page_key'] ?? '';
 
         if (empty($pageKey)) {
-            return Response::error('Page key is required', 400);
+            return Response::error('Page key is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -167,7 +167,7 @@ class ConfigController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to load sections: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load sections: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -183,13 +183,13 @@ class ConfigController extends BaseApiController
         $pageKey = $params['page_key'] ?? '';
 
         if (empty($pageKey)) {
-            return Response::error('Page key is required', 400);
+            return Response::error('Page key is required', Response::HTTP_BAD_REQUEST);
         }
 
         $data = $this->getRequestData();
 
         if (!isset($data['sections']) || !is_array($data['sections'])) {
-            return Response::error('Sections array is required', 400);
+            return Response::error('Sections array is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -203,11 +203,11 @@ class ConfigController extends BaseApiController
                     'message' => 'Sections saved successfully',
                 ]);
             } else {
-                return Response::error('Failed to save sections', 500);
+                return Response::error('Failed to save sections', Response::HTTP_INTERNAL_SERVER_ERROR);
             }
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to save sections: ' . $e->getMessage(), 500);
+            return Response::error('Failed to save sections: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -224,7 +224,7 @@ class ConfigController extends BaseApiController
         $sectionKey = $params['section_key'] ?? '';
 
         if (empty($pageKey) || empty($sectionKey)) {
-            return Response::error('Page key and section key are required', 400);
+            return Response::error('Page key and section key are required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -238,11 +238,11 @@ class ConfigController extends BaseApiController
                     'message' => 'Section deleted successfully',
                 ]);
             } else {
-                return Response::error('Failed to delete section (base sections cannot be deleted)', 400);
+                return Response::error('Failed to delete section (base sections cannot be deleted)', Response::HTTP_BAD_REQUEST);
             }
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to delete section: ' . $e->getMessage(), 500);
+            return Response::error('Failed to delete section: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryOptionsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryOptionsController.php
@@ -37,7 +37,7 @@ class CategoryOptionsController
     {
         $categoryId = (int)($params['category_id'] ?? 0);
         if (!$categoryId) {
-            return Response::error('category_id is required', 400)->getData();
+            return Response::error('category_id is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $query = trim((string)($params['query'] ?? ''));
@@ -89,7 +89,7 @@ class CategoryOptionsController
         $categoryId = (int)($data['category_id'] ?? 0);
         $optionId = (int)($data['option_id'] ?? 0);
         if (!$categoryId || !$optionId) {
-            return Response::error('category_id and option_id are required', 400)->getData();
+            return Response::error('category_id and option_id are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if ($this->modx->getCount(msCategoryOption::class, ['category_id' => $categoryId, 'option_id' => $optionId]) > 0) {
@@ -109,7 +109,7 @@ class CategoryOptionsController
         );
 
         if (!$ok) {
-            return Response::error('Failed to add option to category', 500)->getData();
+            return Response::error('Failed to add option to category', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         if (!empty($data['required'])) {
@@ -139,7 +139,7 @@ class CategoryOptionsController
         $categoryId = (int)($data['category_id'] ?? 0);
         $optionId = (int)($data['option_id'] ?? 0);
         if (!$categoryId || !$optionId) {
-            return Response::error('category_id and option_id are required', 400)->getData();
+            return Response::error('category_id and option_id are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $link = $this->modx->getObject(msCategoryOption::class, [
@@ -147,7 +147,7 @@ class CategoryOptionsController
             'option_id' => $optionId,
         ]);
         if (!$link) {
-            return Response::error('Link not found', 404)->getData();
+            return Response::error('Link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowed = ['value', 'active', 'required', 'position', 'caption', 'description'];
@@ -163,7 +163,7 @@ class CategoryOptionsController
         }
 
         if (!$link->save()) {
-            return Response::error('Failed to update link', 500)->getData();
+            return Response::error('Failed to update link', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Link updated')->getData();
@@ -177,12 +177,12 @@ class CategoryOptionsController
         $categoryId = (int)($params['category_id'] ?? 0);
         $optionId = (int)($params['option_id'] ?? 0);
         if (!$categoryId || !$optionId) {
-            return Response::error('category_id and option_id are required', 400)->getData();
+            return Response::error('category_id and option_id are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ok = $this->optionService->removeOptionFromCategory($optionId, $categoryId);
         if (!$ok) {
-            return Response::error('Failed to remove link', 500)->getData();
+            return Response::error('Failed to remove link', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Link removed')->getData();
@@ -202,7 +202,7 @@ class CategoryOptionsController
             $optionIds = is_array($decoded) ? $decoded : [];
         }
         if (!$categoryId || !is_array($optionIds) || $optionIds === []) {
-            return Response::error('category_id and option_ids are required', 400)->getData();
+            return Response::error('category_id and option_ids are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $position = 0;
@@ -241,12 +241,12 @@ class CategoryOptionsController
         $optionIds = array_values(array_filter(array_map('intval', is_array($optionIds) ? $optionIds : [])));
 
         if (!$categoryId || $optionIds === []) {
-            return Response::error('category_id and option_ids are required', 400)->getData();
+            return Response::error('category_id and option_ids are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $allowedActions = ['activate', 'deactivate', 'require', 'unrequire', 'remove'];
         if (!in_array($action, $allowedActions, true)) {
-            return Response::error("Unknown action '{$action}'", 400)->getData();
+            return Response::error("Unknown action '{$action}'", Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $affected = 0;
@@ -300,16 +300,16 @@ class CategoryOptionsController
         $categoryTo = (int)($data['category_id'] ?? 0);
         $categoryFrom = (int)($data['category_from'] ?? 0);
         if (!$categoryTo || !$categoryFrom) {
-            return Response::error('category_id and category_from are required', 400)->getData();
+            return Response::error('category_id and category_from are required', Response::HTTP_BAD_REQUEST)->getData();
         }
         if ($categoryTo === $categoryFrom) {
-            return Response::error('Source and target categories must be different', 400)->getData();
+            return Response::error('Source and target categories must be different', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $fromCategory = $this->modx->getObject(msCategory::class, $categoryFrom);
         $toCategory = $this->modx->getObject(msCategory::class, $categoryTo);
         if (!$fromCategory || !$toCategory) {
-            return Response::error('Category not found', 404)->getData();
+            return Response::error('Category not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $copied = 0;

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -37,12 +37,12 @@ class CategoryProductsController
         $categoryId = (int)($params['id'] ?? 0);
 
         if (!$categoryId) {
-            return Response::error('Category ID is required', 400)->getData();
+            return Response::error('Category ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $category = $this->modx->getObject(msCategory::class, $categoryId);
         if (!$category) {
-            return Response::error('Category not found', 404)->getData();
+            return Response::error('Category not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $start = (int)($params['start'] ?? 0);
@@ -197,11 +197,11 @@ class CategoryProductsController
         $items = $params['items'] ?? [];
 
         if (!$categoryId) {
-            return Response::error('Category ID is required', 400)->getData();
+            return Response::error('Category ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (empty($items) || !is_array($items)) {
-            return Response::error('Items array is required', 400)->getData();
+            return Response::error('Items array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $updated = 0;
@@ -245,11 +245,11 @@ class CategoryProductsController
         $ids = $params['ids'] ?? [];
 
         if (empty($method)) {
-            return Response::error('Method is required', 400)->getData();
+            return Response::error('Method is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Product IDs array is required', 400)->getData();
+            return Response::error('Product IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Sanitize IDs
@@ -258,7 +258,7 @@ class CategoryProductsController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid product IDs provided', 400)->getData();
+            return Response::error('No valid product IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $success = 0;
@@ -325,7 +325,7 @@ class CategoryProductsController
         }
 
         if ($success === 0) {
-            return Response::error('No products were updated', 500)->getData();
+            return Response::error('No products were updated', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -360,13 +360,13 @@ class CategoryProductsController
         $published = isset($params['published']) ? (int)$params['published'] : null;
 
         if (!$productId) {
-            return Response::error('Product ID is required', 400)->getData();
+            return Response::error('Product ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $product = $this->modx->getObject(msProduct::class, $productId);
 
         if (!$product) {
-            return Response::error('Product not found', 404)->getData();
+            return Response::error('Product not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // If published param not provided, toggle current state
@@ -384,7 +384,7 @@ class CategoryProductsController
         }
 
         if (!$product->save()) {
-            return Response::error('Failed to update product', 500)->getData();
+            return Response::error('Failed to update product', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([

--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomerAddressesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomerAddressesController.php
@@ -33,12 +33,12 @@ class CustomerAddressesController
         $customerId = (int)($params['id'] ?? 0);
 
         if (!$customerId) {
-            return Response::error('Customer ID is required', 400)->getData();
+            return Response::error('Customer ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $customer = $this->modx->getObject(msCustomer::class, $customerId);
         if (!$customer) {
-            return Response::error('Customer not found', 404)->getData();
+            return Response::error('Customer not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $addresses = $this->modx->getIterator(msCustomerAddress::class, [
@@ -72,12 +72,12 @@ class CustomerAddressesController
         $customerId = (int)($data['customer_id'] ?? 0);
 
         if (!$customerId) {
-            return Response::error('Customer ID is required', 400)->getData();
+            return Response::error('Customer ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $customer = $this->modx->getObject(msCustomer::class, $customerId);
         if (!$customer) {
-            return Response::error('Customer not found', 404)->getData();
+            return Response::error('Customer not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         /** @var msCustomerAddress $address */
@@ -100,7 +100,7 @@ class CustomerAddressesController
         $address->set('createdon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error('Failed to create address', 500)->getData();
+            return Response::error('Failed to create address', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(
@@ -122,7 +122,7 @@ class CustomerAddressesController
         $addressId = (int)($data['id'] ?? 0);
 
         if (!$customerId || !$addressId) {
-            return Response::error('Customer ID and Address ID are required', 400)->getData();
+            return Response::error('Customer ID and Address ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -131,7 +131,7 @@ class CustomerAddressesController
         ]);
 
         if (!$address) {
-            return Response::error('Address not found', 404)->getData();
+            return Response::error('Address not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = [
@@ -149,7 +149,7 @@ class CustomerAddressesController
         $address->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error('Failed to update address', 500)->getData();
+            return Response::error('Failed to update address', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(
@@ -171,7 +171,7 @@ class CustomerAddressesController
         $addressId = (int)($params['address_id'] ?? 0);
 
         if (!$customerId || !$addressId) {
-            return Response::error('Customer ID and Address ID are required', 400)->getData();
+            return Response::error('Customer ID and Address ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -180,11 +180,11 @@ class CustomerAddressesController
         ]);
 
         if (!$address) {
-            return Response::error('Address not found', 404)->getData();
+            return Response::error('Address not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$address->remove()) {
-            return Response::error('Failed to delete address', 500)->getData();
+            return Response::error('Failed to delete address', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Address deleted successfully')->getData();

--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -130,13 +130,13 @@ class CustomersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Customer ID is required', 400)->getData();
+            return Response::error('Customer ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $customer = $this->modx->getObject(msCustomer::class, $id);
 
         if (!$customer) {
-            return Response::error('Customer not found', 404)->getData();
+            return Response::error('Customer not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatCustomer($customer))->getData();
@@ -154,13 +154,13 @@ class CustomersController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Customer ID is required', 400)->getData();
+            return Response::error('Customer ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $customer = $this->modx->getObject(msCustomer::class, $id);
 
         if (!$customer) {
-            return Response::error('Customer not found', 404)->getData();
+            return Response::error('Customer not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = ['first_name', 'last_name', 'email', 'phone', 'is_active', 'is_blocked'];
@@ -177,7 +177,7 @@ class CustomersController
         }
 
         if (!$customer->save()) {
-            return Response::error('Failed to save customer', 500)->getData();
+            return Response::error('Failed to save customer', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatCustomer($customer), 'Customer updated successfully')->getData();
@@ -195,13 +195,13 @@ class CustomersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Customer ID is required', 400)->getData();
+            return Response::error('Customer ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $customer = $this->modx->getObject(msCustomer::class, $id);
 
         if (!$customer) {
-            return Response::error('Customer not found', 404)->getData();
+            return Response::error('Customer not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $addresses = $this->modx->getIterator(\MiniShop3\Model\msCustomerAddress::class, ['customer_id' => $id]);
@@ -215,7 +215,7 @@ class CustomersController
         }
 
         if (!$customer->remove()) {
-            return Response::error('Failed to delete customer', 500)->getData();
+            return Response::error('Failed to delete customer', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Customer deleted successfully')->getData();
@@ -233,7 +233,7 @@ class CustomersController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Customer IDs array is required', 400)->getData();
+            return Response::error('Customer IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Sanitize IDs
@@ -242,7 +242,7 @@ class CustomersController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid customer IDs provided', 400)->getData();
+            return Response::error('No valid customer IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -276,7 +276,7 @@ class CustomersController
         }
 
         if ($deleted === 0) {
-            return Response::error('Failed to delete customers', 500)->getData();
+            return Response::error('Failed to delete customers', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([

--- a/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
@@ -89,13 +89,13 @@ class DeliveriesController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Delivery ID is required', 400)->getData();
+            return Response::error('Delivery ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $delivery = $this->modx->getObject(msDelivery::class, $id);
 
         if (!$delivery) {
-            return Response::error('Delivery not found', 404)->getData();
+            return Response::error('Delivery not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $data = $this->formatDelivery($delivery);
@@ -120,7 +120,7 @@ class DeliveriesController
     public function create(array $data = []): array
     {
         if (empty($data['name'])) {
-            return Response::error('Delivery name is required', 400)->getData();
+            return Response::error('Delivery name is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $delivery = $this->modx->newObject(msDelivery::class);
@@ -146,7 +146,7 @@ class DeliveriesController
         }
 
         if (!$delivery->save()) {
-            return Response::error('Failed to create delivery', 500)->getData();
+            return Response::error('Failed to create delivery', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         // Handle payments assignment
@@ -169,13 +169,13 @@ class DeliveriesController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Delivery ID is required', 400)->getData();
+            return Response::error('Delivery ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $delivery = $this->modx->getObject(msDelivery::class, $id);
 
         if (!$delivery) {
-            return Response::error('Delivery not found', 404)->getData();
+            return Response::error('Delivery not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = ['name', 'description', 'price', 'weight_price', 'distance_price',
@@ -189,7 +189,7 @@ class DeliveriesController
         }
 
         if (!$delivery->save()) {
-            return Response::error('Failed to save delivery', 500)->getData();
+            return Response::error('Failed to save delivery', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         // Handle payments assignment
@@ -212,13 +212,13 @@ class DeliveriesController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Delivery ID is required', 400)->getData();
+            return Response::error('Delivery ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $delivery = $this->modx->getObject(msDelivery::class, $id);
 
         if (!$delivery) {
-            return Response::error('Delivery not found', 404)->getData();
+            return Response::error('Delivery not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Delete related payment members
@@ -227,7 +227,7 @@ class DeliveriesController
         }
 
         if (!$delivery->remove()) {
-            return Response::error('Failed to delete delivery', 500)->getData();
+            return Response::error('Failed to delete delivery', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Delivery deleted successfully')->getData();
@@ -245,7 +245,7 @@ class DeliveriesController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Delivery IDs array is required for sorting', 400)->getData();
+            return Response::error('Delivery IDs array is required for sorting', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $position = 0;
@@ -276,7 +276,7 @@ class DeliveriesController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Delivery IDs array is required', 400)->getData();
+            return Response::error('Delivery IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ids = array_filter(array_map('intval', $ids), function ($id) {
@@ -284,7 +284,7 @@ class DeliveriesController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid delivery IDs provided', 400)->getData();
+            return Response::error('No valid delivery IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -311,7 +311,7 @@ class DeliveriesController
         }
 
         if ($deleted === 0) {
-            return Response::error('Failed to delete deliveries', 500)->getData();
+            return Response::error('Failed to delete deliveries', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -332,7 +332,7 @@ class DeliveriesController
         $positions = $data['positions'] ?? [];
 
         if (empty($positions) || !is_array($positions)) {
-            return Response::error('Positions array is required', 400)->getData();
+            return Response::error('Positions array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $updated = 0;
@@ -386,7 +386,7 @@ class DeliveriesController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Delivery ID is required', 400)->getData();
+            return Response::error('Delivery ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $results = [];
@@ -413,7 +413,7 @@ class DeliveriesController
         $paymentId = (int)($data['payment_id'] ?? 0);
 
         if (!$deliveryId || !$paymentId) {
-            return Response::error('Delivery ID and Payment ID are required', 400)->getData();
+            return Response::error('Delivery ID and Payment ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Check if relationship already exists
@@ -431,7 +431,7 @@ class DeliveriesController
         $member->set('payment_id', $paymentId);
 
         if (!$member->save()) {
-            return Response::error('Failed to add payment to delivery', 500)->getData();
+            return Response::error('Failed to add payment to delivery', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Payment added to delivery')->getData();
@@ -450,7 +450,7 @@ class DeliveriesController
         $paymentId = (int)($params['payment_id'] ?? 0);
 
         if (!$deliveryId || !$paymentId) {
-            return Response::error('Delivery ID and Payment ID are required', 400)->getData();
+            return Response::error('Delivery ID and Payment ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $member = $this->modx->getObject(msDeliveryMember::class, [
@@ -459,11 +459,11 @@ class DeliveriesController
         ]);
 
         if (!$member) {
-            return Response::error('Payment link not found', 404)->getData();
+            return Response::error('Payment link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$member->remove()) {
-            return Response::error('Failed to remove payment from delivery', 500)->getData();
+            return Response::error('Failed to remove payment from delivery', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Payment removed from delivery')->getData();

--- a/core/components/minishop3/src/Controllers/Api/Manager/LinksController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/LinksController.php
@@ -89,13 +89,13 @@ class LinksController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Link ID is required', 400)->getData();
+            return Response::error('Link ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $link = $this->modx->getObject(msLink::class, $id);
 
         if (!$link) {
-            return Response::error('Link not found', 404)->getData();
+            return Response::error('Link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatLink($link))->getData();
@@ -134,15 +134,15 @@ class LinksController
     public function create(array $data = []): array
     {
         if (empty($data['name'])) {
-            return Response::error('Link name is required', 400)->getData();
+            return Response::error('Link name is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (empty($data['type'])) {
-            return Response::error('Link type is required', 400)->getData();
+            return Response::error('Link type is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($data['type'], $this->linkTypes)) {
-            return Response::error('Invalid link type', 400)->getData();
+            return Response::error('Invalid link type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $link = $this->modx->newObject(msLink::class);
@@ -156,7 +156,7 @@ class LinksController
         }
 
         if (!$link->save()) {
-            return Response::error('Failed to create link', 500)->getData();
+            return Response::error('Failed to create link', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatLink($link), 'Link created successfully')->getData();
@@ -174,13 +174,13 @@ class LinksController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Link ID is required', 400)->getData();
+            return Response::error('Link ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $link = $this->modx->getObject(msLink::class, $id);
 
         if (!$link) {
-            return Response::error('Link not found', 404)->getData();
+            return Response::error('Link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Note: type cannot be changed after creation
@@ -193,7 +193,7 @@ class LinksController
         }
 
         if (!$link->save()) {
-            return Response::error('Failed to save link', 500)->getData();
+            return Response::error('Failed to save link', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatLink($link), 'Link updated successfully')->getData();
@@ -211,23 +211,23 @@ class LinksController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Link ID is required', 400)->getData();
+            return Response::error('Link ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $link = $this->modx->getObject(msLink::class, $id);
 
         if (!$link) {
-            return Response::error('Link not found', 404)->getData();
+            return Response::error('Link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check if link is used by products
         $usageCount = $this->modx->getCount(msProductLink::class, ['link_id' => $id]);
         if ($usageCount > 0) {
-            return Response::error("Cannot delete link: it is used by {$usageCount} product connections", 400)->getData();
+            return Response::error("Cannot delete link: it is used by {$usageCount} product connections", Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$link->remove()) {
-            return Response::error('Failed to delete link', 500)->getData();
+            return Response::error('Failed to delete link', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Link deleted successfully')->getData();
@@ -245,7 +245,7 @@ class LinksController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Link IDs array is required', 400)->getData();
+            return Response::error('Link IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ids = array_filter(array_map('intval', $ids), function ($id) {
@@ -253,7 +253,7 @@ class LinksController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid link IDs provided', 400)->getData();
+            return Response::error('No valid link IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -284,9 +284,9 @@ class LinksController
 
         if ($deleted === 0) {
             if ($inUse > 0) {
-                return Response::error("Cannot delete: {$inUse} links are in use", 400)->getData();
+                return Response::error("Cannot delete: {$inUse} links are in use", Response::HTTP_BAD_REQUEST)->getData();
             }
-            return Response::error('Failed to delete links', 500)->getData();
+            return Response::error('Failed to delete links', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([

--- a/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
@@ -106,13 +106,13 @@ class ModelFieldsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Field ID is required', 400)->getData();
+            return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $field = $this->modx->getObject(msModelField::class, $id);
 
         if (!$field) {
-            return Response::error('Field not found', 404)->getData();
+            return Response::error('Field not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatField($field))->getData();
@@ -131,11 +131,11 @@ class ModelFieldsController
         $name = $params['name'] ?? '';
 
         if (empty($model) || empty($name)) {
-            return Response::error('Model and name are required', 400)->getData();
+            return Response::error('Model and name are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Check if field already exists
@@ -145,7 +145,7 @@ class ModelFieldsController
         ]);
 
         if ($existing) {
-            return Response::error('Field with this name already exists for this model', 400)->getData();
+            return Response::error('Field with this name already exists for this model', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $field = $this->modx->newObject(msModelField::class);
@@ -165,7 +165,7 @@ class ModelFieldsController
         ]);
 
         if (!$field->save()) {
-            return Response::error('Failed to create field', 500)->getData();
+            return Response::error('Failed to create field', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatField($field), 'Field created successfully', 201)->getData();
@@ -183,13 +183,13 @@ class ModelFieldsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Field ID is required', 400)->getData();
+            return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $field = $this->modx->getObject(msModelField::class, $id);
 
         if (!$field) {
-            return Response::error('Field not found', 404)->getData();
+            return Response::error('Field not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check uniqueness if name or model changed
@@ -205,13 +205,13 @@ class ModelFieldsController
                 ]);
 
                 if ($existing) {
-                    return Response::error('Field with this name already exists for this model', 400)->getData();
+                    return Response::error('Field with this name already exists for this model', Response::HTTP_BAD_REQUEST)->getData();
                 }
             }
         }
 
         if (isset($params['model']) && !in_array($params['model'], msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $updateFields = ['model', 'name', 'label', 'xtype', 'visible', 'required', 'sort_order', 'section_id', 'width', 'placeholder', 'description', 'config'];
@@ -230,7 +230,7 @@ class ModelFieldsController
         }
 
         if (!$field->save()) {
-            return Response::error('Failed to update field', 500)->getData();
+            return Response::error('Failed to update field', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatField($field), 'Field updated successfully')->getData();
@@ -248,17 +248,17 @@ class ModelFieldsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Field ID is required', 400)->getData();
+            return Response::error('Field ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $field = $this->modx->getObject(msModelField::class, $id);
 
         if (!$field) {
-            return Response::error('Field not found', 404)->getData();
+            return Response::error('Field not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$field->remove()) {
-            return Response::error('Failed to delete field', 500)->getData();
+            return Response::error('Failed to delete field', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(null, 'Field deleted successfully')->getData();
@@ -300,11 +300,11 @@ class ModelFieldsController
         $model = $params['model'] ?? '';
 
         if (empty($model)) {
-            return Response::error('Model is required', 400)->getData();
+            return Response::error('Model is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // `comboOptions` may include status/payment/delivery names stored as lexicon keys.
@@ -396,7 +396,7 @@ class ModelFieldsController
         $ranks = $params['ranks'] ?? [];
 
         if (empty($ranks) || !is_array($ranks)) {
-            return Response::error('Ranks array is required', 400)->getData();
+            return Response::error('Ranks array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         foreach ($ranks as $item) {
@@ -505,11 +505,11 @@ class ModelFieldsController
         $model = $params['model'] ?? '';
 
         if (empty($model)) {
-            return Response::error('Model is required', 400)->getData();
+            return Response::error('Model is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelFieldSection::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $this->modx->lexicon->load('minishop3:vue');
@@ -536,11 +536,11 @@ class ModelFieldsController
         $sectionKey = $params['section_key'] ?? '';
 
         if (empty($model) || empty($sectionKey)) {
-            return Response::error('Model and section_key are required', 400)->getData();
+            return Response::error('Model and section_key are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelFieldSection::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Check if section already exists
@@ -550,7 +550,7 @@ class ModelFieldsController
         ]);
 
         if ($existing) {
-            return Response::error('Section with this key already exists for this model', 400)->getData();
+            return Response::error('Section with this key already exists for this model', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $section = $this->modx->newObject(msModelFieldSection::class);
@@ -565,7 +565,7 @@ class ModelFieldsController
         ]);
 
         if (!$section->save()) {
-            return Response::error('Failed to create section', 500)->getData();
+            return Response::error('Failed to create section', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->modx->lexicon->load('minishop3:vue');
@@ -584,13 +584,13 @@ class ModelFieldsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Section ID is required', 400)->getData();
+            return Response::error('Section ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $section = $this->modx->getObject(msModelFieldSection::class, $id);
 
         if (!$section) {
-            return Response::error('Section not found', 404)->getData();
+            return Response::error('Section not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $updateFields = ['label', 'lexicon_key', 'hidden', 'sort_order'];
@@ -607,7 +607,7 @@ class ModelFieldsController
         }
 
         if (!$section->save()) {
-            return Response::error('Failed to update section', 500)->getData();
+            return Response::error('Failed to update section', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->modx->lexicon->load('minishop3:vue');
@@ -626,18 +626,18 @@ class ModelFieldsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Section ID is required', 400)->getData();
+            return Response::error('Section ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $section = $this->modx->getObject(msModelFieldSection::class, $id);
 
         if (!$section) {
-            return Response::error('Section not found', 404)->getData();
+            return Response::error('Section not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check if it's a default section
         if ($section->get('is_default')) {
-            return Response::error('Cannot delete default section', 400)->getData();
+            return Response::error('Cannot delete default section', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Set fields in this section to null
@@ -649,7 +649,7 @@ class ModelFieldsController
         }
 
         if (!$section->remove()) {
-            return Response::error('Failed to delete section', 500)->getData();
+            return Response::error('Failed to delete section', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(null, 'Section deleted successfully')->getData();
@@ -667,7 +667,7 @@ class ModelFieldsController
         $ranks = $params['ranks'] ?? [];
 
         if (empty($ranks) || !is_array($ranks)) {
-            return Response::error('Ranks array is required', 400)->getData();
+            return Response::error('Ranks array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         foreach ($ranks as $item) {
@@ -704,11 +704,11 @@ class ModelFieldsController
         $model = $params['model'] ?? '';
 
         if (empty($model)) {
-            return Response::error('Model is required', 400)->getData();
+            return Response::error('Model is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Get fields with combo xtypes (select, combobox, dropdown, etc.)
@@ -749,11 +749,11 @@ class ModelFieldsController
         $fieldName = $params['field_name'] ?? '';
 
         if (empty($model) || empty($fieldName)) {
-            return Response::error('Model and field_name are required', 400)->getData();
+            return Response::error('Model and field_name are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', 400)->getData();
+            return Response::error('Invalid model type', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Get field from database

--- a/core/components/minishop3/src/Controllers/Api/Manager/NotificationsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/NotificationsController.php
@@ -88,13 +88,13 @@ class NotificationsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Notification config ID is required', 400)->getData();
+            return Response::error('Notification config ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $config = $this->modx->getObject(msNotificationConfig::class, $id);
 
         if (!$config) {
-            return Response::error('Notification config not found', 404)->getData();
+            return Response::error('Notification config not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatConfig($config))->getData();
@@ -112,7 +112,7 @@ class NotificationsController
         $required = ['event', 'recipient_type', 'channel'];
         foreach ($required as $field) {
             if (empty($data[$field])) {
-                return Response::error("Field '{$field}' is required", 400)->getData();
+                return Response::error("Field '{$field}' is required", Response::HTTP_BAD_REQUEST)->getData();
             }
         }
 
@@ -124,7 +124,7 @@ class NotificationsController
         ]);
 
         if ($exists) {
-            return Response::error('Notification config with this combination already exists', 400)->getData();
+            return Response::error('Notification config with this combination already exists', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         /** @var msNotificationConfig $config */
@@ -145,7 +145,7 @@ class NotificationsController
         }
 
         if (!$config->save()) {
-            return Response::error('Failed to save notification config', 500)->getData();
+            return Response::error('Failed to save notification config', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(
@@ -166,13 +166,13 @@ class NotificationsController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Notification config ID is required', 400)->getData();
+            return Response::error('Notification config ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $config = $this->modx->getObject(msNotificationConfig::class, $id);
 
         if (!$config) {
-            return Response::error('Notification config not found', 404)->getData();
+            return Response::error('Notification config not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = ['event', 'status_id', 'recipient_type', 'channel', 'enabled', 'subject', 'template', 'delay', 'position'];
@@ -205,7 +205,7 @@ class NotificationsController
         }
 
         if (!$config->save()) {
-            return Response::error('Failed to save notification config', 500)->getData();
+            return Response::error('Failed to save notification config', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success(
@@ -226,17 +226,17 @@ class NotificationsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Notification config ID is required', 400)->getData();
+            return Response::error('Notification config ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $config = $this->modx->getObject(msNotificationConfig::class, $id);
 
         if (!$config) {
-            return Response::error('Notification config not found', 404)->getData();
+            return Response::error('Notification config not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$config->remove()) {
-            return Response::error('Failed to delete notification config', 500)->getData();
+            return Response::error('Failed to delete notification config', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], $this->modx->lexicon('ms3_notification_deleted'))->getData();

--- a/core/components/minishop3/src/Controllers/Api/Manager/OptionsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OptionsController.php
@@ -96,12 +96,12 @@ class OptionsController
     {
         $id = (int)($params['id'] ?? 0);
         if (!$id) {
-            return Response::error('Option ID is required', 400)->getData();
+            return Response::error('Option ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $option = $this->modx->getObject(msOption::class, $id);
         if (!$option) {
-            return Response::error('Option not found', 404)->getData();
+            return Response::error('Option not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $data = $this->formatOption($option);
@@ -117,7 +117,7 @@ class OptionsController
     {
         $key = trim((string)($data['key'] ?? ''));
         if ($key === '') {
-            return Response::error('Option key is required', 400, ['errors' => ['key']])->getData();
+            return Response::error('Option key is required', Response::HTTP_BAD_REQUEST, ['errors' => ['key']])->getData();
         }
         $key = str_replace('.', '_', $key);
 
@@ -129,7 +129,7 @@ class OptionsController
         $this->applyWritableFields($option, array_merge($data, ['key' => $key]));
 
         if (!$option->save()) {
-            return Response::error('Failed to create option', 500)->getData();
+            return Response::error('Failed to create option', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->syncCategoriesFromPayload($option, $data['categories'] ?? null);
@@ -149,19 +149,19 @@ class OptionsController
     {
         $id = (int)($data['id'] ?? 0);
         if (!$id) {
-            return Response::error('Option ID is required', 400)->getData();
+            return Response::error('Option ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $option = $this->modx->getObject(msOption::class, $id);
         if (!$option) {
-            return Response::error('Option not found', 404)->getData();
+            return Response::error('Option not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $oldKey = $option->get('key');
         if (isset($data['key'])) {
             $newKey = str_replace('.', '_', trim((string)$data['key']));
             if ($newKey === '') {
-                return Response::error('Option key is required', 400, ['errors' => ['key']])->getData();
+                return Response::error('Option key is required', Response::HTTP_BAD_REQUEST, ['errors' => ['key']])->getData();
             }
             if ($newKey !== $oldKey
                 && $this->modx->getCount(msOption::class, ['key' => $newKey, 'id:!=' => $id]) > 0) {
@@ -173,7 +173,7 @@ class OptionsController
         $this->applyWritableFields($option, $data);
 
         if (!$option->save()) {
-            return Response::error('Failed to save option', 500)->getData();
+            return Response::error('Failed to save option', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->syncCategoriesFromPayload($option, $data['categories'] ?? null);
@@ -199,16 +199,16 @@ class OptionsController
     {
         $id = (int)($params['id'] ?? 0);
         if (!$id) {
-            return Response::error('Option ID is required', 400)->getData();
+            return Response::error('Option ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $option = $this->modx->getObject(msOption::class, $id);
         if (!$option) {
-            return Response::error('Option not found', 404)->getData();
+            return Response::error('Option not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$option->remove()) {
-            return Response::error('Failed to delete option', 500)->getData();
+            return Response::error('Failed to delete option', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Option deleted')->getData();
@@ -223,7 +223,7 @@ class OptionsController
     {
         $ids = $this->decodeIntArray($data['ids'] ?? null);
         if ($ids === []) {
-            return Response::error('No valid option IDs provided', 400)->getData();
+            return Response::error('No valid option IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -238,7 +238,7 @@ class OptionsController
         }
 
         if ($deleted === 0) {
-            return Response::error('No options were deleted', 500)->getData();
+            return Response::error('No options were deleted', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -260,7 +260,7 @@ class OptionsController
         $categoryIds = $this->decodeIntArray($data['categories'] ?? null);
 
         if ($optionIds === [] || $categoryIds === []) {
-            return Response::error('Both options and categories are required', 400)->getData();
+            return Response::error('Both options and categories are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $assigned = 0;
@@ -410,7 +410,7 @@ class OptionsController
     {
         $key = trim((string)($params['key'] ?? ''));
         if ($key === '') {
-            return Response::error('key is required', 400)->getData();
+            return Response::error('key is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $query = trim((string)($params['query'] ?? ''));

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -269,13 +269,13 @@ class OrdersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $order = $this->modx->getObject(msOrder::class, $id);
 
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $status = $order->getOne('Status');
@@ -321,13 +321,13 @@ class OrdersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $order = $this->modx->getObject(msOrder::class, $id);
 
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $addresses = $this->modx->getIterator(msOrderAddress::class, ['order_id' => $id]);
@@ -341,7 +341,7 @@ class OrdersController
         }
 
         if (!$order->remove()) {
-            return Response::error('Failed to delete order', 500)->getData();
+            return Response::error('Failed to delete order', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Order deleted successfully')->getData();
@@ -359,7 +359,7 @@ class OrdersController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Order IDs array is required', 400)->getData();
+            return Response::error('Order IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Sanitize IDs
@@ -368,7 +368,7 @@ class OrdersController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid order IDs provided', 400)->getData();
+            return Response::error('No valid order IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -408,7 +408,7 @@ class OrdersController
         }
 
         if ($deleted === 0) {
-            return Response::error('Failed to delete orders', 500)->getData();
+            return Response::error('Failed to delete orders', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -489,7 +489,7 @@ class OrdersController
                     modX::LOG_LEVEL_ERROR,
                     "[OrdersController] Failed to create customer: " . $e->getMessage()
                 );
-                return Response::error('Failed to create customer: ' . $e->getMessage(), 500)->getData();
+                return Response::error('Failed to create customer: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
             }
         }
 
@@ -530,7 +530,7 @@ class OrdersController
         $order->set('weight', 0);
 
         if (!$order->save()) {
-            return Response::error('Failed to create order', 500)->getData();
+            return Response::error('Failed to create order', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         // Create empty address
@@ -595,7 +595,7 @@ class OrdersController
     {
         $orderId = (int) ($params['id'] ?? 0);
         if (!$orderId) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $options = [
@@ -622,13 +622,13 @@ class OrdersController
                 $translatedMessage = $message;
             }
 
-            return Response::error($translatedMessage, 400, $result['data'] ?? [])->getData();
+            return Response::error($translatedMessage, Response::HTTP_BAD_REQUEST, $result['data'] ?? [])->getData();
         }
 
         // Reload order with full data
         $order = $this->modx->getObject(msOrder::class, $orderId);
         if (!$order) {
-            return Response::error('Order not found after finalization', 500)->getData();
+            return Response::error('Order not found after finalization', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $orderData = $order->toArray();
@@ -713,13 +713,13 @@ class OrdersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $order = $this->modx->getObject(msOrder::class, $id);
 
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Store old values for logging
@@ -757,7 +757,7 @@ class OrdersController
         $order->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$order->save()) {
-            return Response::error('Failed to update order', 500)->getData();
+            return Response::error('Failed to update order', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         // Log order field changes (excluding status_id which is logged separately)
@@ -851,7 +851,7 @@ class OrdersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $c = $this->modx->newQuery(\MiniShop3\Model\msOrderProduct::class);
@@ -884,29 +884,29 @@ class OrdersController
         $productId = (int)($params['product_id'] ?? 0);
 
         if (!$orderId) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$productId) {
-            return Response::error('Product ID is required', 400)->getData();
+            return Response::error('Product ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Get the order
         $order = $this->modx->getObject(msOrder::class, $orderId);
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check order status (should not be final)
         $status = $this->modx->getObject(\MiniShop3\Model\msOrderStatus::class, $order->get('status_id'));
         if ($status && $status->get('final')) {
-            return Response::error('Cannot add products to finalized order', 400)->getData();
+            return Response::error('Cannot add products to finalized order', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Get the product
         $product = $this->modx->getObject(\MiniShop3\Model\msProduct::class, $productId);
         if (!$product) {
-            return Response::error('Product not found', 404)->getData();
+            return Response::error('Product not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Get product data
@@ -959,16 +959,16 @@ class OrdersController
 
         $response = $this->getMs3Utils()->invokeEvent('msOnBeforeCreateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$orderProduct->save()) {
-            return Response::error('Failed to add product to order', 500)->getData();
+            return Response::error('Failed to add product to order', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $response = $this->getMs3Utils()->invokeEvent('msOnCreateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Log product addition
@@ -1008,7 +1008,7 @@ class OrdersController
         $productId = (int)($params['product_id'] ?? 0);
 
         if (!$orderId || !$productId) {
-            return Response::error('Order ID and Product ID are required', 400)->getData();
+            return Response::error('Order ID and Product ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Find the order product record
@@ -1018,13 +1018,13 @@ class OrdersController
         ]);
 
         if (!$orderProduct) {
-            return Response::error('Order product not found', 404)->getData();
+            return Response::error('Order product not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Get the order to recalculate totals
         $order = $this->modx->getObject(msOrder::class, $orderId);
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Store old values for logging
@@ -1071,7 +1071,7 @@ class OrdersController
         }
 
         if (!$updated) {
-            return Response::error('No fields to update', 400)->getData();
+            return Response::error('No fields to update', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Recalculate cost
@@ -1094,16 +1094,16 @@ class OrdersController
 
         $response = $this->getMs3Utils()->invokeEvent('msOnBeforeUpdateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$orderProduct->save()) {
-            return Response::error('Failed to update order product', 500)->getData();
+            return Response::error('Failed to update order product', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $response = $this->getMs3Utils()->invokeEvent('msOnUpdateOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Log product update if there were changes
@@ -1142,7 +1142,7 @@ class OrdersController
         $productId = (int)($params['product_id'] ?? 0);
 
         if (!$orderId || !$productId) {
-            return Response::error('Order ID and Product ID are required', 400)->getData();
+            return Response::error('Order ID and Product ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Find the order product record
@@ -1152,19 +1152,19 @@ class OrdersController
         ]);
 
         if (!$orderProduct) {
-            return Response::error('Order product not found', 404)->getData();
+            return Response::error('Order product not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Get the order to recalculate totals
         $order = $this->modx->getObject(msOrder::class, $orderId);
         if (!$order) {
-            return Response::error('Order not found', 404)->getData();
+            return Response::error('Order not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check if this is the last product
         $productCount = $this->modx->getCount(\MiniShop3\Model\msOrderProduct::class, ['order_id' => $orderId]);
         if ($productCount <= 1) {
-            return Response::error('Cannot delete the last product from order', 400)->getData();
+            return Response::error('Cannot delete the last product from order', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Store data for logging before removal
@@ -1185,16 +1185,16 @@ class OrdersController
 
         $response = $this->getMs3Utils()->invokeEvent('msOnBeforeRemoveOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$orderProduct->remove()) {
-            return Response::error('Failed to delete order product', 500)->getData();
+            return Response::error('Failed to delete order product', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $response = $this->getMs3Utils()->invokeEvent('msOnRemoveOrderProduct', $eventContext);
         if (!$response['success']) {
-            return Response::error($response['message'], 400)->getData();
+            return Response::error($response['message'], Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Log product removal
@@ -1258,7 +1258,7 @@ class OrdersController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Order ID is required', 400)->getData();
+            return Response::error('Order ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $c = $this->modx->newQuery(\MiniShop3\Model\msOrderLog::class);

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -14,6 +14,8 @@ use MiniShop3\Model\msOrderLog;
 use MiniShop3\Model\msOrderStatus;
 use MiniShop3\Model\msPayment;
 use MiniShop3\Router\Response;
+use MiniShop3\Utils\Utils;
+use MODX\Revolution\modSystemEvent;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
 use MiniShop3\Services\FilterConfigManager;
@@ -24,6 +26,10 @@ use MODX\Revolution\modX;
  * API controller for order management (Manager API)
  *
  * Handles CRUD operations for orders in admin panel.
+ *
+ * Order line items: msOnCreateOrderProduct, msOnUpdateOrderProduct, msOnRemoveOrderProduct run after
+ * save/remove; a failing "after" plugin cannot roll back persistence — veto or validation belongs in the
+ * matching msOnBefore* handlers or by mutating the object in before-hooks.
  *
  * @package MiniShop3\Controllers\Api\Manager
  */
@@ -57,6 +63,17 @@ class OrdersController
             }
         }
         return $this->orderLog;
+    }
+
+    /**
+     * @return Utils MiniShop3 utils (invokeEvent with success/message handling)
+     */
+    protected function getMs3Utils(): Utils
+    {
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+
+        return $ms3->utils;
     }
 
     /**
@@ -933,8 +950,25 @@ class OrdersController
         $orderProduct->set('cost', $count * $price);
         $orderProduct->set('options', !empty($options) ? json_encode($options) : null);
 
+        $eventContext = [
+            'mode' => modSystemEvent::MODE_NEW,
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeCreateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->save()) {
             return Response::error('Failed to add product to order', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnCreateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product addition
@@ -1051,8 +1085,25 @@ class OrdersController
             $changes['cost'] = ['old' => $oldValues['cost'], 'new' => $newCost];
         }
 
+        $eventContext = [
+            'mode' => modSystemEvent::MODE_UPD,
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeUpdateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->save()) {
             return Response::error('Failed to update order product', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnUpdateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product update if there were changes
@@ -1125,8 +1176,25 @@ class OrdersController
             'cost' => $orderProduct->get('cost'),
         ];
 
+        $eventContext = [
+            'id' => $orderProduct->get('id'),
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+        ];
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnBeforeRemoveOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
+        }
+
         if (!$orderProduct->remove()) {
             return Response::error('Failed to delete order product', 500)->getData();
+        }
+
+        $response = $this->getMs3Utils()->invokeEvent('msOnRemoveOrderProduct', $eventContext);
+        if (!$response['success']) {
+            return Response::error($response['message'], 400)->getData();
         }
 
         // Log product removal

--- a/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
@@ -91,13 +91,13 @@ class PaymentsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Payment ID is required', 400)->getData();
+            return Response::error('Payment ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $payment = $this->modx->getObject(msPayment::class, $id);
 
         if (!$payment) {
-            return Response::error('Payment not found', 404)->getData();
+            return Response::error('Payment not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatPayment($payment))->getData();
@@ -113,7 +113,7 @@ class PaymentsController
     public function create(array $data = []): array
     {
         if (empty($data['name'])) {
-            return Response::error('Payment name is required', 400)->getData();
+            return Response::error('Payment name is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $payment = $this->modx->newObject(msPayment::class);
@@ -140,7 +140,7 @@ class PaymentsController
         }
 
         if (!$payment->save()) {
-            return Response::error('Failed to create payment', 500)->getData();
+            return Response::error('Failed to create payment', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatPayment($payment), 'Payment created successfully')->getData();
@@ -158,13 +158,13 @@ class PaymentsController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Payment ID is required', 400)->getData();
+            return Response::error('Payment ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $payment = $this->modx->getObject(msPayment::class, $id);
 
         if (!$payment) {
-            return Response::error('Payment not found', 404)->getData();
+            return Response::error('Payment not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = ['name', 'description', 'price', 'logo', 'position', 'active', 'class', 'properties'];
@@ -176,7 +176,7 @@ class PaymentsController
         }
 
         if (!$payment->save()) {
-            return Response::error('Failed to save payment', 500)->getData();
+            return Response::error('Failed to save payment', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatPayment($payment), 'Payment updated successfully')->getData();
@@ -194,13 +194,13 @@ class PaymentsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Payment ID is required', 400)->getData();
+            return Response::error('Payment ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $payment = $this->modx->getObject(msPayment::class, $id);
 
         if (!$payment) {
-            return Response::error('Payment not found', 404)->getData();
+            return Response::error('Payment not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Delete related delivery members
@@ -209,7 +209,7 @@ class PaymentsController
         }
 
         if (!$payment->remove()) {
-            return Response::error('Failed to delete payment', 500)->getData();
+            return Response::error('Failed to delete payment', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Payment deleted successfully')->getData();
@@ -227,7 +227,7 @@ class PaymentsController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Payment IDs array is required for sorting', 400)->getData();
+            return Response::error('Payment IDs array is required for sorting', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $position = 0;
@@ -258,7 +258,7 @@ class PaymentsController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Payment IDs array is required', 400)->getData();
+            return Response::error('Payment IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ids = array_filter(array_map('intval', $ids), function ($id) {
@@ -266,7 +266,7 @@ class PaymentsController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid payment IDs provided', 400)->getData();
+            return Response::error('No valid payment IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -293,7 +293,7 @@ class PaymentsController
         }
 
         if ($deleted === 0) {
-            return Response::error('Failed to delete payments', 500)->getData();
+            return Response::error('Failed to delete payments', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -314,7 +314,7 @@ class PaymentsController
         $positions = $data['positions'] ?? [];
 
         if (empty($positions) || !is_array($positions)) {
-            return Response::error('Positions array is required', 400)->getData();
+            return Response::error('Positions array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $updated = 0;
@@ -364,7 +364,7 @@ class PaymentsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Payment ID is required', 400)->getData();
+            return Response::error('Payment ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $results = [];
@@ -391,7 +391,7 @@ class PaymentsController
         $deliveryId = (int)($data['delivery_id'] ?? 0);
 
         if (!$paymentId || !$deliveryId) {
-            return Response::error('Payment ID and Delivery ID are required', 400)->getData();
+            return Response::error('Payment ID and Delivery ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Check if relationship already exists
@@ -409,7 +409,7 @@ class PaymentsController
         $member->set('payment_id', $paymentId);
 
         if (!$member->save()) {
-            return Response::error('Failed to add delivery to payment', 500)->getData();
+            return Response::error('Failed to add delivery to payment', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Delivery added to payment')->getData();
@@ -428,7 +428,7 @@ class PaymentsController
         $deliveryId = (int)($params['delivery_id'] ?? 0);
 
         if (!$paymentId || !$deliveryId) {
-            return Response::error('Payment ID and Delivery ID are required', 400)->getData();
+            return Response::error('Payment ID and Delivery ID are required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $member = $this->modx->getObject(msDeliveryMember::class, [
@@ -437,11 +437,11 @@ class PaymentsController
         ]);
 
         if (!$member) {
-            return Response::error('Delivery link not found', 404)->getData();
+            return Response::error('Delivery link not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$member->remove()) {
-            return Response::error('Failed to remove delivery from payment', 500)->getData();
+            return Response::error('Failed to remove delivery from payment', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Delivery removed from payment')->getData();

--- a/core/components/minishop3/src/Controllers/Api/Manager/StatusesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/StatusesController.php
@@ -78,13 +78,13 @@ class StatusesController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Status ID is required', 400)->getData();
+            return Response::error('Status ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $status = $this->modx->getObject(msOrderStatus::class, $id);
 
         if (!$status) {
-            return Response::error('Status not found', 404)->getData();
+            return Response::error('Status not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatStatus($status))->getData();
@@ -100,7 +100,7 @@ class StatusesController
     public function create(array $data = []): array
     {
         if (empty($data['name'])) {
-            return Response::error('Status name is required', 400)->getData();
+            return Response::error('Status name is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         // Get max position for new status
@@ -131,7 +131,7 @@ class StatusesController
         $status->set('position', $maxPosition + 1);
 
         if (!$status->save()) {
-            return Response::error('Failed to create status', 500)->getData();
+            return Response::error('Failed to create status', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatStatus($status), 'Status created successfully')->getData();
@@ -149,13 +149,13 @@ class StatusesController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Status ID is required', 400)->getData();
+            return Response::error('Status ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $status = $this->modx->getObject(msOrderStatus::class, $id);
 
         if (!$status) {
-            return Response::error('Status not found', 404)->getData();
+            return Response::error('Status not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = ['name', 'description', 'color', 'active', 'final', 'fixed', 'editable'];
@@ -172,7 +172,7 @@ class StatusesController
         }
 
         if (!$status->save()) {
-            return Response::error('Failed to save status', 500)->getData();
+            return Response::error('Failed to save status', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatStatus($status), 'Status updated successfully')->getData();
@@ -190,23 +190,23 @@ class StatusesController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Status ID is required', 400)->getData();
+            return Response::error('Status ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $status = $this->modx->getObject(msOrderStatus::class, $id);
 
         if (!$status) {
-            return Response::error('Status not found', 404)->getData();
+            return Response::error('Status not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         // Check if status is used by orders
         $ordersCount = $this->modx->getCount('MiniShop3\\Model\\msOrder', ['status_id' => $id]);
         if ($ordersCount > 0) {
-            return Response::error("Cannot delete status: {$ordersCount} orders are using it", 400)->getData();
+            return Response::error("Cannot delete status: {$ordersCount} orders are using it", Response::HTTP_BAD_REQUEST)->getData();
         }
 
         if (!$status->remove()) {
-            return Response::error('Failed to delete status', 500)->getData();
+            return Response::error('Failed to delete status', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Status deleted successfully')->getData();
@@ -224,7 +224,7 @@ class StatusesController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Status IDs array is required', 400)->getData();
+            return Response::error('Status IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ids = array_filter(array_map('intval', $ids), function ($id) {
@@ -232,7 +232,7 @@ class StatusesController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid status IDs provided', 400)->getData();
+            return Response::error('No valid status IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -263,9 +263,9 @@ class StatusesController
 
         if ($deleted === 0) {
             if ($inUse > 0) {
-                return Response::error("Cannot delete: {$inUse} statuses are in use by orders", 400)->getData();
+                return Response::error("Cannot delete: {$inUse} statuses are in use by orders", Response::HTTP_BAD_REQUEST)->getData();
             }
-            return Response::error('Failed to delete statuses', 500)->getData();
+            return Response::error('Failed to delete statuses', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([
@@ -287,7 +287,7 @@ class StatusesController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Status IDs array is required for sorting', 400)->getData();
+            return Response::error('Status IDs array is required for sorting', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $position = 0;

--- a/core/components/minishop3/src/Controllers/Api/Manager/VendorsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/VendorsController.php
@@ -136,13 +136,13 @@ class VendorsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Vendor ID is required', 400)->getData();
+            return Response::error('Vendor ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $vendor = $this->modx->getObject(msVendor::class, $id);
 
         if (!$vendor) {
-            return Response::error('Vendor not found', 404)->getData();
+            return Response::error('Vendor not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatVendor($vendor))->getData();
@@ -158,7 +158,7 @@ class VendorsController
     public function create(array $data = []): array
     {
         if (empty($data['name'])) {
-            return Response::error('Vendor name is required', 400)->getData();
+            return Response::error('Vendor name is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $vendor = $this->modx->newObject(msVendor::class);
@@ -172,7 +172,7 @@ class VendorsController
         }
 
         if (!$vendor->save()) {
-            return Response::error('Failed to create vendor', 500)->getData();
+            return Response::error('Failed to create vendor', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatVendor($vendor), 'Vendor created successfully')->getData();
@@ -190,13 +190,13 @@ class VendorsController
         $id = (int)($data['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Vendor ID is required', 400)->getData();
+            return Response::error('Vendor ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $vendor = $this->modx->getObject(msVendor::class, $id);
 
         if (!$vendor) {
-            return Response::error('Vendor not found', 404)->getData();
+            return Response::error('Vendor not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         $allowedFields = $this->getAllowedFields();
@@ -208,7 +208,7 @@ class VendorsController
         }
 
         if (!$vendor->save()) {
-            return Response::error('Failed to save vendor', 500)->getData();
+            return Response::error('Failed to save vendor', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success($this->formatVendor($vendor), 'Vendor updated successfully')->getData();
@@ -226,17 +226,17 @@ class VendorsController
         $id = (int)($params['id'] ?? 0);
 
         if (!$id) {
-            return Response::error('Vendor ID is required', 400)->getData();
+            return Response::error('Vendor ID is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $vendor = $this->modx->getObject(msVendor::class, $id);
 
         if (!$vendor) {
-            return Response::error('Vendor not found', 404)->getData();
+            return Response::error('Vendor not found', Response::HTTP_NOT_FOUND)->getData();
         }
 
         if (!$vendor->remove()) {
-            return Response::error('Failed to delete vendor', 500)->getData();
+            return Response::error('Failed to delete vendor', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([], 'Vendor deleted successfully')->getData();
@@ -254,7 +254,7 @@ class VendorsController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Vendor IDs array is required for sorting', 400)->getData();
+            return Response::error('Vendor IDs array is required for sorting', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $position = 0;
@@ -285,7 +285,7 @@ class VendorsController
         $ids = $data['ids'] ?? [];
 
         if (empty($ids) || !is_array($ids)) {
-            return Response::error('Vendor IDs array is required', 400)->getData();
+            return Response::error('Vendor IDs array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ids = array_filter(array_map('intval', $ids), function ($id) {
@@ -293,7 +293,7 @@ class VendorsController
         });
 
         if (empty($ids)) {
-            return Response::error('No valid vendor IDs provided', 400)->getData();
+            return Response::error('No valid vendor IDs provided', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $deleted = 0;
@@ -315,7 +315,7 @@ class VendorsController
         }
 
         if ($deleted === 0) {
-            return Response::error('Failed to delete vendors', 500)->getData();
+            return Response::error('Failed to delete vendors', Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         return Response::success([

--- a/core/components/minishop3/src/Controllers/Api/ProductDataController.php
+++ b/core/components/minishop3/src/Controllers/Api/ProductDataController.php
@@ -21,7 +21,7 @@ class ProductDataController extends BaseApiController
         $productId = (int)($params['id'] ?? 0);
 
         if (!$productId) {
-            return Response::error('Product ID is required', 400);
+            return Response::error('Product ID is required', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -31,13 +31,13 @@ class ProductDataController extends BaseApiController
             $data = $productDataService->getProductData($productId);
 
             if (!$data) {
-                return Response::error('Product data not found', 404);
+                return Response::error('Product data not found', Response::HTTP_NOT_FOUND);
             }
 
             return Response::success($data);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ProductDataController] ' . $e->getMessage());
-            return Response::error('Failed to load product data: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load product data: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -53,13 +53,13 @@ class ProductDataController extends BaseApiController
         $productId = (int)($params['id'] ?? 0);
 
         if (!$productId) {
-            return Response::error('Product ID is required', 400);
+            return Response::error('Product ID is required', Response::HTTP_BAD_REQUEST);
         }
 
         $data = $this->getRequestData();
 
         if (!$data) {
-            return Response::error('Invalid request data', 400);
+            return Response::error('Invalid request data', Response::HTTP_BAD_REQUEST);
         }
 
         try {
@@ -77,7 +77,7 @@ class ProductDataController extends BaseApiController
             return Response::error($message, $code);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ProductDataController] ' . $e->getMessage());
-            return Response::error('Failed to save product data: ' . $e->getMessage(), 500);
+            return Response::error('Failed to save product data: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/ReferencesController.php
+++ b/core/components/minishop3/src/Controllers/Api/ReferencesController.php
@@ -49,7 +49,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to load vendors: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load vendors: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -67,18 +67,18 @@ class ReferencesController extends BaseApiController
             $searchQuery = $_GET['query'] ?? null;
 
             if (empty($fieldName)) {
-                return Response::error('Field name is required', 400);
+                return Response::error('Field name is required', Response::HTTP_BAD_REQUEST);
             }
 
             $modelMeta = $this->modx->getFields('MiniShop3\\Model\\msProductData');
             if (!isset($modelMeta[$fieldName])) {
-                return Response::error("Field '{$fieldName}' not found in msProductData", 400);
+                return Response::error("Field '{$fieldName}' not found in msProductData", Response::HTTP_BAD_REQUEST);
             }
 
             $tableName = $this->modx->getTableName('MiniShop3\\Model\\msProductData');
 
             if (!preg_match('/^[a-zA-Z0-9_]+$/', $fieldName)) {
-                return Response::error("Invalid field name", 400);
+                return Response::error("Invalid field name", Response::HTTP_BAD_REQUEST);
             }
 
             $sql = "SELECT DISTINCT `{$fieldName}` as `value`
@@ -127,7 +127,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to load autocomplete: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load autocomplete: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -146,7 +146,7 @@ class ReferencesController extends BaseApiController
             $exclude = isset($_GET['exclude']) ? json_decode($_GET['exclude'], true) : [];
 
             if (empty($key)) {
-                return Response::error('Option key is required', 400);
+                return Response::error('Option key is required', Response::HTTP_BAD_REQUEST);
             }
 
             $key = preg_replace('#^options-#', '', $key);
@@ -200,7 +200,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to load options: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load options: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -251,7 +251,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to load product option fields: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load product option fields: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -270,16 +270,16 @@ class ReferencesController extends BaseApiController
             $searchQuery = $_GET['query'] ?? null;
 
             if (empty($fieldName)) {
-                return Response::error('Field name is required', 400);
+                return Response::error('Field name is required', Response::HTTP_BAD_REQUEST);
             }
 
             if (empty($productId)) {
-                return Response::error('Product ID is required', 400);
+                return Response::error('Product ID is required', Response::HTTP_BAD_REQUEST);
             }
 
             // Validate field name (alphanumeric and underscore only)
             if (!preg_match('/^[a-zA-Z0-9_]+$/', $fieldName)) {
-                return Response::error('Invalid field name', 400);
+                return Response::error('Invalid field name', Response::HTTP_BAD_REQUEST);
             }
 
             // Known option fields in msProductData
@@ -292,7 +292,7 @@ class ReferencesController extends BaseApiController
             ]);
 
             if (!in_array($fieldName, $allowedFields) && !$customField) {
-                return Response::error("Field '{$fieldName}' is not available for options", 400);
+                return Response::error("Field '{$fieldName}' is not available for options", Response::HTTP_BAD_REQUEST);
             }
 
             $tableName = $this->modx->getTableName('MiniShop3\\Model\\msProductData');
@@ -363,7 +363,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to load field values: ' . $e->getMessage(), 500);
+            return Response::error('Failed to load field values: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -450,7 +450,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to search products: ' . $e->getMessage(), 500);
+            return Response::error('Failed to search products: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -538,7 +538,7 @@ class ReferencesController extends BaseApiController
             ]);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ReferencesController] ' . $e->getMessage());
-            return Response::error('Failed to search customers: ' . $e->getMessage(), 500);
+            return Response::error('Failed to search customers: ' . $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CartController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CartController.php
@@ -71,7 +71,7 @@ class CartController
         }
 
         if (empty($product_key)) {
-            return Response::error('Product key is required', 400)->getData();
+            return Response::error('Product key is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -102,7 +102,7 @@ class CartController
         }
 
         if (empty($product_key)) {
-            return Response::error('Product key is required', 400)->getData();
+            return Response::error('Product key is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -203,7 +203,7 @@ class CartController
         if ($result['success']) {
             return Response::success($result['data'], $result['message'] ?? '')->getData();
         } else {
-            return Response::error($result['message'] ?? 'Unknown error', 400, $result['data'] ?? [])->getData();
+            return Response::error($result['message'] ?? 'Unknown error', Response::HTTP_BAD_REQUEST, $result['data'] ?? [])->getData();
         }
     }
 

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAddressController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAddressController.php
@@ -73,7 +73,7 @@ class CustomerAddressController
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -82,7 +82,7 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), 404)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), Response::HTTP_NOT_FOUND)->getData();
         }
 
         return Response::success($this->formatAddress($address))->getData();
@@ -108,7 +108,7 @@ class CustomerAddressController
         $required = ['name', 'city', 'street'];
         foreach ($required as $field) {
             if (empty($input[$field])) {
-                return Response::error($this->modx->lexicon('ms3_customer_err_field_required'), 400)->getData();
+                return Response::error($this->modx->lexicon('ms3_customer_err_field_required'), Response::HTTP_BAD_REQUEST)->getData();
             }
         }
 
@@ -137,7 +137,7 @@ class CustomerAddressController
         }
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_creation_error'), 500)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_creation_error'), Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Created customer address: ' . $addressHash . ' for customer #' . $customer->get('id'));
@@ -163,7 +163,7 @@ class CustomerAddressController
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -172,7 +172,7 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), 404)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), Response::HTTP_NOT_FOUND)->getData();
         }
 
         $input = $this->getRequestData();
@@ -193,7 +193,7 @@ class CustomerAddressController
             $address->set('updatedon', date('Y-m-d H:i:s'));
 
             if (!$address->save()) {
-                return Response::error($this->modx->lexicon('ms3_customer_address_update_error'), 500)->getData();
+                return Response::error($this->modx->lexicon('ms3_customer_address_update_error'), Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
             }
 
             $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Updated customer address #' . $addressId);
@@ -220,7 +220,7 @@ class CustomerAddressController
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -230,7 +230,7 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), 404)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), Response::HTTP_NOT_FOUND)->getData();
         }
 
         $table = $this->modx->getTableName(msCustomerAddress::class);
@@ -242,7 +242,7 @@ class CustomerAddressController
         $address->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_default_error'), 500)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_default_error'), Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Set default address #' . $addressId . ' for customer #' . $customer->get('id'));
@@ -268,7 +268,7 @@ class CustomerAddressController
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -277,14 +277,14 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), 404)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), Response::HTTP_NOT_FOUND)->getData();
         }
 
         $address->set('active', 0);
         $address->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_delete_error'), 500)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_delete_error'), Response::HTTP_INTERNAL_SERVER_ERROR)->getData();
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Deleted customer address #' . $addressId);

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerOrderController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerOrderController.php
@@ -45,7 +45,7 @@ class CustomerOrderController
         $orderId = (int)($params['id'] ?? 0);
 
         if (!$orderId) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_no_order'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_no_order'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         /** @var msOrder|null $order */
@@ -55,7 +55,7 @@ class CustomerOrderController
         ]);
 
         if (!$order) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_not_found'), 404)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_not_found'), Response::HTTP_NOT_FOUND)->getData();
         }
 
         /** @var OrderStatusService $orderStatusService */
@@ -64,7 +64,7 @@ class CustomerOrderController
         $currentStatusId = (int) $order->get('status_id');
 
         if (!in_array($currentStatusId, $allowedStatusIds, true)) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_status'), 400)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_status'), Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $cancelledStatusId = (int) $this->modx->getOption('ms3_status_canceled', null, 5);
@@ -73,7 +73,7 @@ class CustomerOrderController
 
         if ($result !== true) {
             $message = is_string($result) ? $result : $this->modx->lexicon('ms3_customer_order_cancel_err_failed');
-            return Response::error($message, 400)->getData();
+            return Response::error($message, Response::HTTP_BAD_REQUEST)->getData();
         }
 
         return Response::success(

--- a/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
@@ -66,7 +66,7 @@ class OrderController
         }
 
         if (empty($key)) {
-            return Response::error('Field key is required', 400)->getData();
+            return Response::error('Field key is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -97,7 +97,7 @@ class OrderController
         }
 
         if (empty($fields) || !is_array($fields)) {
-            return Response::error('Fields array is required', 400)->getData();
+            return Response::error('Fields array is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -128,7 +128,7 @@ class OrderController
         }
 
         if (empty($key)) {
-            return Response::error('Field key is required', 400)->getData();
+            return Response::error('Field key is required', Response::HTTP_BAD_REQUEST)->getData();
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -140,7 +140,7 @@ class OrderController
         if ($exists) {
             return Response::success(['removed' => $key], 'Field removed successfully')->getData();
         } else {
-            return Response::error('Field not found', 404)->getData();
+            return Response::error('Field not found', Response::HTTP_NOT_FOUND)->getData();
         }
     }
 
@@ -425,7 +425,7 @@ class OrderController
         if ($result['success']) {
             return Response::success($result['data'], $result['message'] ?? '')->getData();
         } else {
-            return Response::error($result['message'] ?? 'Unknown error', 400, $result['data'] ?? [])->getData();
+            return Response::error($result['message'] ?? 'Unknown error', Response::HTTP_BAD_REQUEST, $result['data'] ?? [])->getData();
         }
     }
 }

--- a/core/components/minishop3/src/Router/HttpStatus.php
+++ b/core/components/minishop3/src/Router/HttpStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MiniShop3\Router;
+
+/**
+ * HTTP status codes used by the MiniShop3 API layer.
+ *
+ * Single source of truth; {@see Response} re-exports the same values as HTTP_* for convenience.
+ */
+final class HttpStatus
+{
+    public const OK = 200;
+    public const BAD_REQUEST = 400;
+    public const NOT_FOUND = 404;
+    public const INTERNAL_SERVER_ERROR = 500;
+}

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -7,11 +7,16 @@ namespace MiniShop3\Router;
  */
 class Response
 {
+    public const HTTP_OK = HttpStatus::OK;
+    public const HTTP_BAD_REQUEST = HttpStatus::BAD_REQUEST;
+    public const HTTP_NOT_FOUND = HttpStatus::NOT_FOUND;
+    public const HTTP_INTERNAL_SERVER_ERROR = HttpStatus::INTERNAL_SERVER_ERROR;
+
     protected $data;
     protected $statusCode;
     protected $headers = [];
 
-    public function __construct($data, int $statusCode = 200, array $headers = [])
+    public function __construct($data, int $statusCode = HttpStatus::OK, array $headers = [])
     {
         $this->data = $data;
         $this->statusCode = $statusCode;
@@ -21,7 +26,7 @@ class Response
     /**
      * Create success response
      */
-    public static function success($data = null, string $message = null, int $statusCode = 200): self
+    public static function success(mixed $data = null, ?string $message = null, int $statusCode = self::HTTP_OK): self
     {
         return new self([
             'success' => true,
@@ -33,7 +38,7 @@ class Response
     /**
      * Create error response
      */
-    public static function error(string $message, int $statusCode = 400, $errors = null): self
+    public static function error(string $message, int $statusCode = self::HTTP_BAD_REQUEST, mixed $errors = null): self
     {
         return new self([
             'success' => false,

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -262,7 +262,7 @@ class Router
 
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:
-                return Response::error('Route not found', 404);
+                return Response::error('Route not found', Response::HTTP_NOT_FOUND);
 
             case Dispatcher::METHOD_NOT_ALLOWED:
                 return Response::error('Method not allowed', 405);
@@ -274,7 +274,7 @@ class Router
                 return $this->executeRoute($routeData, $vars);
         }
 
-        return Response::error('Unknown error', 500);
+        return Response::error('Unknown error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /**
@@ -311,20 +311,20 @@ class Router
             [$controllerClass, $method] = explode('@', $handler);
 
             if (!class_exists($controllerClass)) {
-                return Response::error("Controller not found: {$controllerClass}", 500);
+                return Response::error("Controller not found: {$controllerClass}", Response::HTTP_INTERNAL_SERVER_ERROR);
             }
 
             $controller = new $controllerClass($this->modx);
 
             if (!method_exists($controller, $method)) {
-                return Response::error("Method not found: {$method}", 500);
+                return Response::error("Method not found: {$method}", Response::HTTP_INTERNAL_SERVER_ERROR);
             }
 
             $result = $controller->$method($vars);
             return $this->normalizeResponse($result);
         }
 
-        return Response::error('Invalid handler', 500);
+        return Response::error('Invalid handler', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /**
@@ -349,7 +349,7 @@ class Router
             return new Response($result, $statusCode);
         }
 
-        return Response::error('Invalid response type', 500);
+        return Response::error('Invalid response type', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /**


### PR DESCRIPTION
## Описание

Введён класс `MiniShop3\Router\HttpStatus` с базовыми кодами ответа; `Response` использует эти значения через публичные константы `Response::HTTP_*` (в т.ч. `HTTP_NOT_FOUND`). Сигнатуры `success` / `error` уточнены под строгую типизацию (`mixed`, явный `?string`). Магические числа в `Response::error` и связанных вызовах заменены на именованные константы по роутам и API-контроллерам; обновлён `Router`.

Поведение HTTP-ответов не меняется по смыслу — только читаемость и единообразие.

**База PR:** ветка `fix/gh-207-manager-order-product-events`. После мержа этого PR в ту ветку и мержа #207 в `beta` можно влить оставшиеся изменения одним потоком, либо ребейзнуть эту ветку на обновлённый `beta`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Refs #207 (контекст — тот же `OrdersController` получает константы вместо литералов; основной фикc в отдельном PR).

## Как это было протестировано?

Статический обзор диффа: замена констант, без изменения ветвлений по кодам.

- [ ] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3:
- MODX:
- PHP:

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Рекомендуемый порядок: смержить PR с #207 в `beta`, затем `refactor/http-status-response-constants` перебазировать на `beta` и открыть отдельный PR в `beta`, если второй PR шёл только в ветку фикса. Текущий PR нацелен на ветку фикса, чтобы дифф оставался только рефакторингом без дублирования с #207.
