### PR TITLE
fix(import): неверный ключ настройки шаблона товара в импорте

### DIFF
--- a/core/components/minishop3/src/Processors/Utilities/Import/Fields.php
+++ b/core/components/minishop3/src/Processors/Utilities/Import/Fields.php
@@ -124,7 +124,7 @@ class Fields extends Processor
         $tvs = [];
 
         // Get product template
-        $productTemplate = $this->modx->getOption('ms3_product_default_template', null, 0);
+        $productTemplate = $this->modx->getOption('ms3_template_product_default', null, 0);
 
         $q = $this->modx->newQuery(modTemplateVar::class);
         $q->select(['id', 'name', 'caption']);


### PR DESCRIPTION
## Summary

В `Processors\Utilities\Import\Fields::getTvFields()` используется ключ настройки `ms3_product_default_template`, которого нигде нет. Правильный ключ — `ms3_template_product_default` (используется в `controllers/product/create.class.php`, в лексиконах `setting_ms3_template_product_default`, в seed).

### Что ломалось

На экране импорта товаров блок «TV-поля» перечислял **все** modTemplateVar, а не только те, что привязаны к шаблону-дефолту для новых товаров — потому что `getOption('ms3_product_default_template')` всегда возвращал `0` (такого ключа нет в system settings), и JOIN к `modTemplateVarTemplate` не подставлялся.

### Что сделано

Поменял ключ на правильный. Теперь при заданном `ms3_template_product_default` импорт предлагает только TV, привязанные именно к этому шаблону.

## Test plan

- [ ] В system settings задать `ms3_template_product_default` = ID шаблона, где есть TV
- [ ] Открыть Утилиты → Импорт товаров → блок «TV-поля» — должны показаться только TV из этого шаблона
- [ ] Сбросить `ms3_template_product_default` в 0 — показываются все TV (поведение как раньше, потому что код падает в ветку «без дефолтного шаблона»)