### PR TITLE
fix(events): OrderFinalizeService вызывает зарегистрированные msOnBeforeMgrCreateOrder / msOnMgrCreateOrder

### DIFF
--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -70,8 +70,9 @@ class OrderFinalizeService
             }
         }
 
-        // Event: before finalize (similar to msOnSubmitOrder but for manager)
-        $response = $this->ms3->utils->invokeEvent('msOnBeforeFinalizeOrder', [
+        // Event: before manager-side order creation (finalize = draft → real order).
+        // Sibling of msOnSubmitOrder but fires in the manager finalize flow.
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeMgrCreateOrder', [
             'service' => $this,
             'msOrder' => $order,
             'from_manager' => true,
@@ -157,8 +158,8 @@ class OrderFinalizeService
         // Reload order after status change
         $order = $this->modx->getObject(msOrder::class, $orderId);
 
-        // Event: after finalize
-        $this->ms3->utils->invokeEvent('msOnFinalizeOrder', [
+        // Event: manager-side order creation finished (draft finalized).
+        $this->ms3->utils->invokeEvent('msOnMgrCreateOrder', [
             'service' => $this,
             'msOrder' => $order,
             'from_manager' => true,


### PR DESCRIPTION
## Summary

`OrderFinalizeService` вызывал `msOnBeforeFinalizeOrder` и `msOnFinalizeOrder` — имена, которых **не существует** в `_build/elements/events.php`. После install/upgrade ни одного `modEvent` с такими именами в системе не появлялось — подписать плагин через UI MODX было нельзя.

Параллельно в билдере **уже зарегистрированы** подходящие по семантике `msOnBeforeMgrCreateOrder` и `msOnMgrCreateOrder`, но они нигде не вызывались.

## Что сделано

В `OrderFinalizeService` заменил два `invokeEvent`:

| Было | Стало |
|---|---|
| `msOnBeforeFinalizeOrder` | `msOnBeforeMgrCreateOrder` |
| `msOnFinalizeOrder` | `msOnMgrCreateOrder` |

Добавил комментарии, что «manager create» здесь означает финализацию draft'а в готовый заказ (получает номер, меняется статус, уходят уведомления).

`_build/elements/events.php` не трогается — имена в билдере сохраняются, `Mgr`-префикс однозначно указывает на админский флоу.

## Scope

`OrderFinalizeService::finalize()` вызывается только из `POST /api/mgr/orders/{id}/finalize` (manager route, permission `msorder_save`). Никаких web-API или фронтовых путей — проверено `grep`'ом по `core/` и `assets/`.

## Test plan

- [ ] Elements → Plugins → Создать плагин, на вкладке System events в списке видны `msOnBeforeMgrCreateOrder` и `msOnMgrCreateOrder`
- [ ] Подписать плагин на `msOnBeforeMgrCreateOrder`, выполнить finalize любого draft-заказа из админки — плагин должен сработать
- [ ] Аналогично для `msOnMgrCreateOrder` (срабатывает **после** смены статуса)