### PR TITLE
fix(events): propagate plugin mutations via returnedValues

### DIFF
--- a/core/components/minishop3/elements/snippets/ms3_products.php
+++ b/core/components/minishop3/elements/snippets/ms3_products.php
@@ -368,11 +368,21 @@ if (!empty($scriptProperties['usePackages'])) {
 if (!empty($rows) && is_array($rows)) {
     $productIds = array_column($rows, 'id');
     $modx->invokeEvent('msOnProductsLoad', [
-        'rows' => &$rows,
+        'rows' => $rows,
         'productIds' => $productIds,
         'usePackages' => $usePackages,
         'scriptProperties' => $scriptProperties,
     ]);
+    // Apply plugin mutations via returnedValues (by-ref params don't propagate
+    // through MODX invokeEvent scope isolation). Plugins should set
+    // $modx->event->returnedValues = ['rows' => [...]] with full rows collection
+    // (typically enriched copy of the original array).
+    if (isset($modx->event->returnedValues) && is_array($modx->event->returnedValues)) {
+        $returned = $modx->event->returnedValues;
+        if (isset($returned['rows']) && is_array($returned['rows'])) {
+            $rows = $returned['rows'];
+        }
+    }
     $pdoFetch->addTime('Invoked msOnProductsLoad event');
 }
 
@@ -440,10 +450,18 @@ if (!empty($rows) && is_array($rows)) {
 
         // Event: msOnProductPrepare - enrich single product data from external packages
         $modx->invokeEvent('msOnProductPrepare', [
-            'row' => &$rows[$k],
+            'row' => $rows[$k],
             'productId' => $row['id'],
             'idx' => $row['idx'],
         ]);
+        // Apply plugin mutations via returnedValues (by-ref params don't propagate
+        // through MODX invokeEvent scope isolation).
+        if (isset($modx->event->returnedValues) && is_array($modx->event->returnedValues)) {
+            $returned = $modx->event->returnedValues;
+            if (isset($returned['row']) && is_array($returned['row'])) {
+                $rows[$k] = array_merge($rows[$k], $returned['row']);
+            }
+        }
         $row = $rows[$k]; // Update local variable after event modifications
 
         if ($scriptProperties['return'] == 'data') {

--- a/core/components/minishop3/src/Notifications/NotificationManager.php
+++ b/core/components/minishop3/src/Notifications/NotificationManager.php
@@ -71,10 +71,23 @@ class NotificationManager
         // Fire before event - allows plugins to modify or cancel notification
         $eventResult = $this->modx->invokeEvent('msOnBeforeSendNotification', [
             'notification' => $notification,
-            'recipient' => &$recipient,
+            'recipient' => $recipient,
             'recipientType' => $recipientType,
-            'channels' => &$channels,
+            'channels' => $channels,
         ]);
+
+        // Apply plugin mutations via returnedValues (MODX invokeEvent scope isolation
+        // prevents by-ref params from propagating, so plugins must set
+        // $modx->event->returnedValues = ['recipient' => [...], 'channels' => [...]]).
+        if (isset($this->modx->event->returnedValues) && is_array($this->modx->event->returnedValues)) {
+            $returned = $this->modx->event->returnedValues;
+            if (isset($returned['recipient']) && is_array($returned['recipient'])) {
+                $recipient = array_merge($recipient, $returned['recipient']);
+            }
+            if (isset($returned['channels']) && is_array($returned['channels'])) {
+                $channels = $returned['channels'];
+            }
+        }
 
         // Check if notification was cancelled by plugin
         $cancelled = false;

--- a/core/components/minishop3/src/Utils/ImportCSV.php
+++ b/core/components/minishop3/src/Utils/ImportCSV.php
@@ -123,8 +123,16 @@ class ImportCSV
         // Fire before import event
         $eventResult = $this->modx->invokeEvent('msOnBeforeImport', [
             'file' => $this->params['file'],
-            'params' => &$this->params,
+            'params' => $this->params,
         ]);
+        // Apply plugin mutations via returnedValues (by-ref params don't propagate
+        // through MODX invokeEvent scope isolation).
+        if (isset($this->modx->event->returnedValues) && is_array($this->modx->event->returnedValues)) {
+            $returned = $this->modx->event->returnedValues;
+            if (isset($returned['params']) && is_array($returned['params'])) {
+                $this->params = array_merge($this->params, $returned['params']);
+            }
+        }
         if ($this->isEventCancelled($eventResult)) {
             $error = $this->modx->lexicon('ms3_utilities_import_cancelled');
             return $this->ms3->utils->error($error);
@@ -347,11 +355,28 @@ class ImportCSV
         $eventResult = $this->modx->invokeEvent('msOnImportRow', [
             'row' => $this->rows,
             'csv' => $csv,
-            'data' => &$data,
-            'tvData' => &$tvData,
-            'optionData' => &$optionData,
-            'gallery' => &$gallery,
+            'data' => $data,
+            'tvData' => $tvData,
+            'optionData' => $optionData,
+            'gallery' => $gallery,
         ]);
+        // Apply plugin mutations via returnedValues (by-ref params don't propagate
+        // through MODX invokeEvent scope isolation).
+        if (isset($this->modx->event->returnedValues) && is_array($this->modx->event->returnedValues)) {
+            $returned = $this->modx->event->returnedValues;
+            if (isset($returned['data']) && is_array($returned['data'])) {
+                $data = array_merge($data, $returned['data']);
+            }
+            if (isset($returned['tvData']) && is_array($returned['tvData'])) {
+                $tvData = array_merge($tvData, $returned['tvData']);
+            }
+            if (isset($returned['optionData']) && is_array($returned['optionData'])) {
+                $optionData = array_merge($optionData, $returned['optionData']);
+            }
+            if (isset($returned['gallery']) && is_array($returned['gallery'])) {
+                $gallery = $returned['gallery'];
+            }
+        }
         if ($this->isEventCancelled($eventResult)) {
             $this->skipped++;
             return true;


### PR DESCRIPTION
## Проблема

В пяти местах ядра плагин, подписанный на событие, **молча не может** изменить данные, которые должен был изменить. Ядро вызывает `$modx->invokeEvent(...)` напрямую и даже передаёт параметры по ссылке, но мутация из плагина не распространяется в scope вызова: MODX внутри `invokeEvent()` делает `extract()` в scope плагина, и by-ref в массиве params на этапе extract обнуляется.

Подробный разбор — #219. Конкретный кейс (email уходит старому клиенту при повторном заказе в одной сессии, плагин не может его подменить) — #218.

## Что сделано

Во всех пяти местах:

1. После `$modx->invokeEvent(...)` читаем `$modx->event->returnedValues` и мержим значения обратно в локальные переменные.
2. Убрали декоративное `&` в params — оно только вводило в заблуждение.
3. Cancel-семантика (`$modx->event->output === false`, `isEventCancelled()`) сохранена.

| Файл | Событие | Мутируемые ключи |
|---|---|---|
| `src/Notifications/NotificationManager.php` | `msOnBeforeSendNotification` | `recipient`, `channels` |
| `src/Utils/ImportCSV.php` | `msOnBeforeImport` | `params` |
| `src/Utils/ImportCSV.php` | `msOnImportRow` | `data`, `tvData`, `optionData`, `gallery` |
| `elements/snippets/ms3_products.php` | `msOnProductsLoad` | `rows` |
| `elements/snippets/ms3_products.php` | `msOnProductPrepare` | `row` |

## Новый контракт плагина

```php
// Было (не работало):
$recipient['email'] = $newEmail;

// Стало:
$modx->event->returnedValues = [
    'recipient' => ['email' => $newEmail],
];
```

Ключи `recipient`, `params`, `data`, `tvData`, `optionData`, `row` — мержатся через `array_merge` (плагин отдаёт только то, что меняет). Ключи `channels`, `gallery`, `rows` — заменяются целиком (это естественная семантика: список каналов/галерея/полная коллекция).

## Обратная совместимость

Плагины, которые **сейчас** пытаются мутировать по ссылке — и так не работают (см. #218). PR их не ломает; новые плагины, использующие `returnedValues`, начинают работать в ожидаемом виде.

## Проверка

- PHPStan чистый на изменённых файлах.
- Кэш MODX очищен на dev-сайте.
- Ручная проверка `msOnBeforeSendNotification` для кейса из #218 — письмо уходит на актуальный email, если плагин пишет `returnedValues.recipient.email`.

Closes #218
Closes #219