### PR TITLE
fix(cart): add missing get success lexicon

### DIFF
--- a/core/components/minishop3/lexicon/en/cart.inc.php
+++ b/core/components/minishop3/lexicon/en/cart.inc.php
@@ -17,6 +17,7 @@ $_lang['ms3_cart_cost'] = 'Cost';
 $_lang['ms3_cart_remove'] = 'Remove';
 $_lang['ms3_cart_total'] = 'Total';
 
+$_lang['ms3_cart_get_success'] = 'Cart data retrieved';
 $_lang['ms3_cart_add_success'] = 'Product successfully added to cart: [[+count]]';
 $_lang['ms3_cart_add_err_id'] = 'Error adding to cart: product identifier not specified';
 $_lang['ms3_cart_add_err_nf'] = 'Error adding to cart: product not found';

--- a/core/components/minishop3/lexicon/ru/cart.inc.php
+++ b/core/components/minishop3/lexicon/ru/cart.inc.php
@@ -17,6 +17,7 @@ $_lang['ms3_cart_cost'] = 'Стоимость';
 $_lang['ms3_cart_remove'] = 'Удалить';
 $_lang['ms3_cart_total'] = 'Итого';
 
+$_lang['ms3_cart_get_success'] = 'Данные корзины получены';
 $_lang['ms3_cart_add_success'] = 'Товар успешно добавлен в корзину: [[+count]]';
 $_lang['ms3_cart_add_err_id'] = 'Ошибка добавления в корзину: не указан идентификатор товара';
 $_lang['ms3_cart_add_err_nf'] = 'Ошибка добавления в корзину: товар не найден';


### PR DESCRIPTION
## Описание

Добавляет отсутствующий лексикон `ms3_cart_get_success` в `ru/en` cart-лексиконы, чтобы вызов `Cart::get()` не записывал в лог сообщение `Language string not found`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #222

## Как это было протестировано?

Проверил, что изменение ограничено двумя лексиконами и PHP-синтаксис в обоих файлах валиден.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `beta`
- MODX: не указано
- PHP: локальная проверка `php -l`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Не применимо | Не применимо |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Причина бага: `ms3_cart_get_success` уже использовался в `core/components/minishop3/src/Controllers/Cart/Cart.php`, но отсутствовал в:

- `core/components/minishop3/lexicon/ru/cart.inc.php`
- `core/components/minishop3/lexicon/en/cart.inc.php`

Изменение не затрагивает бизнес-логику и устраняет только пропущенные переводы.