### PR TITLE
fix(service-registry): skip logs for missing optional defaults

### DIFF
--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -253,17 +253,17 @@ class ServiceRegistry
      */
     protected function loadMainConfig(): void
     {
-        $customConfigPath = $this->modx->getOption(
-            'ms3_services_config',
-            null,
-            MODX_CORE_PATH . 'config/ms3.services.php'
-        );
+        $defaultConfigPath = MODX_CORE_PATH . 'config/ms3.services.php';
+        $configuredPath = $this->modx->getOption('ms3_services_config');
+        $customConfigPath = $configuredPath ?: $defaultConfigPath;
 
         if (!file_exists($customConfigPath)) {
-            $this->modx->log(
-                modX::LOG_LEVEL_DEBUG,
-                "[MiniShop3 ServiceRegistry] Custom config not found: {$customConfigPath}"
-            );
+            if (!empty($configuredPath)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_DEBUG,
+                    "[MiniShop3 ServiceRegistry] Custom config not found: {$customConfigPath}"
+                );
+            }
             return;
         }
 
@@ -309,17 +309,17 @@ class ServiceRegistry
      */
     protected function loadAddonConfigs(): void
     {
-        $addonsDir = $this->modx->getOption(
-            'ms3_services_addons_dir',
-            null,
-            MODX_CORE_PATH . 'config/ms3.services.d/'
-        );
+        $defaultAddonsDir = MODX_CORE_PATH . 'config/ms3.services.d/';
+        $configuredAddonsDir = $this->modx->getOption('ms3_services_addons_dir');
+        $addonsDir = $configuredAddonsDir ?: $defaultAddonsDir;
 
         if (!is_dir($addonsDir)) {
-            $this->modx->log(
-                modX::LOG_LEVEL_DEBUG,
-                "[MiniShop3 ServiceRegistry] Addons directory not found: {$addonsDir}"
-            );
+            if (!empty($configuredAddonsDir)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_DEBUG,
+                    "[MiniShop3 ServiceRegistry] Addons directory not found: {$addonsDir}"
+                );
+            }
             return;
         }
 


### PR DESCRIPTION
## Описание

Убирает лишние debug-сообщения из `ServiceRegistry`, когда отсутствуют дефолтные опциональные пути `core/config/ms3.services.php` и `core/config/ms3.services.d/`.

Логирование сохраняется для реально проблемных случаев: если путь был явно задан через системные настройки `ms3_services_config` или `ms3_services_addons_dir`, но не существует.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #224

## Как это было протестировано?

Проверил поведение до и после изменения на минимальном воспроизведении `ServiceRegistry`.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `beta`
- MODX: stub-окружение для изолированной проверки `ServiceRegistry`
- PHP: локальная проверка `php -l` + выполнение PHP-скриптов проверки

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Не применимо | Не применимо |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Сейчас отсутствие дефолтных override-путей является штатным сценарием, потому что они используются только при кастомизации сервисов. До фикса это приводило к постоянному debug-шуму в логах на обычной установке.

Изменение намеренно не отключает диагностику для явно настроенных путей: если пользователь задал кастомный путь и он отсутствует, `ServiceRegistry` по-прежнему пишет debug-сообщение.