### PR TITLE
fix(options): clear orphan msOption.modcategory_id on modCategory removal

### DIFF
--- a/_build/elements/plugins.php
+++ b/_build/elements/plugins.php
@@ -12,6 +12,7 @@ return [
             'OnUserSave',
             'OnBeforeUserFormSave',
             'OnUserRemove',
+            'OnCategoryRemove',
         ],
     ],
 ];

--- a/core/components/minishop3/elements/plugins/minishop3.php
+++ b/core/components/minishop3/elements/plugins/minishop3.php
@@ -10,16 +10,20 @@
  * - OnUserSave: Synchronize msCustomer ↔ modUser (create/update)
  * - OnBeforeUserFormSave: Synchronize msCustomer when modUser profile changes
  * - OnUserRemove: Unlink msCustomer from deleted modUser
+ * - OnCategoryRemove: Clear modcategory_id on msOption rows pointing at the removed modCategory
  *
  * @var \MODX\Revolution\modX $modx
  * @var array $scriptProperties
  */
 
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msOption;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Services\Product\ProductService;
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
+use MODX\Revolution\modX;
 
 switch ($modx->event->name) {
     case 'OnMODXInit':
@@ -197,6 +201,39 @@ switch ($modx->event->name) {
             $modx->log(
                 modX::LOG_LEVEL_INFO,
                 "[MiniShop3] Unlinked msCustomer #{$customer->id} from deleted modUser #{$userId}"
+            );
+        }
+        break;
+
+    /**
+     * OnCategoryRemove - clear orphan modcategory_id on msOption
+     *
+     * When a modCategory is removed (e.g. on uninstall of a third-party component),
+     * any msOption rows that referenced it would otherwise keep a dangling
+     * modcategory_id and show up as a separate "no group" tab in the product
+     * options UI. Reset the link to 0 so they fall into the real "no group" bucket.
+     */
+    case 'OnCategoryRemove':
+        /** @var modCategory $category */
+        if (!isset($category) || !$category instanceof modCategory) {
+            break;
+        }
+
+        $categoryId = (int)$category->get('id');
+        if ($categoryId <= 0) {
+            break;
+        }
+
+        $count = $modx->updateCollection(
+            msOption::class,
+            ['modcategory_id' => 0],
+            ['modcategory_id' => $categoryId]
+        );
+
+        if (is_int($count) && $count > 0) {
+            $modx->log(
+                modX::LOG_LEVEL_INFO,
+                "[MiniShop3] Cleared modcategory_id for {$count} option(s) after removing modCategory #{$categoryId}"
             );
         }
         break;


### PR DESCRIPTION
## Проблема

В карточке товара на вкладке «Опции товара» появляются **два таба с одинаковой подписью «Без группы»** (плюс реальный таб именованной группы). Скриншот:

- «Без группы» — 5 опций
- «MiniShop3» — 2 опции
- «Без группы» — 10 опций

Причина — у опций, относящихся к этим двум табам, в БД лежат **разные** `modcategory_id`, ссылающиеся на уже удалённые `modCategory` (типичный сценарий — деинсталляция стороннего компонента, который при установке создавал свою категорию для опций MS3).

В `OptionLoaderService::getFieldsForProduct()` группировка делается через `LEFT JOIN modCategory`. Для удалённых категорий `category_name` приходит `NULL`, но `modcategory_id` сохраняется. Vue-компонент `ProductOptionsTab.vue` группирует строго по сырому `modcategory_id`:

```
const groupId = Number(option.modcategory_id) || 0
```

→ две группы с разными мёртвыми `modcategory_id` → два отдельных таба с одинаковым фолбэк-заголовком «Без группы».

## Что сделано

Подписал плагин `MiniShop3` на событие `OnCategoryRemove` и в обработчике обнуляю `msOption.modcategory_id` для всех записей, ссылавшихся на удалённую категорию.

Это **зеркалит штатный MODX-паттерн** — внутри `modCategory::remove()` уже происходит сброс поля `category` к 0 для `modChunk`, `modPlugin`, `modSnippet`, `modTemplate`, `modTemplateVar`. Просто расширяем его на `msOption`.

```php
case 'OnCategoryRemove':
    /** @var modCategory $category */
    if (!isset($category) || !$category instanceof modCategory) {
        break;
    }

    $categoryId = (int)$category->get('id');
    if ($categoryId <= 0) {
        break;
    }

    $count = $modx->updateCollection(
        msOption::class,
        ['modcategory_id' => 0],
        ['modcategory_id' => $categoryId]
    );

    if (is_int(\$count) && \$count > 0) {
        $modx->log(
            modX::LOG_LEVEL_INFO,
            \"[MiniShop3] Cleared modcategory_id for {\$count} option(s) after removing modCategory #{\$categoryId}\"
        );
    }
    break;
```

Плюс зарегистрировал `OnCategoryRemove` в `_build/elements/plugins.php` — чтобы привязка плагин↔событие применилась при сборке/апгрейде пакета.

## Что НЕ делаем

**Миграцию для одноразовой чистки уже грязных данных не добавляю** — встретить такой кейс в текущем темпе распространения MS3 редко, и тащить отдельную миграцию ради единичных инсталляций избыточно. Операторы, наткнувшиеся на проблему, могут вычистить руками одной из команд:

**SQL** (стандартный префикс `modx_`):

```
UPDATE modx_ms3_options o
LEFT JOIN modx_categories c ON c.id = o.modcategory_id
SET o.modcategory_id = 0
WHERE o.modcategory_id > 0 AND c.id IS NULL;
```

**xPDO** (если префикс нестандартный):

```
\$c = \$modx->newQuery(MiniShop3\Model\msOption::class);
\$c->leftJoin(MODX\Revolution\modCategory::class, 'Category', 'Category.id = msOption.modcategory_id');
\$c->where(['msOption.modcategory_id:>' => 0, 'Category.id:IS' => null]);

foreach (\$modx->getIterator(MiniShop3\Model\msOption::class, \$c) as \$option) {
    \$option->set('modcategory_id', 0);
    \$option->save();
}
```

После применения PR новые висячие связи появляться не будут.

## Что не закрывает этот PR

Архитектурный вопрос — **нужно ли вообще привязывать `msOption` к `modCategory`** (стандартной таблице категорий элементов MODX), или собрать собственную таблицу `ms3_option_groups` — вынесен в отдельный issue **#227** для обсуждения с комьюнити.

## Test plan

- [ ] Установить апдейт пакета.
- [ ] Создать `modCategory` через **Элементы → Категории → Новая**.
- [ ] В **Настройки → Опции** создать новую опцию и привязать к этой категории (поле «Категория»).
- [ ] Удалить созданную `modCategory`.
- [ ] Открыть товар, у которого есть эта опция → вкладка **Опции товара** показывает её в группе «Без группы», а не отдельным табом-фантомом.
- [ ] В логах MODX — info-сообщение `[MiniShop3] Cleared modcategory_id for N option(s) after removing modCategory #ID`.

## Связанные

- #227 — архитектурный вопрос про связку `msOption ↔ modCategory`