### PR TITLE
fix(options): keep all option group panels mounted to preserve state

### DIFF
--- a/vueManager/src/components/product/ProductOptionsTab.vue
+++ b/vueManager/src/components/product/ProductOptionsTab.vue
@@ -46,8 +46,6 @@ watch(
   { immediate: true }
 )
 
-const activeGroup = computed(() => groups.value.find(g => g.id === activeGroupId.value) || null)
-
 function onOptionChange(payload) {
   // Hidden inputs propagate values into the MODX form POST automatically.
   // Hook left here for future dirty-tracking / validation wiring.
@@ -89,9 +87,22 @@ function onOptionChange(payload) {
         </button>
       </nav>
 
-      <section class="vtabs-panel" role="tabpanel">
+      <!--
+        All groups are rendered at once and toggled via v-show. This preserves
+        per-field state (local refs, focus, partial input) when the user switches
+        between tabs and — more importantly — keeps every hidden input mounted
+        in the DOM so the MODX/ExtJS form picks them up at submit. v-if-driven
+        unmount/remount loses both.
+      -->
+      <section
+        v-for="group in groups"
+        v-show="group.id === activeGroupId"
+        :key="group.id"
+        class="vtabs-panel"
+        role="tabpanel"
+      >
         <ProductOptionField
-          v-for="option in activeGroup?.options || []"
+          v-for="option in group.options"
           :key="option.key"
           :option="option"
           @change="onOptionChange"


### PR DESCRIPTION
## Проблема

В карточке товара на вкладке «Опции товара», когда у товара несколько групп опций:

1. Открываешь любую неактивную группу.
2. Заполняешь поля, переключаешь чекбоксы — заметно меняешь состояние.
3. Переходишь на другую группу и возвращаешься назад — **все изменения сброшены в дефолты**.

Это **не визуальный баг** — данные действительно теряются. Сохранение не помогает: значения неактивных табов вообще **не доезжают на бэкенд**.

## Причина

Панель таба рендерила одну секцию с `v-for` по **активной группе**:

```
<section class="vtabs-panel" role="tabpanel">
  <ProductOptionField
    v-for="option in activeGroup?.options || []"
    :key="option.key"
    :option="option"
    @change="onOptionChange"
  />
</section>
```

Переключение `activeGroupId` → массив `activeGroup.options` меняется → Vue **разрушает** все `ProductOptionField` старого таба и **создаёт** новые для нового. Вместе с компонентом улетают:

1. **Локальный `value = ref(...)`** каждого поля. Возврат на исходный таб → новый инстанс инициализируется снова из `props.option.value` (исходное значение с бэкенда). Видимый «сброс».
2. **Скрытые `<input type="hidden">`** внутри `ProductOptionField` (есть у всех типов кроме textfield/textarea). MODX/ExtJS `BasicForm.getValues()` собирает только те инпуты, что **в DOM** на момент сабмита. Поля неактивного таба в форму просто **не попадают** → `_validated` на бэке для них пуст → сохраняются дефолты.

Именно поэтому предварительное сохранение не спасает: POST уходит без этих полей, сервер кладёт дефолты, при следующей загрузке мы их и видим.

## Фикс

Рендерим **все** группы сразу, прячем неактивные через `v-show`. Каждый `ProductOptionField` создаётся один раз и живёт весь сеанс работы с карточкой:

- локальное состояние полей не теряется при переключении таба;
- hidden inputs всех групп остаются в DOM → форма собирает значения **со всех табов** при сабмите.

Также убран неиспользуемый `activeGroup` computed.

## Чем платим

- Все `ProductOptionField` создаются одномоментно при открытии вкладки. Если у товара 200+ опций в нескольких группах — лёгкое замедление первого рендера. На обычных товарах с десятками опций — незаметно.
- PrimeVue-компоненты (DatePicker, Select, MultiSelect) в `display: none` ведут себя нормально.

## Test plan

- [ ] Открыть товар с двумя+ группами опций.
- [ ] Заполнить поля разных типов в неактивной группе (text, number, checkbox, combo, multi-select, date).
- [ ] Переключиться на другую группу и обратно — введённое **на месте**.
- [ ] Сохранить товар — введённые значения **попадают на бэкенд** и видны после перезагрузки страницы.
- [ ] DatePicker и MultiSelect в скрытом табе нормально открываются после переключения на их группу (не «застревают» в закрытом состоянии).
- [ ] Если у товара одна группа — `single-group` ветка продолжает работать как раньше.