### PR TITLE
release: v1.10.1-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,54 @@
 
 ## Апрель 2026
 
+### [2026-04-27] 🚀 Версия 1.10.1-beta1
+
+**Тип релиза:** PATCH (beta) — точечные исправления и восстановление контракта событий
+
+---
+
+#### 🐛 Исправлено
+
+**Manager API — события жизненного цикла позиции заказа (#208, closes #207):**
+- Vue-админка дёргает `msOnBefore/Create/Update/Remove OrderProduct` через `Utils::invokeEvent` при добавлении/изменении/удалении позиций заказа — раньше события были зарегистрированы в `events.php`, но `OrdersController` их не вызывал, и сторонние подписчики (ms3PromoCode и т.п.) не срабатывали.
+- Before-hooks могут заблокировать операцию через `Response::error(400)`. After-hooks логируются на WARN-уровне с маркером `(persistence already done)` — ошибка плагина после `save()`/`remove()` не возвращается клиенту как 4xx, потому что persistence уже произошёл.
+
+**Опции товара — переключение групп больше не сбрасывает значения (#230):**
+- `ProductOptionsTab.vue` рендерит все группы сразу с `v-show` вместо `v-if`-style монтирования только активной — локальные `value = ref(...)` и hidden inputs сохраняются между переключениями вкладок.
+- Раньше значения, введённые в неактивной группе, терялись и не доезжали на бэкенд (MODX/ExtJS `BasicForm.getValues()` собирает только инпуты, физически присутствующие в DOM на момент сабмита).
+
+**Опции товара — висячие `modcategory_id` после удаления категории (#228):**
+- Плагин `MiniShop3` подписан на `OnCategoryRemove` — обнуляет `msOption.modcategory_id` для всех опций, ссылавшихся на удалённую `modCategory`. Зеркалит штатный паттерн MODX, где `modCategory::remove()` сбрасывает `category` у `modChunk`/`modPlugin`/`modSnippet`/`modTemplate`/`modTemplateVar`.
+- Без фикса в карточке товара мог появиться второй таб «Без группы» с разными мёртвыми `modcategory_id`.
+
+**OrderFinalizeService вызывал несуществующие события (#217):**
+- `msOnBeforeFinalizeOrder` / `msOnFinalizeOrder` нигде не были зарегистрированы как `modEvent`, подписать плагин через UI было нельзя. Заменены на `msOnBeforeMgrCreateOrder` / `msOnMgrCreateOrder` — уже существовали в билдере, но никем не вызывались.
+
+**Импорт товаров — неправильный ключ system setting для дефолтного шаблона (#210):**
+- `Processors\Utilities\Import\Fields::getTvFields()` использовал несуществующий ключ `ms3_product_default_template`. Корректный ключ — `ms3_template_product_default` (используется в `controllers/product/create.class.php`). Из-за опечатки на экране импорта блок «TV-поля» перечислял все TV вместо только привязанных к шаблону-дефолту.
+
+**Cart API — отсутствующий лексикон (#223, closes #222):**
+- Добавлен ключ `ms3_cart_get_success` в `lexicon/{ru,en}/cart.inc.php` — ключ использовался в `Cart::get()`, но без перевода MODX писал в лог `Language string not found`.
+
+**ServiceRegistry — лишний debug-шум в логах (#225, closes #224):**
+- На штатной установке без кастомизации сервисов `loadMainConfig()` / `loadAddonConfigs()` писали DEBUG про отсутствие дефолтных override-путей. Теперь логирование срабатывает только если оператор явно задал `ms3_services_config` / `ms3_services_addons_dir` через system settings, а файла/папки по этому пути нет.
+
+#### 📁 Изменённые файлы
+
+```
+_build/elements/plugins.php
+core/components/minishop3/elements/plugins/minishop3.php
+core/components/minishop3/lexicon/en/cart.inc.php
+core/components/minishop3/lexicon/ru/cart.inc.php
+core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+core/components/minishop3/src/Processors/Utilities/Import/Fields.php
+core/components/minishop3/src/ServiceRegistry.php
+core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+vueManager/src/components/product/ProductOptionsTab.vue
+```
+
+---
+
 ### 🚀 Версия 1.10.0-beta1
 
 **Тип релиза:** MINOR (beta) — полный перевод управления опциями с ExtJS на Vue, рефакторинг карточки заказа, self-heal миграция

--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -12,7 +12,7 @@ return [
     'name' => 'MiniShop3',
     'name_lower' => 'minishop3',
     'name_short' => 'ms3',
-    'version' => '1.10.0',
+    'version' => '1.10.1',
     'release' => 'beta1',
     // Install package to site right after build
     'install' => false,

--- a/core/components/minishop3/docs/changelog.txt
+++ b/core/components/minishop3/docs/changelog.txt
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1-beta1]
+
+### Fixed
+- Manager API now invokes `msOnBefore/Create/Update/Remove OrderProduct` events when adding, updating, or removing order line items via the Vue admin (#208, closes #207). Before-hooks may abort with HTTP 400; after-hooks are observe-only and their failures are logged at WARN level (`persistence already done`) without returning a 4xx — the row is already in DB. Previously third-party plugins (ms3PromoCode etc.) silently missed these events.
+- Product Options tab: switching between option groups no longer wipes user-entered values (#230). All groups are kept mounted via `v-show` instead of `v-if`-style remount, so per-field local state and hidden inputs survive tab switches and reach the form on submit.
+- Cleared dangling `msOption.modcategory_id` references when a `modCategory` is removed (#228). Plugin subscribes to `OnCategoryRemove` and resets the link to 0, mirroring how MODX core handles `modChunk` / `modPlugin` / `modSnippet` / `modTemplate` / `modTemplateVar` on category removal. Prevents the duplicate "no group" tab in the product options UI when a third-party component is uninstalled.
+- `OrderFinalizeService` now invokes registered `msOnBeforeMgrCreateOrder` / `msOnMgrCreateOrder` instead of non-existent `msOnBeforeFinalizeOrder` / `msOnFinalizeOrder` (#217). The old names were never registered as `modEvent`, so plugins could not subscribe via the UI.
+- Import → TV fields panel uses the correct setting key `ms3_template_product_default` (was: non-existent `ms3_product_default_template`), so the panel lists only TVs bound to the configured default product template instead of every TV in the system (#210).
+- Added missing lexicon `ms3_cart_get_success` in `lexicon/{ru,en}/cart.inc.php` — the key was used by `Cart::get()` but missing from translations, producing `Language string not found` warnings in MODX logs (#223, closes #222).
+- `ServiceRegistry` no longer logs DEBUG noise for missing default optional override paths (`core/config/ms3.services.php`, `core/config/ms3.services.d/`) on stock installations (#225, closes #224). The DEBUG log is preserved when the operator explicitly sets `ms3_services_config` / `ms3_services_addons_dir` system settings to a missing path.
+
 ## [1.10.0-beta1]
 
 ### Added

--- a/core/components/minishop3/src/MiniShop3.php
+++ b/core/components/minishop3/src/MiniShop3.php
@@ -20,7 +20,7 @@ use xPDO\xPDO;
 
 class MiniShop3
 {
-    public $version = '1.10.0-beta1';
+    public $version = '1.10.1-beta1';
 
     /** @var modX $modx */
     public $modx;


### PR DESCRIPTION
Patch release on top of `v1.10.0-beta1`. Bundles 7 fixes already merged into `beta`:

| PR | Summary |
|---|---|
| #208 | Manager API invokes `msOnBefore/Create/Update/Remove OrderProduct` events on order line CRUD (closes #207) |
| #230 | Product options tab: keep all groups mounted via `v-show` so per-field state and hidden inputs survive tab switches |
| #228 | Plugin clears orphan `msOption.modcategory_id` on `OnCategoryRemove` (mirrors MODX core for elements) |
| #217 | `OrderFinalizeService` calls registered `msOnBefore/MgrCreateOrder` instead of non-existent `msOn*FinalizeOrder` |
| #225 | `ServiceRegistry`: skip DEBUG log for missing default override paths on stock installs (closes #224) |
| #223 | Add missing `ms3_cart_get_success` lexicon in ru/en (closes #222) |
| #210 | Import → TV fields uses correct `ms3_template_product_default` setting key |

## Diff in this PR

Only the release prep:
- `CHANGELOG.md` — adds the 1.10.1-beta1 section (rus, detailed)
- `core/components/minishop3/docs/changelog.txt` — adds `[1.10.1-beta1]` (en, Keep-a-Changelog)
- `_build/config.inc.php` — `version: 1.10.1`
- `core/components/minishop3/src/MiniShop3.php` — `\$version = '1.10.1-beta1'`

## After merge

Tag `v1.10.1-beta1` on `beta` → GitHub Actions creates the release.

## Out of scope

- #231 (refactor: HttpStatus single-source) — open in `beta`, scheduled for the next minor release, intentionally excluded from this patch.