### PR TITLE
fix(web): подтверждение email — ссылка в письме, resend в ЛК, редирект

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,6 @@
   },
   "ignorePatterns": ["**/node_modules/**", "**/mgr/**"],
   "rules": {
-    "no-unused-vars": ["error", { "varsIgnorePattern": "^(CartUI|CustomerUI|OrderUI|ProductCardUI|QuantityUI)$" }]
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^(CartUI|CustomerAPI|CustomerUI|OrderUI|ProductCardUI|QuantityUI)$" }]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@
 **ServiceRegistry — лишний debug-шум в логах (#225, closes #224):**
 - На штатной установке без кастомизации сервисов `loadMainConfig()` / `loadAddonConfigs()` писали DEBUG про отсутствие дефолтных override-путей. Теперь логирование срабатывает только если оператор явно задал `ms3_services_config` / `ms3_services_addons_dir` через system settings, а файла/папки по этому пути нет.
 
+**Подтверждение email на витрине — ссылка из письма и повторная отправка в ЛК (#226):**
+- Ссылка по умолчанию ведёт на Web API `api.php?route=…/email/verify&token=…&html=1` (раньше — несуществующий `verify-email` на `site_url`); кастомный URL — системная настройка `ms3_email_verification_url`. После клика в письме: редирект на сайт с `ms3_email_verified=1|0` (для success — опционально `ms3_email_verification_success_url`); `format=json` по-прежнему отдаёт JSON.
+- `Response` и `api.php` поддерживают HTTP-редирект вместо JSON для таких маршрутов.
+- Подключены `CustomerAPI::resendVerificationEmail`, `CustomerUI`, селекторы и `ms3_customer_profile.tpl` — кнопка resend инициирует `POST /api/v1/customer/email/resend-verification`. Добавлены README, лексиконы, smoke-тест `core/components/minishop3/tests/EmailVerificationUrlTest.php`.
+
 #### 📁 Изменённые файлы
 
 ```

--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -419,6 +419,16 @@ return [
         'xtype' => 'numberfield',
         'area' => 'ms3_security',
     ],
+    'ms3_email_verification_url' => [
+        'value' => '',
+        'xtype' => 'textfield',
+        'area' => 'ms3_security',
+    ],
+    'ms3_email_verification_success_url' => [
+        'value' => '',
+        'xtype' => 'textfield',
+        'area' => 'ms3_security',
+    ],
     'ms3_payment_secret' => [
         'value' => '',
         'xtype' => 'textfield',

--- a/assets/components/minishop3/api.php
+++ b/assets/components/minishop3/api.php
@@ -15,8 +15,7 @@
  * @package MiniShop3
  */
 
-// Устанавливаем заголовки для JSON API
-header('Content-Type: application/json; charset=utf-8');
+// JSON Content-Type выставляется только при отдаче тела (не при HTTP redirect)
 
 // Проверяем наличие параметра route
 if (empty($_REQUEST['route'])) {
@@ -92,14 +91,19 @@ try {
     // Обрабатываем запрос
     $response = $router->dispatch($route, $_SERVER['REQUEST_METHOD']);
 
-    // Получаем данные ответа
-    $responseData = $response->getData();
     $statusCode = $response->getStatusCode();
+    $redirectUrl = $response->getRedirectUrl();
+    if ($redirectUrl !== null && $redirectUrl !== '') {
+        http_response_code($statusCode);
+        header('Location: ' . $redirectUrl);
+        exit;
+    }
 
-    // Устанавливаем HTTP статус код
+    $responseData = $response->getData();
+
     http_response_code($statusCode);
+    header('Content-Type: application/json; charset=utf-8');
 
-    // Выводим JSON
     echo json_encode($responseData, JSON_UNESCAPED_UNICODE);
 
 } catch (\Exception $e) {

--- a/assets/components/minishop3/js/web/core/CustomerAPI.js
+++ b/assets/components/minishop3/js/web/core/CustomerAPI.js
@@ -159,4 +159,15 @@ class CustomerAPI {
   async cancelOrder (orderId) {
     return this.api.post(`/api/v1/customer/orders/${orderId}/cancel`)
   }
+
+  /**
+   * Resend email verification (cabinet; requires customer session)
+   *
+   * POST /api/v1/customer/email/resend-verification
+   *
+   * @returns {Promise<Object>}
+   */
+  async resendVerificationEmail () {
+    return this.api.post('/api/v1/customer/email/resend-verification', {})
+  }
 }

--- a/assets/components/minishop3/js/web/core/Selectors.js
+++ b/assets/components/minishop3/js/web/core/Selectors.js
@@ -22,6 +22,8 @@ const defaultSelectors = {
   orderCancel: '.ms3-order-cancel',
   addressSetDefault: '.set-default-address',
   addressDelete: '.delete-address',
+  resendVerificationEmail:
+    '#resend-verification-email, [data-ms3-resend-verification]',
   authLoginForm: '#ms3-login-form',
   authRegisterForm: '#ms3-register-form',
   authForgotPassword: '#forgot-password-link'

--- a/assets/components/minishop3/js/web/ms3.js
+++ b/assets/components/minishop3/js/web/ms3.js
@@ -75,6 +75,8 @@ const ms3 = {
       orderCancel: '.ms3-order-cancel',
       addressSetDefault: '.set-default-address',
       addressDelete: '.delete-address',
+      resendVerificationEmail:
+        '#resend-verification-email, [data-ms3-resend-verification]',
       authLoginForm: '#ms3-login-form',
       authRegisterForm: '#ms3-register-form',
       authForgotPassword: '#forgot-password-link'

--- a/assets/components/minishop3/js/web/ui/CustomerUI.js
+++ b/assets/components/minishop3/js/web/ui/CustomerUI.js
@@ -18,7 +18,8 @@ const CUSTOMER_UI_LEXICON = {
   ms3_customer_order_cancel_error: 'Failed to cancel order',
   ms3_customer_order_cancel_request_error: 'Request failed',
   ms3_customer_address_set_default_error: 'Failed to set default address',
-  ms3_customer_address_delete_error: 'Failed to delete address'
+  ms3_customer_address_delete_error: 'Failed to delete address',
+  ms3_email_verification_sent: 'Verification email has been sent'
 }
 
 class CustomerUI {
@@ -64,6 +65,7 @@ class CustomerUI {
     })
     this.initOrderCancel()
     this.initAddressManagement()
+    this.initResendVerification()
   }
 
   /**
@@ -322,6 +324,49 @@ class CustomerUI {
       this.message.error(this.t('ms3_customer_err_occurred_saving'))
       return { success: false, message: error.message }
     }
+  }
+
+  /**
+   * Resend email verification (profile / cabinet)
+   */
+  initResendVerification () {
+    const selector = this.selectors.resendVerificationEmail
+    if (!selector) {
+      return
+    }
+    document.querySelectorAll(selector).forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.preventDefault()
+        if (btn.disabled) {
+          return
+        }
+        const hookData = { button: btn }
+        await this.hooks.runHooks('beforeResendVerificationEmail', hookData)
+        if (hookData.cancel) {
+          return
+        }
+        btn.disabled = true
+        try {
+          const response = await this.customer.resendVerificationEmail()
+          await this.hooks.runHooks('afterResendVerificationEmail', { response, button: btn })
+          if (response.success) {
+            this.message.success(
+              response.message || this.t('ms3_email_verification_sent')
+            )
+            setTimeout(() => {
+              window.location.reload()
+            }, 1200)
+          } else {
+            this.message.error(response.message || this.t('ms3_customer_err_occurred'))
+            btn.disabled = false
+          }
+        } catch (error) {
+          console.error('CustomerUI.initResendVerification error:', error)
+          this.message.error(this.t('ms3_customer_err_occurred'))
+          btn.disabled = false
+        }
+      })
+    })
   }
 
   /**

--- a/core/components/minishop3/elements/chunks/ms3_customer_profile.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_customer_profile.tpl
@@ -81,6 +81,7 @@
                         <button class="btn btn-outline-warning"
                                 type="button"
                                 id="resend-verification-email"
+                                data-ms3-resend-verification
                                 data-customer-id="{$customer.id}">
                             {'ms3_customer_email_send_verification' | lexicon}
                         </button>

--- a/core/components/minishop3/lexicon/en/setting.inc.php
+++ b/core/components/minishop3/lexicon/en/setting.inc.php
@@ -174,6 +174,10 @@ $_lang['setting_ms3_password_reset_token_ttl'] = 'Password reset token Time-To-L
 $_lang['setting_ms3_password_reset_token_ttl_desc'] = 'Time in seconds for which the password reset link remains valid. Default is 3600 (1 hour).';
 $_lang['setting_ms3_email_verification_token_ttl'] = 'Email verification token Time-To-Live (TTL)';
 $_lang['setting_ms3_email_verification_token_ttl_desc'] = 'Time in seconds for which the email verification link remains valid. Default is 86400 (24 hours).';
+$_lang['setting_ms3_email_verification_url'] = 'Custom email verification link (optional)';
+$_lang['setting_ms3_email_verification_url_desc'] = 'If empty, the link points to the Web API (api.php) verify route. To use your own page, set a full URL and include the placeholder [[+token]] or {token} where the token must appear.';
+$_lang['setting_ms3_email_verification_success_url'] = 'Redirect URL after successful email verification (optional)';
+$_lang['setting_ms3_email_verification_success_url_desc'] = 'Used when the user opens the verification link from email (html=1). If empty, site_url is used; the query parameter ms3_email_verified=1 is appended.';
 $_lang['setting_ms3_payment_secret'] = 'Payment secret key';
 $_lang['setting_ms3_payment_secret_desc'] = 'Secret key for generating payment notification signatures. Recommended to set a unique value for improved security.';
 

--- a/core/components/minishop3/lexicon/ru/setting.inc.php
+++ b/core/components/minishop3/lexicon/ru/setting.inc.php
@@ -174,6 +174,10 @@ $_lang['setting_ms3_password_reset_token_ttl'] = 'Время жизни токе
 $_lang['setting_ms3_password_reset_token_ttl_desc'] = 'Время в секундах, в течение которого ссылка для сброса пароля остается действительной. По умолчанию 3600 (1 час).';
 $_lang['setting_ms3_email_verification_token_ttl'] = 'Время жизни токена верификации email (TTL)';
 $_lang['setting_ms3_email_verification_token_ttl_desc'] = 'Время в секундах, в течение которого ссылка для верификации email остается действительной. По умолчанию 86400 (24 часа).';
+$_lang['setting_ms3_email_verification_url'] = 'Свой URL подтверждения email (необязательно)';
+$_lang['setting_ms3_email_verification_url_desc'] = 'Если пусто, в письме подставляется ссылка на Web API (api.php), маршрут верификации. Для своей страницы укажите полный URL и плейсхолдер [[+token]] или {token} для подстановки токена.';
+$_lang['setting_ms3_email_verification_success_url'] = 'URL редиректа после успешной верификации email (необязательно)';
+$_lang['setting_ms3_email_verification_success_url_desc'] = 'Используется при переходе по ссылке из письма (параметр html=1). Если пусто — берётся site_url; к URL добавляется параметр ms3_email_verified=1.';
 $_lang['setting_ms3_payment_secret'] = 'Секретный ключ для платежей';
 $_lang['setting_ms3_payment_secret_desc'] = 'Секретный ключ для генерации подписей платежных уведомлений. Рекомендуется установить уникальное значение для повышения безопасности.';
 

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Router\Response;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MODX\Revolution\modX;
 
@@ -81,20 +82,34 @@ class CustomerEmailController
      *
      * GET /api/v1/customer/email/verify?token={token}
      *
+     * - `format=json` — всегда JSON (интеграции, отладка).
+     * - `html=1` (как в ссылке из письма) — после успеха/ошибки HTTP 302 на сайт (см. GH-226).
+     *
      * @param array $params Request parameters
-     * @return array ['success' => bool, 'message' => string]
+     * @return array|Response
      */
-    public function verify(array $params): array
+    public function verify(array $params): array|Response
     {
+        $formatJson = ($params['format'] ?? '') === 'json';
+        $htmlFlow = ($params['html'] ?? '') === '1';
+
         $token = $params['token'] ?? '';
 
         if (empty($token)) {
+            if ($htmlFlow && !$formatJson) {
+                return Response::redirect($this->buildEmailVerificationFailedRedirectUrl(), 302);
+            }
+
             return $this->error($this->modx->lexicon('ms3_customer_err_token_required'));
         }
 
         $customer = $this->emailVerification->verifyToken($token);
 
         if (!$customer) {
+            if ($htmlFlow && !$formatJson) {
+                return Response::redirect($this->buildEmailVerificationFailedRedirectUrl(), 302);
+            }
+
             return $this->error($this->modx->lexicon('ms3_customer_err_email_verification_invalid'));
         }
 
@@ -106,10 +121,38 @@ class CustomerEmailController
             "[CustomerEmailController] Email verified and customer #{$customer->id} auto-logged in"
         );
 
+        if ($htmlFlow && !$formatJson) {
+            return Response::redirect($this->buildEmailVerificationSuccessRedirectUrl(), 302);
+        }
+
         return $this->success(
             $this->modx->lexicon('ms3_customer_email_verified'),
             ['customer_id' => $customer->id]
         );
+    }
+
+    /**
+     * Куда вести пользователя после успешной верификации (браузер, html=1)
+     */
+    protected function buildEmailVerificationSuccessRedirectUrl(): string
+    {
+        $target = trim((string) $this->modx->getOption('ms3_email_verification_success_url', null, ''));
+        if ($target === '') {
+            $target = rtrim((string) $this->modx->getOption('site_url', null, '/'), '/');
+        }
+        $sep = str_contains($target, '?') ? '&' : '?';
+
+        return $target . $sep . 'ms3_email_verified=1';
+    }
+
+    /**
+     * Куда вести при невалидном/просроченном токене (браузер, html=1)
+     */
+    protected function buildEmailVerificationFailedRedirectUrl(): string
+    {
+        $base = rtrim((string) $this->modx->getOption('site_url', null, '/'), '/');
+
+        return $base . '?ms3_email_verified=0';
     }
 
     /**

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -11,11 +11,30 @@ class Response
     protected $statusCode;
     protected $headers = [];
 
+    /** @var string|null HTTP redirect target (Location) */
+    protected ?string $redirectUrl = null;
+
     public function __construct($data, int $statusCode = HttpStatus::OK, array $headers = [])
     {
         $this->data = $data;
         $this->statusCode = $statusCode;
         $this->headers = $headers;
+    }
+
+    /**
+     * Redirect response (e.g. email verification in browser; api.php sends Location)
+     */
+    public static function redirect(string $url, int $statusCode = 302): self
+    {
+        $r = new self(null, $statusCode);
+        $r->redirectUrl = $url;
+
+        return $r;
+    }
+
+    public function getRedirectUrl(): ?string
+    {
+        return $this->redirectUrl;
     }
 
     /**
@@ -58,6 +77,14 @@ class Response
     public function send(): void
     {
         http_response_code($this->statusCode);
+
+        if ($this->redirectUrl !== null) {
+            header('Location: ' . $this->redirectUrl);
+            foreach ($this->headers as $name => $value) {
+                header("{$name}: {$value}");
+            }
+            exit;
+        }
 
         header('Content-Type: application/json; charset=utf-8');
         foreach ($this->headers as $name => $value) {

--- a/core/components/minishop3/src/Services/Customer/EmailVerificationService.php
+++ b/core/components/minishop3/src/Services/Customer/EmailVerificationService.php
@@ -99,9 +99,7 @@ class EmailVerificationService
         }
 
         $token = $tokenObj->get('token');
-
-        $siteUrl = $this->modx->getOption('site_url');
-        $verificationUrl = $siteUrl . 'verify-email?token=' . $token;
+        $verificationUrl = $this->buildEmailVerificationUrl($token);
 
         $email = $customer->get('email');
         $siteName = $this->modx->getOption('site_name');
@@ -138,6 +136,54 @@ class EmailVerificationService
         );
 
         return false;
+    }
+
+    /**
+     * Public URL for email confirmation (GET Web API, see routes/web.php).
+     *
+     * Optional system setting ms3_email_verification_url: use [[+token]] or {token} placeholder
+     * for a custom page; leave empty to use api.php route (fixes GH-226 when verify-email page is absent).
+     */
+    protected function buildEmailVerificationUrl(string $token): string
+    {
+        $custom = trim((string) $this->modx->getOption('ms3_email_verification_url', null, ''));
+        if ($custom !== '') {
+            return str_replace(
+                ['[[+token]]', '{token}'],
+                [rawurlencode($token), rawurlencode($token)],
+                $custom
+            );
+        }
+
+        $assetsUrl = $this->modx->getOption(
+            'ms3_assets_url',
+            null,
+            $this->modx->getOption('assets_url', null, '') . 'components/minishop3/'
+        );
+        $apiBase = rtrim($assetsUrl, '/') . '/api.php';
+        if (!str_starts_with($apiBase, 'http://') && !str_starts_with($apiBase, 'https://') && !str_starts_with($apiBase, '//')) {
+            $apiBase = rtrim($this->modx->getOption('site_url', null, ''), '/') . '/' . ltrim($apiBase, '/');
+        }
+
+        return self::buildDefaultVerifyRequestUrl($apiBase, $token, true);
+    }
+
+    /**
+     * Собирает query для Web API подтверждения email (тесты и единая логика с письмом).
+     *
+     * @param string $apiPhpAbsoluteUrl Полный URL до api.php
+     * @param bool   $includeHtmlParam  false — только JSON; true — в ссылку добавляется html=1 (редирект после клика в письме)
+     */
+    public static function buildDefaultVerifyRequestUrl(string $apiPhpAbsoluteUrl, string $token, bool $includeHtmlParam = true): string
+    {
+        $sep = str_contains($apiPhpAbsoluteUrl, '?') ? '&' : '?';
+        $q = 'route=' . rawurlencode('/api/v1/customer/email/verify')
+            . '&token=' . rawurlencode($token);
+        if ($includeHtmlParam) {
+            $q .= '&html=1';
+        }
+
+        return $apiPhpAbsoluteUrl . $sep . $q;
     }
 
     /**

--- a/core/components/minishop3/tests/EmailVerificationUrlTest.php
+++ b/core/components/minishop3/tests/EmailVerificationUrlTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Статические проверки URL подтверждения email (без MODX).
+ *
+ * Запуск: php tests/EmailVerificationUrlTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Customer\EmailVerificationService;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$apiBase = 'https://example.org/assets/components/minishop3/api.php';
+$token = 'tok&x=1';
+$expectedToken = rawurlencode($token);
+$expectedRoute = rawurlencode('/api/v1/customer/email/verify');
+$qBase = "route={$expectedRoute}&token={$expectedToken}";
+
+$withHtml = EmailVerificationService::buildDefaultVerifyRequestUrl($apiBase, $token, true);
+$expectedWithHtml = $apiBase . '?' . $qBase . '&html=1';
+if ($withHtml !== $expectedWithHtml) {
+    $fail("with html: expected \n{$expectedWithHtml}\n got \n{$withHtml}");
+}
+if (!str_contains($withHtml, 'html=1')) {
+    $fail('with html: missing html=1');
+}
+
+$withoutHtml = EmailVerificationService::buildDefaultVerifyRequestUrl($apiBase, $token, false);
+$expectedNoHtml = $apiBase . '?' . $qBase;
+if ($withoutHtml !== $expectedNoHtml) {
+    $fail("without html: expected \n{$expectedNoHtml}\n got \n{$withoutHtml}");
+}
+if (str_contains($withoutHtml, 'html=1')) {
+    $fail('without html: html=1 should be absent');
+}
+
+$apiWithQuery = 'https://example.org/api.php?debug=0';
+$withAmp = EmailVerificationService::buildDefaultVerifyRequestUrl($apiWithQuery, 'abc', true);
+if (!str_starts_with($withAmp, $apiWithQuery . '&')) {
+    $fail('base URL with ? must use & to append query');
+}
+
+fwrite(STDOUT, "OK EmailVerificationUrlTest\n");
+exit(0);

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,12 @@ php _build/build.php
 - [REST API](https://docs.modx.pro/components/minishop3/development/api) — интеграция с внешними системами
 - [События](https://docs.modx.pro/components/minishop3/development/events) — расширение функциональности
 
+### Подтверждение email (Web API)
+
+Ссылка в письме ведёт на `api.php` с путём верификации и параметром `html=1` — в ответ сервер отдаёт **HTTP-редирект** (302) на сайт с признаком `ms3_email_verified=1` либо `ms3_email_verified=0`. URL после успешной проверки задаётся системной настройкой `ms3_email_verification_success_url` (если пусто — `site_url`).
+
+Если открыть тот же URL **без** `html=1` или с `format=json`, ответ будет **JSON** (удобно для API-клиентов; в браузере увидите «сырое» тело).
+
 ## 🏗️ Структура проекта
 
 ```


### PR DESCRIPTION
## Описание

Устраняет [интеграционный разрыв](https://github.com/modx-pro/MiniShop3/issues/226): письмо вело на несуществующий путь `verify-email` (не вызывался Web API), кнопка повторной отправки в шаблоне ЛК не была привязана к JS.

- **Письмо:** по умолчанию ссылка на `api.php` с `route=/api/v1/customer/email/verify`, `token`, `html=1` (опция `ms3_email_verification_url` для кастомного URL). После клика — HTTP-редирект на сайт с `ms3_email_verified=1|0`, опционально цель успеха `ms3_email_verification_success_url`. Запрос с `format=json` по-прежнему возвращает JSON.
- **ЛК:** `CustomerAPI::resendVerificationEmail`, обработка в `CustomerUI`, селекторы и `ms3_customer_profile.tpl`.
- **Технически:** `Response::redirect`, ветка в `api.php` без раннего `Content-Type: application/json` при редиректе; `CustomerEmailController::verify` учитывает `html=1` / `format=json`.
- **Документация и тесты:** фрагмент в `readme.md`, лексиконы настроек ru/en, `php tests/EmailVerificationUrlTest.php` для URL-сборки.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [x] Документация
- [ ] Другое (опишите):

## Связанные Issues

Fixes #226

## Как это было протестировано?

- [x] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/gh-226-email-verification`
- MODX: —
- PHP: 8.2+ (syntax / phpcs / запуск `EmailVerificationUrlTest`)

Проверки: `php -l` по затронутым PHP, `phpcs` для тест-скрипта, `npx eslint` для изменённого JS, `php core/components/minishop3/tests/EmailVerificationUrlTest.php`.

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Ревью: при открытии verify без `html=1` в браузере по-прежнему возможен «сырой» JSON — поведение описано в README.
