### PR TITLE
fix(product): сохранение options-* при обновлении товара, MODX 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 
 #### 🐛 Исправлено
 
+**Опции товара — удаление не применялось после сохранения (дополнение к #199 / #202):**
+- В `Processors\Product\Update` после вызова родительского `afterSave()` свойство процессора `options` в MODX 3 часто пустое, из‑за чего не выполнялся `ProductDataService::saveOptions(..., removeOther: true)` и строки в `ms3_product_options` не синхронизировались с формой. Массив из полей `options-*` сохраняется в `beforeSet` в `$ms3ProductFormOptions` и передаётся в сервис после сохранения ресурса.
+
 **Manager API — события жизненного цикла позиции заказа (#208, closes #207):**
 - Vue-админка дёргает `msOnBefore/Create/Update/Remove OrderProduct` через `Utils::invokeEvent` при добавлении/изменении/удалении позиций заказа — раньше события были зарегистрированы в `events.php`, но `OrdersController` их не вызывал, и сторонние подписчики (ms3PromoCode и т.п.) не срабатывали.
 - Before-hooks могут заблокировать операцию через `Response::error(400)`. After-hooks логируются на WARN-уровне с маркером `(persistence already done)` — ошибка плагина после `save()`/`remove()` не возвращается клиенту как 4xx, потому что persistence уже произошёл.

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -20,6 +20,15 @@ class Update extends UpdateProcessor
     public $object;
 
     /**
+     * Values parsed from options-* request fields in beforeSet(). On MODX 3, getProperty('options') is
+     * often empty after the parent afterSave() call, so this copy is used for
+     * ProductDataService::saveOptions(..., removeOther: true) — #199. Null if the request had no options-*.
+     *
+     * @var array<string, mixed>|null
+     */
+    protected $ms3ProductFormOptions = null;
+
+    /**
      * Allow for Resources to use derivative classes for their processors
      *
      * @static
@@ -38,14 +47,20 @@ class Update extends UpdateProcessor
      */
     public function beforeSet()
     {
+        $this->ms3ProductFormOptions = null;
         $properties = $this->getProperties();
         $options = [];
+        $hadOptionFieldsInRequest = false;
         foreach ($properties as $key => $value) {
             $optionKey = Utils::extractOptionKey($key);
             if ($optionKey !== null) {
+                $hadOptionFieldsInRequest = true;
                 $options[$optionKey] = Utils::decodeOptionValue($value);
                 $this->unsetProperty($key);
             }
+        }
+        if ($hadOptionFieldsInRequest) {
+            $this->ms3ProductFormOptions = $options;
         }
         if (!empty($options)) {
             $this->setProperty('options', $options);
@@ -107,18 +122,12 @@ class Update extends UpdateProcessor
     {
         $result = parent::afterSave();
 
-        // Save product options from options-* form fields (parsed in beforeSet)
-        // Only runs when form actually contained options-* fields
-        // removeOther=true: POST contains the full set of options shown on the form — keys missing after
-        // user removal must be deleted from DB (see #199). JSON-only sync still uses saveOptions(null)
-        // in msProductData::save(), which forces removeOther=false (#153, #158).
-        $options = $this->getProperty('options');
-        if (!empty($options) && is_array($options)) {
+        if ($this->ms3ProductFormOptions !== null) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                $service->saveOptions($productData, $options, true);
+                $service->saveOptions($productData, $this->ms3ProductFormOptions, true);
             }
         }
 


### PR DESCRIPTION
## Описание

В `MiniShop3\Processors\Product\Update` массив опций из полей `options-*` больше не читается через `getProperty('options')` **после** `parent::afterSave()`: в MODX 3 к этому моменту свойство часто пустое, поэтому не вызывался `ProductDataService::saveOptions(..., removeOther: true)` — строки в `ms3_product_options` оставались (сценарий [issue #199](https://github.com/modx-pro/MiniShop3/issues/199): копирование товара, удаление опции, сохранение, значение снова после перезагрузки).

Парсинг по-прежнему в `beforeSet()`, снимок хранится в `$ms3ProductFormOptions` и передаётся в сервис в `afterSave()`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #199

## Как это было протестировано?

Рекомендуемая проверка: товар в категории с опцией(ями) — задать значение — сохранить — очистить/удалить опцию (или сценарий с копированием товара, как в #199) — сохранить — перезагрузить карточку; убедиться, что в `ms3_product_options` нет «лишних» строк по ожидаемой политике `removeOther`.

- [x] Ручное тестирование (ожидается на стороне ревьюера/автора)
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**

- MiniShop3: ветка PR
- MODX: 3.20+ (как в #199)
- PHP: согласно окружению проекта

## Скриншоты (если применимо)

N/A (изменения только в PHP-процессоре)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений) — N/A
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Связанные с более ранним фиксом: `removeOther=true` при явном списке из формы; JSON-only путь `saveOptions(null)` в `msProductData::save()` с `removeOther=false` не затрагивается (#153, #158).
