### PR TITLE
fix(manager): предупреждение formatRow и сохранение дополнительных категорий товара

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@
 - `msOnBeforeImport` и `msOnImportRow` применяют `returnedValues` к параметрам импорта и данным строки (`data`, `tvData`, `optionData`, `gallery`).
 - `msOnProductsLoad` и `msOnProductPrepare` применяют `returnedValues['rows']` / `returnedValues['row']`, чтобы bulk-обогащение списка товаров и подготовка отдельной строки доходили до рендера.
 
+### [2026-05-08] 🐛 Исправления Manager API и сохранения товара (#238)
+
+#### 🐛 Исправлено
+
+**Категория → опции — PHP Warning `Undefined array key "id"` (PHP 8+):**
+- У `msCategoryOption` составной первичный ключ; в выборке списка нет столбца `id`. `CategoryOptionsController::formatRow()` больше не обращается к несуществующему ключу: если `id` нет в строке PDO, для поля ответа `id` используется `option_id` (в рамках одной категории уникально; Vue-грид и так использует `data-key="option_id"`).
+
+**Товар — сохранение без вкладки «Категории» обнуляло дополнительные категории:**
+- `ProductDataService::saveCategories()` при отсутствии ключа `categories` в `_fields` (POST не содержит поля, пока дерево вкладки не отрисовалось) больше не трактует это как пустой список и не вызывает `removeCollection`. Поведение согласовано с `saveLinks()`: явная передача `categories` по-прежнему синхронизирует `msCategoryMember` (в том числе пустой массив после открытия вкладки).
+
+#### 📁 Изменённые файлы
+
+```
+core/components/minishop3/src/Controllers/Api/Manager/CategoryOptionsController.php
+core/components/minishop3/src/Services/Product/ProductDataService.php
+```
+
 ---
 
 ## Апрель 2026

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryOptionsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryOptionsController.php
@@ -369,10 +369,15 @@ class CategoryOptionsController
             $globalCaption
         );
 
+        // msCategoryOption has composite PK (category_id, option_id); SQL select has no `id` column.
+        $categoryId = (int)($row['category_id'] ?? 0);
+        $optionId = (int)($row['option_id'] ?? 0);
+        $rowId = array_key_exists('id', $row) ? (int)$row['id'] : $optionId;
+
         return [
-            'id' => (int)$row['id'],
-            'option_id' => (int)$row['option_id'],
-            'category_id' => (int)$row['category_id'],
+            'id' => $rowId,
+            'option_id' => $optionId,
+            'category_id' => $categoryId,
             'position' => (int)($row['position'] ?? 0),
             'active' => (bool)($row['active'] ?? false),
             'required' => (bool)($row['required'] ?? false),

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -79,6 +79,9 @@ class ProductDataService
      * IMPORTANT: msProductData::get('categories') is overridden and reads from DB,
      * so we use reflection to get the value from $_fields (POST data)
      *
+     * If `categories` was not sent (e.g. manager save before the Categories tab mounted its
+     * hidden field), leave msCategoryMember untouched — same contract as saveLinks().
+     *
      * @param msProductData $productData
      * @return void
      */
@@ -90,7 +93,12 @@ class ProductDataService
         $property = $reflection->getProperty('_fields');
         $property->setAccessible(true);
         $fields = $property->getValue($productData);
-        $categories = $fields['categories'] ?? null;
+
+        if (!array_key_exists('categories', $fields)) {
+            return;
+        }
+
+        $categories = $fields['categories'];
 
         if (is_string($categories)) {
             $categories = json_decode($categories, true);


### PR DESCRIPTION
## Описание

Исправление двух связанных проблем менеджера (карточка категории → опции; карточка товара → дополнительные категории).

- **Список опций категории:** у `msCategoryOption` составной первичный ключ, в PDO-строке нет колонки `id`; `formatRow()` больше не читает `$row['id']` (fallback на `option_id` в рамках одной категории, при появлении `id` в выборке используется он).
- **Доп. категории товара:** `saveCategories()` при отсутствии ключа `categories` в `$_fields` (форма не отправила поле, например вкладка «Категории» ещё не монтировала скрытое поле) выходит без изменений, не очищая `msCategoryMember` — тот же контракт, что у `saveLinks()`.

Добавлена запись в `CHANGELOG.md`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #238

**Примечание:** поведение интеграций, которые сознательно опирались на «в POST нет `categories` → очистить связи», изменилось: очистка возможна только при явной передаче `categories` (включая пустой массив).

## Как это было протестировано?

- Логическое сопоставление с сценарием из issue; `php -l` для изменённых PHP-файлов.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: —
- PHP: синтаксическая проверка локально

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Ревью: при необходимости зафиксировать в документации для интеграторов, что отсутствие ключа `categories` означает «не менять членство», а не «сбросить».
