### PR TITLE
fix(snippet): числовые плейсхолдеры сумм в msOrder и msGetOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
 - `msOnBeforeImport` и `msOnImportRow` применяют `returnedValues` к параметрам импорта и данным строки (`data`, `tvData`, `optionData`, `gallery`).
 - `msOnProductsLoad` и `msOnProductPrepare` применяют `returnedValues['rows']` / `returnedValues['row']`, чтобы bulk-обогащение списка товаров и подготовка отдельной строки доходили до рендера.
 
+#### ✨ Улучшено
+
+**Сниппеты msOrder / msGetOrder — числовые суммы для шаблонов (#242):**
+- В массив `$order` сниппета **msOrder** добавлены `cost_numeric`, `cart_cost_numeric`, `delivery_cost_numeric`, `discount_cost_numeric` (float из ответа `getCost()`): для Fenom/pdoTools доступен безопасный `|number` и арифметика; поля `cost`, `cart_cost`, `delivery_cost`, `discount_cost` по-прежнему отформатированные строки для совместимости с чанками.
+- В **msGetOrder** в плейсхолдер `total` добавлены `cost_numeric`, `cart_cost_numeric`, `delivery_cost_numeric` (значения из модели заказа).
+
 ---
 
 ## Апрель 2026

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -257,13 +257,18 @@ try {
         'payment' => ($payment = $msOrder->getOne('Payment'))
             ? $payment->toArray()
             : [],
+        // Блок total: cost, cart_cost и delivery_cost — отформатированные строки для шаблона;
+        // поля с суффиксом _numeric — те же суммы числом, из записи заказа в БД.
         'total' => [
             'cost' => $ms3->format->price($msOrder->get('cost')),
             'cost_formatted' => $ms3->format->price($msOrder->get('cost'), true),
+            'cost_numeric' => (float)$msOrder->get('cost'),
             'cart_cost' => $ms3->format->price($msOrder->get('cart_cost')),
             'cart_cost_formatted' => $ms3->format->price($msOrder->get('cart_cost'), true),
+            'cart_cost_numeric' => (float)$msOrder->get('cart_cost'),
             'delivery_cost' => $ms3->format->price($msOrder->get('delivery_cost')),
             'delivery_cost_formatted' => $ms3->format->price($msOrder->get('delivery_cost'), true),
+            'delivery_cost_numeric' => (float)$msOrder->get('delivery_cost'),
             'weight' => $ms3->format->weight($msOrder->get('weight')),
             'weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
             'cart_weight' => $ms3->format->weight($msOrder->get('weight')),

--- a/core/components/minishop3/elements/snippets/ms3_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_order.php
@@ -55,11 +55,17 @@ if ($response['success']) {
 $response = $ms3->order->getCost();
 if ($response['success']) {
     $cost = $response['data'];
+    // Суммы в cost, cart_cost, delivery_cost и discount_cost — это строки с локальным форматом
+    // (разделители тысяч, десятичный разделитель), как в стандартных чанках. Те же величины
+    // как числа — в полях с суффиксом _numeric (удобно для |number в Fenom и арифметики).
     $order['cost'] = $ms3->format->price($cost['cost']);
     $order['cart_cost'] = $ms3->format->price($cost['cart_cost']);
     $order['delivery_cost'] = $ms3->format->price($cost['delivery_cost']);
     $order['discount_cost'] = $ms3->format->price($cost['total_discount']);
-    // Pre-formatted fields with currency symbol for display in chunks
+    $order['cost_numeric'] = (float)($cost['cost'] ?? 0);
+    $order['cart_cost_numeric'] = (float)($cost['cart_cost'] ?? 0);
+    $order['delivery_cost_numeric'] = (float)($cost['delivery_cost'] ?? 0);
+    $order['discount_cost_numeric'] = (float)($cost['total_discount'] ?? 0);
     $order['cost_formatted'] = $ms3->format->price($cost['cost'], true);
     $order['cart_cost_formatted'] = $ms3->format->price($cost['cart_cost'], true);
     $order['delivery_cost_formatted'] = $ms3->format->price($cost['delivery_cost'], true);


### PR DESCRIPTION
## Описание

В сниппете **msOrder** (`ms3_order.php`) в массив `$order` добавлены поля `cost_numeric`, `cart_cost_numeric`, `delivery_cost_numeric` и `discount_cost_numeric` — те же суммы, что приходят из `getCost()`, но как `float`. Строковые `cost`, `cart_cost`, `delivery_cost`, `discount_cost` и блок `*_formatted` **не меняются**, чтобы не ломать текущие чанки (в т.ч. вывод с отдельным `currency_symbol`).

В **msGetOrder** (`ms3_get_order.php`) в плейсхолдер `total` добавлены `cost_numeric`, `cart_cost_numeric` и `delivery_cost_numeric` по значениям из модели заказа — единый контракт с msOrder для шаблонов.

В **CHANGELOG** добавлена запись за май 2026. Комментарии в коде поясняют разницу между строками для вывода и числами для расчётов.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Fixes #242

## Как это было протестировано?

- Проверка синтаксиса PHP: `php -l` для `ms3_order.php` и `ms3_get_order.php`.

- [ ] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: —
- PHP: —

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Использование в Fenom: например `{$order.cart_cost_numeric | number : 0 : '.' : ' '}` вместо `|number` по строковому `cart_cost`.

Источник обсуждения: [modx.pro, комментарий к новости](https://modx.pro/components/25552#comment-146510).