### PR TITLE
fix(events): restore by-ref params alongside returnedValues

### DIFF
--- a/core/components/minishop3/elements/snippets/ms3_products.php
+++ b/core/components/minishop3/elements/snippets/ms3_products.php
@@ -389,8 +389,13 @@ $applyReturnedArray = static function (array $current, array $returnedValues, st
 if (!empty($rows) && is_array($rows)) {
     $productIds = array_column($rows, 'id');
     $clearEventReturnedValues();
+    // Two propagation paths supported:
+    //   1) by-ref mutation of $rows in the plugin scope — preserved for plugins
+    //      (ms3Variants and others) that mutate $scriptProperties['rows'] directly.
+    //   2) $modx->event->returnedValues['rows'] — the explicit channel introduced
+    //      in #219/#245 for plugins that prefer the returned-values contract.
     $modx->invokeEvent('msOnProductsLoad', [
-        'rows' => $rows,
+        'rows' => &$rows,
         'productIds' => $productIds,
         'usePackages' => $usePackages,
         'scriptProperties' => $scriptProperties,
@@ -463,8 +468,9 @@ if (!empty($rows) && is_array($rows)) {
 
         // Event: msOnProductPrepare - enrich single product data from external packages
         $clearEventReturnedValues();
+        // by-ref + returnedValues — see msOnProductsLoad comment above.
         $modx->invokeEvent('msOnProductPrepare', [
-            'row' => $rows[$k],
+            'row' => &$rows[$k],
             'productId' => $row['id'],
             'idx' => $row['idx'],
         ]);

--- a/core/components/minishop3/src/Notifications/NotificationManager.php
+++ b/core/components/minishop3/src/Notifications/NotificationManager.php
@@ -68,13 +68,21 @@ class NotificationManager
         $channels = $notification->via($recipientType);
         $order = $notification->getOrder();
 
-        // Fire before event - allows plugins to modify or cancel notification
+        // Fire before event - allows plugins to modify or cancel notification.
+        //
+        // Two propagation paths supported:
+        //   1) by-ref mutation of $recipient/$channels in the plugin scope —
+        //      preserved for plugins that mutate $scriptProperties directly
+        //      (long-standing extension contract for third-party packages).
+        //   2) $modx->event->returnedValues['recipient']/['channels'] —
+        //      explicit channel introduced in #219/#245 for plugins that prefer
+        //      the returned-values contract.
         $this->clearEventReturnedValues();
         $eventResult = $this->modx->invokeEvent('msOnBeforeSendNotification', [
             'notification' => $notification,
-            'recipient' => $recipient,
+            'recipient' => &$recipient,
             'recipientType' => $recipientType,
-            'channels' => $channels,
+            'channels' => &$channels,
         ]);
         $returnedValues = $this->getEventReturnedValues();
         $recipient = $this->applyReturnedArray($recipient, $returnedValues, 'recipient');

--- a/core/components/minishop3/src/Utils/ImportCSV.php
+++ b/core/components/minishop3/src/Utils/ImportCSV.php
@@ -120,11 +120,17 @@ class ImportCSV
             }
         }
 
-        // Fire before import event
+        // Fire before import event.
+        //
+        // Two propagation paths supported:
+        //   1) by-ref mutation of $this->params in the plugin scope — preserved
+        //      for plugins that mutate $scriptProperties['params'] directly.
+        //   2) $modx->event->returnedValues['params'] — explicit channel from
+        //      #219/#245 for plugins that prefer the returned-values contract.
         $this->clearEventReturnedValues();
         $eventResult = $this->modx->invokeEvent('msOnBeforeImport', [
             'file' => $this->params['file'],
-            'params' => $this->params,
+            'params' => &$this->params,
         ]);
         $this->params = $this->applyReturnedArray($this->params, $this->getEventReturnedValues(), 'params');
         if ($this->isEventCancelled($eventResult)) {
@@ -345,15 +351,23 @@ class ImportCSV
             }
         }
 
-        // Fire event to allow modification of row data
+        // Fire event to allow modification of row data.
+        //
+        // Two propagation paths supported:
+        //   1) by-ref mutation of $data/$tvData/$optionData/$gallery in the
+        //      plugin scope — preserved for plugins that mutate $scriptProperties
+        //      directly (long-standing extension contract).
+        //   2) $modx->event->returnedValues['data'|'tvData'|'optionData'|'gallery']
+        //      — explicit channel from #219/#245 for plugins that prefer the
+        //      returned-values contract.
         $this->clearEventReturnedValues();
         $eventResult = $this->modx->invokeEvent('msOnImportRow', [
             'row' => $this->rows,
             'csv' => $csv,
-            'data' => $data,
-            'tvData' => $tvData,
-            'optionData' => $optionData,
-            'gallery' => $gallery,
+            'data' => &$data,
+            'tvData' => &$tvData,
+            'optionData' => &$optionData,
+            'gallery' => &$gallery,
         ]);
         $returnedValues = $this->getEventReturnedValues();
         $data = $this->applyReturnedArray($data, $returnedValues, 'data');


### PR DESCRIPTION
## Регрессия

PR #245 убрал \`&\` в параметрах пяти `invokeEvent`-вызовов на предположении, что by-ref-распространение всё равно не работает через MODX 3. На практике — работает. Сценарий, который сломался:

- На demo-сайте с MS3 **1.10.1-beta1** компонент **ms3Variants** корректно подгружал варианты товаров в каталог через мутацию `\$row = &\$scriptProperties['row']; \$row['variants'] = ...;`.
- После наката текущей \`beta\` (которая включает PR #245) — варианты исчезли с каталога.
- После применения этого фикса на ту же \`beta\` — варианты снова на месте.

Эмпирически подтверждено двусторонним тестом на сайте, где результат до/после был известен.

## Что в этом PR

Возвращаю \`&\` markers в пяти точках, **сохраняя** `returnedValues`-механизм рядом — оба способа работают параллельно. Плагины могут выбирать:

- **Старый путь** (используют существующие плагины, в т.ч. ms3Variants):
  ```php
  \$row = &\$scriptProperties['row'];
  \$row['variants'] = \$variantsMap[\$productId];
  ```
- **Новый путь** (добавлен в PR #245):
  ```php
  \$modx->event->returnedValues = ['row' => ['variants' => \$variantsMap[\$productId]]];
  ```

### Изменения

| Файл | Параметры с восстановленным \`&\` |
|---|---|
| \`core/components/minishop3/elements/snippets/ms3_products.php\` | \`rows\` (msOnProductsLoad), \`row\` (msOnProductPrepare) |
| \`core/components/minishop3/src/Notifications/NotificationManager.php\` | \`recipient\`, \`channels\` (msOnBeforeSendNotification) |
| \`core/components/minishop3/src/Utils/ImportCSV.php\` | \`params\` (msOnBeforeImport); \`data\`, \`tvData\`, \`optionData\`, \`gallery\` (msOnImportRow) |

К каждому месту добавлен inline-комментарий «Two propagation paths supported», чтобы будущему разработчику было понятно, почему мы держим оба механизма.

3 файла, +28/−12 строк. PHPStan — 0 ошибок.

## Что НЕ ломается

- Плагины, использующие новый `returnedValues`-механизм из PR #245, продолжают работать — мы не убирали helper-методы (\`clearEventReturnedValues\`, \`getEventReturnedValues\`, \`applyReturnedArray\`) и продолжаем применять returnedValues после invokeEvent.
- Issue #219 остаётся закрытым через PR #245 — second механизм действительно работает, добавляет новую точку расширения.

## Заметка по issue #219

Анализ в issue #219 содержал неверное утверждение, что MODX 3 не сохраняет references через \`invokeEvent\`. На практике сохраняет — через \`array_merge\` + \`extract\` references проходят. Это объясняет, почему ms3Variants годами работал именно через by-ref. \`returnedValues\` — параллельный путь, не замена.

## Тип релиза

PATCH к минорному треку. Critical regression: после PR #245 ms3Variants (и любой другой плагин, мутирующий эти params по ссылке) ломался на каталоге / в импорте / в уведомлениях. Поднять в первый же будущий релиз минора (1.11.0-beta1).

## Test plan

- [x] PHPStan на трогаемых файлах: 0 ошибок.
- [x] Тест на demo-сайте: до фикса — ms3Variants не выводит варианты, после — выводит.
- [ ] Перепроверить уведомления (msOnBeforeSendNotification) и CSV-импорт (msOnImportRow) на сторонних плагинах, если они в проекте есть.

Refs #219