### PR TITLE
fix(snippet): числовые плейсхолдеры сумм в msOrder и msGetOrder (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
 - `ProductDataService::saveCategories()` при отсутствии ключа `categories` в `_fields` (POST не содержит поля, пока дерево вкладки не отрисовалось) больше не трактует это как пустой список и не вызывает `removeCollection`. Поведение согласовано с `saveLinks()`: явная передача `categories` по-прежнему синхронизирует `msCategoryMember` (в том числе пустой массив после открытия вкладки).
 - **⚠️ Изменение контракта:** интеграции, сознательно полагавшиеся на «нет `categories` в POST → очистить связи», должны теперь передавать пустой массив явно.
 
+#### ✨ Улучшено
+
+**Сниппеты `msOrder` / `msGetOrder` — числовые суммы для шаблонов (#242):**
+- В массив `$order` сниппета **msOrder** добавлены `cost_numeric`, `cart_cost_numeric`, `delivery_cost_numeric`, `discount_cost_numeric` (float из ответа `getCost()`): для Fenom/pdoTools доступен безопасный `|number` и арифметика; поля `cost`, `cart_cost`, `delivery_cost`, `discount_cost` по-прежнему отформатированные строки для совместимости с чанками.
+- В **msGetOrder** в плейсхолдер `total` добавлены `cost_numeric`, `cart_cost_numeric`, `delivery_cost_numeric` (значения из модели заказа).
+
 ---
 
 ## Апрель 2026

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -257,13 +257,18 @@ try {
         'payment' => ($payment = $msOrder->getOne('Payment'))
             ? $payment->toArray()
             : [],
+        // Блок total: cost, cart_cost и delivery_cost — отформатированные строки для шаблона;
+        // поля с суффиксом _numeric — те же суммы числом, из записи заказа в БД.
         'total' => [
             'cost' => $ms3->format->price($msOrder->get('cost')),
             'cost_formatted' => $ms3->format->price($msOrder->get('cost'), true),
+            'cost_numeric' => (float)$msOrder->get('cost'),
             'cart_cost' => $ms3->format->price($msOrder->get('cart_cost')),
             'cart_cost_formatted' => $ms3->format->price($msOrder->get('cart_cost'), true),
+            'cart_cost_numeric' => (float)$msOrder->get('cart_cost'),
             'delivery_cost' => $ms3->format->price($msOrder->get('delivery_cost')),
             'delivery_cost_formatted' => $ms3->format->price($msOrder->get('delivery_cost'), true),
+            'delivery_cost_numeric' => (float)$msOrder->get('delivery_cost'),
             'weight' => $ms3->format->weight($msOrder->get('weight')),
             'weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
             'cart_weight' => $ms3->format->weight($msOrder->get('weight')),

--- a/core/components/minishop3/elements/snippets/ms3_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_order.php
@@ -55,11 +55,17 @@ if ($response['success']) {
 $response = $ms3->order->getCost();
 if ($response['success']) {
     $cost = $response['data'];
+    // Суммы в cost, cart_cost, delivery_cost и discount_cost — это строки с локальным форматом
+    // (разделители тысяч, десятичный разделитель), как в стандартных чанках. Те же величины
+    // как числа — в полях с суффиксом _numeric (удобно для |number в Fenom и арифметики).
     $order['cost'] = $ms3->format->price($cost['cost']);
     $order['cart_cost'] = $ms3->format->price($cost['cart_cost']);
     $order['delivery_cost'] = $ms3->format->price($cost['delivery_cost']);
     $order['discount_cost'] = $ms3->format->price($cost['total_discount']);
-    // Pre-formatted fields with currency symbol for display in chunks
+    $order['cost_numeric'] = (float)($cost['cost'] ?? 0);
+    $order['cart_cost_numeric'] = (float)($cost['cart_cost'] ?? 0);
+    $order['delivery_cost_numeric'] = (float)($cost['delivery_cost'] ?? 0);
+    $order['discount_cost_numeric'] = (float)($cost['total_discount'] ?? 0);
     $order['cost_formatted'] = $ms3->format->price($cost['cost'], true);
     $order['cart_cost_formatted'] = $ms3->format->price($cost['cart_cost'], true);
     $order['delivery_cost_formatted'] = $ms3->format->price($cost['delivery_cost'], true);


### PR DESCRIPTION
Перенос (с ребейзом) PR #243 от @Ibochkarev — оригинальная ветка в форке автора отставала от \`beta\` и конфликтовала по \`CHANGELOG.md\` после мержа PR #245 / #253 / #254 / #256 / #258. Сам фикс автора оставлен без изменений.

## Что в этом PR

3 файла, +18/−1 поверх актуального \`beta\`. Один коммит, авторство @Ibochkarev сохранено.

## Проблема (#242)

В сниппетах \`msOrder\` и \`msGetOrder\` поля сумм (\`cost\`, \`cart_cost\`, \`delivery_cost\`, \`discount_cost\`) формируются через \`\$ms3->format->price()\` — это **отформатированная строка** (разделители тысяч, запятая как десятичный разделитель), без символа валюты.

В Fenom-шаблонах это создаёт проблему: \`{\$order.cart_cost | number : 0 : '.' : ' '}\` ломается, потому что модификатор \`number\` ожидает на входе число, а получает строку \`\"5 200.00\"\`.

## Решение

В оба сниппета добавлены **новые поля** с суффиксом \`_numeric\` — те же суммы как \`float\`:

- **\`msOrder\` (\`ms3_order.php\`):** \`cost_numeric\`, \`cart_cost_numeric\`, \`delivery_cost_numeric\`, \`discount_cost_numeric\` — из ответа \`OrderCostCalculator::getCost()\`.
- **\`msGetOrder\` (\`ms3_get_order.php\`):** \`cost_numeric\`, \`cart_cost_numeric\`, \`delivery_cost_numeric\` в блоке \`total\` — напрямую из \`msOrder\` модели.

Существующие поля \`cost\` / \`cart_cost\` / \`delivery_cost\` / \`discount_cost\` и \`*_formatted\` **не трогаются** — совместимость с текущими чанками сохранена.

## Что хорошо

- **Non-breaking.** Только добавление новых ключей.
- **Минимальный риск регрессии.**
- **Inline-комментарии** в коде поясняют разницу строковых и числовых вариантов — для будущего разработчика.
- **CHANGELOG** оформлен как \`✨ Улучшено\` (правильный класс — это не bug fix, а улучшение API).
- PHPStan чистый.

## Что разрешено при ребейзе

- Конфликт в \`CHANGELOG.md\` — подраздел \`#### ✨ Улучшено\` добавлен в существующий блок \`## Май 2026 → ### Разработка\` после уже мерженного \`#### 🐛 Исправлено\`. Стиль раздела сохранён.

## Тип релиза

PATCH с improvement. В минор 1.11.0-beta1.

## Использование

В Fenom-шаблонах для арифметики и форматирования через \`|number\`:

\`\`\`
{\$order.cart_cost_numeric | number : 0 : '.' : ' '}
\`\`\`

Для готового вывода с валютой по-прежнему:

\`\`\`
{\$order.cart_cost_formatted}
\`\`\`

## Тестирование

- [x] PHPStan на трогаемых файлах — 0 ошибок.
- [x] Файлы синхронизированы на dev-сайт.
- [ ] Ручная проверка:
  - В чанке оформления заказа добавить \`{\$order.cart_cost_numeric}\` — выведется число.
  - В чанке \`mscart_outer\` (или подобном) использовать \`|number\` — должно работать.

## Связанные

- Closes #242
- Заменяет PR #243 (отставал от \`beta\`, конфликтовал по \`CHANGELOG.md\`; автор @Ibochkarev сохранён в коммите)