### PR TITLE
fix(product): сохранять опции при дублировании ресурса (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 #### 🐛 Исправлено
 
+**Копирование товара «Дублировать ресурс» — пустые опции (#257):**
+- После `modResource::duplicate()` значения из `ms3_product_options` снова выравниваются с исходным товаром через `OptionService` (чтение с `product_id` оригинала и полная синхронизация для копии).
+- `Processors\Product\Create` выровнен с `Update`: массив из полей `options-*` хранится в `$ms3ProductFormOptions`, а `ProductDataService::saveOptions(..., removeOther: true)` вызывается только если в запросе **были** ключи `options-*` — запрос без этих полей больше не обнуляет опции через отличие `!empty($options)` от «поля не пришли».
+
 **События с мутацией данных через `returnedValues` (#219):**
 - `msOnBeforeSendNotification` теперь применяет `returnedValues['recipient']` и `returnedValues['channels']`, поэтому плагины могут изменить получателя и каналы перед отправкой уведомления.
 - `msOnBeforeImport` и `msOnImportRow` применяют `returnedValues` к параметрам импорта и данным строки (`data`, `tvData`, `optionData`, `gallery`).

--- a/core/components/minishop3/src/Model/msProduct.php
+++ b/core/components/minishop3/src/Model/msProduct.php
@@ -396,10 +396,39 @@ class msProduct extends modResource
         parent::set('image', '');
         parent::set('thumb', '');
 
+        $sourceId = (int)$this->get('id');
+
         /** @var msProduct $newProduct */
         $newProduct = parent::duplicate($options);
 
+        // Ensure ms3_product_options rows match the source (#257). Core duplicate() persists JSON
+        // and ProductDataService::save(null), but a full sync from normalized table state is reliable
+        // (dynamic keys, partial JSON mirrors, first-save ordering).
+        if ($newProduct instanceof msProduct && $sourceId > 0) {
+            $targetId = (int)$newProduct->get('id');
+            if ($targetId > 0) {
+                $this->syncDuplicatedProductOptions($sourceId, $targetId);
+            }
+        }
+
         return $newProduct;
+    }
+
+    /**
+     * Copy option values in ms3_product_options from source product to duplicated product.
+     *
+     * @param int $sourceProductId Original product id (before duplicate)
+     * @param int $targetProductId New product id returned by modResource::duplicate()
+     */
+    protected function syncDuplicatedProductOptions(int $sourceProductId, int $targetProductId): void
+    {
+        if (!$this->xpdo->services->has('ms3_option_service')) {
+            return;
+        }
+        /** @var \MiniShop3\Services\Option\OptionService $optionService */
+        $optionService = $this->xpdo->services->get('ms3_option_service');
+        $values = $optionService->getProductOptionValues($sourceProductId, []);
+        $optionService->saveProductOptions($targetProductId, $values, true);
     }
 
     /**

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -3,7 +3,6 @@
 namespace MiniShop3\Processors\Product;
 
 use MiniShop3\Model\msProduct;
-use MiniShop3\Model\msVendor;
 use MiniShop3\Utils\Utils;
 use MODX\Revolution\Processors\Resource\Create as CreateProcessor;
 
@@ -16,6 +15,15 @@ class Create extends CreateProcessor
     public $afterSaveEvent = 'OnDocFormSave';
     /** @var msProduct $object */
     public $object;
+
+    /**
+     * Parsed from options-* request fields in beforeSet(). Used for
+     * ProductDataService::saveOptions(..., removeOther: true) after the resource exists — same contract as
+     * {@see Update::$ms3ProductFormOptions} (#199). Null when the request had no options-* keys (#257).
+     *
+     * @var array<string, mixed>|null
+     */
+    protected $ms3ProductFormOptions = null;
 
     /**
      * @return string
@@ -37,6 +45,7 @@ class Create extends CreateProcessor
      */
     public function beforeSet()
     {
+        $this->ms3ProductFormOptions = null;
         $this->setDefaultProperties([
             'show_in_tree' => $this->modx->getOption('ms3_product_show_in_tree_default', null, false),
             'hidemenu' => $this->modx->getOption('hidemenu_default', null, true),
@@ -50,14 +59,21 @@ class Create extends CreateProcessor
 
         $properties = $this->getProperties();
         $options = [];
+        $hadOptionFieldsInRequest = false;
         foreach ($properties as $key => $value) {
             $optionKey = Utils::extractOptionKey($key);
             if ($optionKey !== null) {
+                $hadOptionFieldsInRequest = true;
                 $options[$optionKey] = Utils::decodeOptionValue($value);
                 $this->unsetProperty($key);
             }
         }
-        $this->setProperty('options', $options);
+        if ($hadOptionFieldsInRequest) {
+            $this->ms3ProductFormOptions = $options;
+        }
+        if (!empty($options)) {
+            $this->setProperty('options', $options);
+        }
 
         if (!empty($properties['vendor_id'])) {
             $vendor_id = Utils::getVendorId($this->modx, $properties['vendor_id']);
@@ -96,21 +112,18 @@ class Create extends CreateProcessor
             $this->modx->context->aliasMap = $results['aliasMap'];
         }
 
-        // Save product options from options-* form fields (parsed in beforeSet)
-        // Only runs when form actually contained options-* fields
-        // removeOther=true: POST is the full set of options from the form — keys missing after removal must be
-        // deleted from DB (#199). JSON-only sync uses saveOptions(null) in msProductData::save() →
-        // removeOther=false (#153, #158)
-        $options = $this->getProperty('options');
-        if (!empty($options) && is_array($options)) {
+        $result = parent::afterSave();
+
+        // Same contract as Update::afterSave (#199): only sync when the request contained options-* keys (#257).
+        if ($this->ms3ProductFormOptions !== null) {
             /** @var \MiniShop3\Model\msProductData $productData */
             $productData = $this->object->loadData();
             if ($productData) {
                 $service = $this->modx->services->get('ms3_product_data_service');
-                $service->saveOptions($productData, $options, true);
+                $service->saveOptions($productData, $this->ms3ProductFormOptions, true);
             }
         }
 
-        return parent::afterSave();
+        return $result;
     }
 }


### PR DESCRIPTION
## Описание

Исправление потери значений опций товара при копировании через контекстное меню MODX «Дублировать ресурс»: после дублирования таблица `ms3_product_options` для нового товара снова заполняется из оригинала; процессор создания товара не трогает опции, если в запросе не было полей `options-*` (как в `Product\Update`).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #257

## Как это было протестировано?

- [x] Ручное тестирование (рекомендуется: дублирование товара с заполненными опциями и проверка вкладки «Опции товара»)
- [x] Автоматические тесты: `php -l` для изменённых PHP-файлов
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR
- MODX: 3.x (ожидается)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (PHPDoc у поля процессора и метода копирования опций)
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требуется (строк UI не менялись)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений) — не применимо
- [x] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- `msProduct::duplicate()`: после `parent::duplicate()` вызывается `OptionService::getProductOptionValues` для исходного `id` и `saveProductOptions` для нового товара с `removeOther: true`.
- `Processors\Product\Create`: введено `$ms3ProductFormOptions` по аналогии с `Update` — синхронизация с формой только если в HTTP-запросе присутствовали ключи `options-*`; убран ложный срабатывание на «непустой» массив с пустыми значениями без реальных полей формы.