### PR TITLE
refactor(snippet): float placeholders и *_formatted на витрине (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,19 @@
 - В списке выбора поля для `validation_rules` доставки доступны кастомные колонки и подписи из админки; служебные поля (id, стоимости, delivery_id и т.д.) отфильтрованы.
 - Те же исключения применяются и к ключам Object Extension, чтобы не предлагать служебные имена.
 
+#### ⚠️ Изменено (breaking, витринные сниппеты — контракт сумм/цен)
+
+Согласовано с обсуждением PR **#259** (ревью): **без суффикса** — число (`float`) для арифметики и `|number` в Fenom; **готовая строка для вывода** — только в полях `*_formatted` (цена с локалью и валютой при необходимости, вес с единицей). Поля `*_numeric` не используются.
+
+- **msOrder:** `cost`, `cart_cost`, `delivery_cost`, `discount_cost` — float из `getCost()`; отображение в чанках — `cost_formatted`, `cart_cost_formatted`, `delivery_cost_formatted`, `discount_cost_formatted`. Дефолтный чанк `ms3_order.tpl` обновлён под вывод через `*_formatted`.
+- **msGetOrder:** в позициях заказа и в `total` базовые суммы/цены/вес — float; строки — `*_formatted` / `weight_formatted`.
+- **msCart:** числовые `price`, `cost`, `weight`, скидки; строки вывода — как ранее через `*_formatted`.
+- **msProducts:** `price`, `old_price`, `weight` — float; форматирование — `price_formatted`, `old_price_formatted`, `weight_formatted` (флаг `withCurrency` влияет на вид `*_formatted`).
+- **msOrderTotal:** числовые поля из `getCost()` не перезаписываются отформатированными строками; `*_formatted` по-прежнему для чанков.
+- **Витринный JS:** в `ms3Config` добавлены `currencySymbol` и `currencyPosition`; `OrderUI.formatPrice()` дополняет сумму символом валюты при обновлении блоков заказа после AJAX (в духе прежнего «число + символ» в шаблоне).
+
+**Миграция шаблонов:** замените вывод `{$order.cost}` на `{$order.cost_formatted}` или оставьте `{$order.cost}` только для числовой логики / `{$order.cost | number : 2}`; то же для корзины, позиций заказа и товаров в каталоге.
+
 ---
 
 ## Апрель 2026

--- a/assets/components/minishop3/js/web/ui/OrderUI.js
+++ b/assets/components/minishop3/js/web/ui/OrderUI.js
@@ -188,15 +188,30 @@ class OrderUI {
   }
 
   /**
-   * Format price for display
+   * Format numeric amount without currency (matches lightweight storefront display).
    *
-   * @param {number} price - Price value
+   * @param {number} num - Parsed finite number
+   * @returns {string}
+   */
+  formatPlainAmount (num) {
+    return num % 1 === 0 ? num.toString() : num.toFixed(2).replace(/\.?0+$/, '')
+  }
+
+  /**
+   * Format price for display (amount + optional currency from ms3Config).
+   *
+   * @param {number|string} price - Price value
    * @returns {string} Formatted price
    */
   formatPrice (price) {
     const num = parseFloat(price) || 0
-    // Format with 2 decimals, remove trailing zeros
-    return num % 1 === 0 ? num.toString() : num.toFixed(2).replace(/\.?0+$/, '')
+    const str = this.formatPlainAmount(num)
+    const sym = this.config?.currencySymbol ? String(this.config.currencySymbol) : ''
+    if (!sym) {
+      return str
+    }
+    const pos = this.config?.currencyPosition || 'after'
+    return pos === 'before' ? `${sym} ${str}` : `${str} ${sym}`
   }
 
   /**

--- a/core/components/minishop3/elements/chunks/ms3_order.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_order.tpl
@@ -260,20 +260,20 @@
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Товары:</span>
                     <span class="fw-semibold">
-                        <span id="ms3_order_cart_cost">{$order.cart_cost ?: 0}</span> {$order.currency_symbol}
+                        <span id="ms3_order_cart_cost">{$order.cart_cost_formatted}</span>
                     </span>
                 </div>
                 <div class="d-flex justify-content-between mb-2">
                     <span class="text-muted">Доставка:</span>
                     <span class="fw-semibold">
-                        <span id="ms3_order_delivery_cost">{$order.delivery_cost ?: 0}</span> {$order.currency_symbol}
+                        <span id="ms3_order_delivery_cost">{$order.delivery_cost_formatted}</span>
                     </span>
                 </div>
                 <hr class="my-2">
                 <div class="d-flex justify-content-between">
                     <span class="h5 mb-0">{'ms3_frontend_order_cost' | lexicon}:</span>
                     <span class="h4 mb-0 text-primary">
-                        <span id="ms3_order_cost">{$order.cost ?: 0}</span> {$order.currency_symbol}
+                        <span id="ms3_order_cost">{$order.cost_formatted}</span>
                     </span>
                 </div>
             </div>

--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -200,19 +200,26 @@ foreach ($cart as $key => $entry) {
     }
     $discount_price = $old_price > 0 ? $old_price - $entry['price'] : 0;
 
-    $product['old_price'] = $old_price;
-    $product['discount_price'] = $ms3->format->price($discount_price);
-    $product['discount_cost'] = $entry['count'] * $discount_price;
+    $linePrice = (float)$entry['price'];
+    $lineWeight = (float)$entry['weight'];
+    $oldPriceNum = (float)$old_price;
+    $discountPriceNum = (float)$discount_price;
+
+    $product['price'] = $linePrice;
+    $product['weight'] = $lineWeight;
+    $product['old_price'] = $oldPriceNum;
+    $product['discount_price'] = $discountPriceNum;
+    $product['discount_cost'] = (float)$entry['count'] * $discountPriceNum;
 
     // Pre-formatted fields with currency/unit for display in chunks
-    $product['old_cost'] = $old_price > 0 ? $entry['count'] * $old_price : 0;
-    $product['price_formatted'] = $ms3->format->price($entry['price'], true);
-    $product['old_price_formatted'] = $old_price > 0 ? $ms3->format->price($old_price, true) : '';
-    $product['cost_formatted'] = $ms3->format->price($entry['count'] * $entry['price'], true);
-    $product['old_cost_formatted'] = $old_price > 0 ? $ms3->format->price($entry['count'] * $old_price, true) : '';
-    $product['discount_price_formatted'] = $discount_price > 0 ? $ms3->format->price($discount_price, true) : '';
-    $product['discount_cost_formatted'] = $discount_price > 0 ? $ms3->format->price($entry['count'] * $discount_price, true) : '';
-    $product['weight_formatted'] = $ms3->format->weightWithUnit($entry['weight']);
+    $product['old_cost'] = $oldPriceNum > 0 ? (float)$entry['count'] * $oldPriceNum : 0.0;
+    $product['price_formatted'] = $ms3->format->price($linePrice, true);
+    $product['old_price_formatted'] = $oldPriceNum > 0 ? $ms3->format->price($oldPriceNum, true) : '';
+    $product['cost_formatted'] = $ms3->format->price($entry['count'] * $linePrice, true);
+    $product['old_cost_formatted'] = $oldPriceNum > 0 ? $ms3->format->price($entry['count'] * $oldPriceNum, true) : '';
+    $product['discount_price_formatted'] = $discountPriceNum > 0 ? $ms3->format->price($discountPriceNum, true) : '';
+    $product['discount_cost_formatted'] = $discountPriceNum > 0 ? $ms3->format->price($entry['count'] * $discountPriceNum, true) : '';
+    $product['weight_formatted'] = $ms3->format->weightWithUnit($lineWeight);
 
     // Additional properties of product in cart
     if (!empty($entry['options']) && is_array($entry['options'])) {

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -192,27 +192,31 @@ foreach ($rows as $product) {
     $rawCost = (float)$product['cost'];
     $rawWeight = (float)$product['weight'];
 
-    $product['old_price'] = $ms3->format->price($old_price);
-    $product['price'] = $ms3->format->price($rawPrice);
-    $product['cost'] = $ms3->format->price($rawCost);
-    $product['weight'] = $ms3->format->weight($rawWeight);
-    $product['discount_price'] = $ms3->format->price($discount_price);
-    $product['discount_cost'] = $ms3->format->price($product['count'] * $discount_price);
+    $oldPriceNum = (float)$old_price;
+    $discountPriceNum = (float)$discount_price;
+    $lineDiscountCostNum = (float)$product['count'] * $discountPriceNum;
+
+    $product['old_price'] = $oldPriceNum;
+    $product['price'] = $rawPrice;
+    $product['cost'] = $rawCost;
+    $product['weight'] = $rawWeight;
+    $product['discount_price'] = $discountPriceNum;
+    $product['discount_cost'] = $lineDiscountCostNum;
 
     // Pre-formatted fields with currency/unit for display in chunks
     $product['price_formatted'] = $ms3->format->price($rawPrice, true);
-    $product['old_price_formatted'] = $old_price > 0 && $old_price > $rawPrice
-        ? $ms3->format->price($old_price, true)
+    $product['old_price_formatted'] = $oldPriceNum > 0 && $oldPriceNum > $rawPrice
+        ? $ms3->format->price($oldPriceNum, true)
         : '';
     $product['cost_formatted'] = $ms3->format->price($rawCost, true);
-    $product['old_cost_formatted'] = $old_price > 0 && $old_price > $rawPrice
-        ? $ms3->format->price($product['count'] * $old_price, true)
+    $product['old_cost_formatted'] = $oldPriceNum > 0 && $oldPriceNum > $rawPrice
+        ? $ms3->format->price($product['count'] * $oldPriceNum, true)
         : '';
-    $product['discount_price_formatted'] = $discount_price > 0
-        ? $ms3->format->price($discount_price, true)
+    $product['discount_price_formatted'] = $discountPriceNum > 0
+        ? $ms3->format->price($discountPriceNum, true)
         : '';
-    $product['discount_cost_formatted'] = $discount_price > 0
-        ? $ms3->format->price($product['count'] * $discount_price, true)
+    $product['discount_cost_formatted'] = $discountPriceNum > 0
+        ? $ms3->format->price($lineDiscountCostNum, true)
         : '';
     $product['weight_formatted'] = $ms3->format->weightWithUnit($rawWeight);
 
@@ -258,18 +262,18 @@ try {
             ? $payment->toArray()
             : [],
         'total' => [
-            'cost' => $ms3->format->price($msOrder->get('cost')),
+            'cost' => (float)$msOrder->get('cost'),
             'cost_formatted' => $ms3->format->price($msOrder->get('cost'), true),
-            'cart_cost' => $ms3->format->price($msOrder->get('cart_cost')),
+            'cart_cost' => (float)$msOrder->get('cart_cost'),
             'cart_cost_formatted' => $ms3->format->price($msOrder->get('cart_cost'), true),
-            'delivery_cost' => $ms3->format->price($msOrder->get('delivery_cost')),
+            'delivery_cost' => (float)$msOrder->get('delivery_cost'),
             'delivery_cost_formatted' => $ms3->format->price($msOrder->get('delivery_cost'), true),
-            'weight' => $ms3->format->weight($msOrder->get('weight')),
+            'weight' => (float)$msOrder->get('weight'),
             'weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
-            'cart_weight' => $ms3->format->weight($msOrder->get('weight')),
+            'cart_weight' => (float)$msOrder->get('weight'),
             'cart_weight_formatted' => $ms3->format->weightWithUnit($msOrder->get('weight')),
             'cart_count' => $cart_count,
-            'cart_discount' => $cart_discount_cost
+            'cart_discount' => (float)$cart_discount_cost,
         ],
     ]);
 } catch (\Exception $e) {

--- a/core/components/minishop3/elements/snippets/ms3_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_order.php
@@ -55,11 +55,11 @@ if ($response['success']) {
 $response = $ms3->order->getCost();
 if ($response['success']) {
     $cost = $response['data'];
-    $order['cost'] = $ms3->format->price($cost['cost']);
-    $order['cart_cost'] = $ms3->format->price($cost['cart_cost']);
-    $order['delivery_cost'] = $ms3->format->price($cost['delivery_cost']);
-    $order['discount_cost'] = $ms3->format->price($cost['total_discount']);
-    // Pre-formatted fields with currency symbol for display in chunks
+    // Базовые ключи — float (ответ getCost); для вывода — только *_formatted (строка, в т.ч. с валютой).
+    $order['cost'] = (float)($cost['cost'] ?? 0);
+    $order['cart_cost'] = (float)($cost['cart_cost'] ?? 0);
+    $order['delivery_cost'] = (float)($cost['delivery_cost'] ?? 0);
+    $order['discount_cost'] = (float)($cost['total_discount'] ?? 0);
     $order['cost_formatted'] = $ms3->format->price($cost['cost'], true);
     $order['cart_cost_formatted'] = $ms3->format->price($cost['cart_cost'], true);
     $order['delivery_cost_formatted'] = $ms3->format->price($cost['delivery_cost'], true);

--- a/core/components/minishop3/elements/snippets/ms3_order_total.php
+++ b/core/components/minishop3/elements/snippets/ms3_order_total.php
@@ -46,17 +46,6 @@ if ($response['success']) {
     $total = array_merge($total, $response['data']);
 }
 
-if (!empty($scriptProperties['formatPrices'])) {
-    $withCurrency = !empty($scriptProperties['withCurrency']);
-    $total['cost'] = $ms3->format->price($total['cost'], $withCurrency);
-    $total['cart_cost'] = $ms3->format->price($total['cart_cost'], $withCurrency);
-    $total['delivery_cost'] = $ms3->format->price($total['delivery_cost'], $withCurrency);
-    $total['payment_cost'] = $ms3->format->price($total['payment_cost'], $withCurrency);
-    $total['total_cost'] = $ms3->format->price($total['total_cost'], $withCurrency);
-    $total['total_discount'] = $ms3->format->price($total['total_discount'], $withCurrency);
-    $total['total_weight'] = $ms3->format->weight($total['total_weight']);
-}
-
 // Pre-formatted fields with currency/unit — always available for chunks
 $data = $response['success'] ? ($response['data'] ?? []) : [];
 $total['cost_formatted'] = $ms3->format->price($data['cost'] ?? 0, true);

--- a/core/components/minishop3/elements/snippets/ms3_products.php
+++ b/core/components/minishop3/elements/snippets/ms3_products.php
@@ -443,18 +443,6 @@ if (!empty($rows) && is_array($rows)) {
             $row = $product->modifyFields($row);
         }
 
-        $row['discount'] = 0;
-        if (!empty($row['old_price']) && $row['old_price'] > 0 && !empty($row['price']) && $row['price'] > 0) {
-            $row['discount'] = $ms3->format->discount($row['old_price'], $row['price']);
-        }
-
-        if (!empty($scriptProperties['formatPrices'])) {
-            $withCurrency = !empty($scriptProperties['withCurrency']);
-            $row['price'] = $ms3->format->price($row['price'], $withCurrency);
-            $row['old_price'] = $ms3->format->price($row['old_price'], $withCurrency);
-            $row['weight'] = $ms3->format->weight($row['weight']);
-        }
-
         $row['idx'] = $pdoFetch->idx++;
 
         $opt_time_start = microtime(true);
@@ -475,7 +463,28 @@ if (!empty($rows) && is_array($rows)) {
             'idx' => $row['idx'],
         ]);
         $rows[$k] = $applyReturnedArray($rows[$k], $getEventReturnedValues(), 'row');
-        $row = $rows[$k]; // Update local variable after event modifications
+        $row = $rows[$k];
+
+        $rawPrice = (float)($row['price'] ?? 0);
+        $rawOldPrice = (float)($row['old_price'] ?? 0);
+        $rawWeight = (float)($row['weight'] ?? 0);
+        $row['price'] = $rawPrice;
+        $row['old_price'] = $rawOldPrice;
+        $row['weight'] = $rawWeight;
+
+        $row['discount'] = 0;
+        if ($rawOldPrice > 0 && $rawPrice > 0) {
+            $row['discount'] = $ms3->format->discount($rawOldPrice, $rawPrice);
+        }
+
+        $withCurrency = !empty($scriptProperties['withCurrency']);
+        $row['price_formatted'] = $ms3->format->price($rawPrice, $withCurrency);
+        $row['old_price_formatted'] = $rawOldPrice > 0
+            ? $ms3->format->price($rawOldPrice, $withCurrency)
+            : '';
+        $row['weight_formatted'] = $ms3->format->weightWithUnit($rawWeight);
+
+        $rows[$k] = $row;
 
         if ($scriptProperties['return'] == 'data') {
             $tpl = $pdoFetch->defineChunk($row);

--- a/core/components/minishop3/src/MiniShop3.php
+++ b/core/components/minishop3/src/MiniShop3.php
@@ -156,6 +156,8 @@ class MiniShop3
                     'connectorUrl' => $this->config['connectorUrl'],
                     'ctx' => $ctx,
                     'tokenName' => $tokenName,
+                    'currencySymbol' => $this->modx->getOption('ms3_currency_symbol', null, '₽'),
+                    'currencyPosition' => $this->modx->getOption('ms3_currency_position', null, 'after'),
                     'render' => [
                         'cart' => []
                     ],


### PR DESCRIPTION
Replacement for #262 (rebased on top of `beta`, CHANGELOG conflict resolved). Original PR from @Ibochkarev.

## Описание

Единый контракт плейсхолдеров для витринных сниппетов: **поля без суффикса** — числа (`float`) для расчётов и Fenom `|number`; **строка для вывода** — только в `*_formatted` (цена с локалью и валютой при необходимости, вес с единицей). Поля `*_numeric` не используются.

**Затронуты:** msOrder, msGetOrder, msCart, msProducts, msOrderTotal; дефолтный чанк `ms3_order.tpl`; в `ms3Config` для витринного JS добавлены `currencySymbol` и `currencyPosition`, `OrderUI` при обновлении сумм после AJAX дополняет число символом валюты. **Нормализация цен/веса в `msProducts` выполняется ПОСЛЕ `msOnProductPrepare`**, чтобы не затираться плагинами.

## Связанные Issues

Closes #242

## Breaking change

Кастомные чанки, выводившие `{$order.cost}` как готовую строку, нужно перевести на `{$order.cost_formatted}` или оставить `{$order.cost}` только как число / с `|number`.

CHANGELOG в Май 2026 оформлен как раздел «⚠️ Изменено (breaking)» с краткой миграцией.

## Тестирование

- PHPStan на 6 PHP-файлах: `[OK] No errors`.