### PR TITLE
fix(snippets): дублирование товаров при includeThumbs

### DIFF
--- a/core/components/minishop3/elements/snippets/ms3_cart.php
+++ b/core/components/minishop3/elements/snippets/ms3_cart.php
@@ -6,6 +6,7 @@ use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductFile;
 use MiniShop3\Model\msProductOption;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Utils\ProductThumbnailJoin;
 use ModxPro\PdoTools\Fetch;
 
 /** @var modX $modx */
@@ -141,7 +142,7 @@ if (!empty($includeThumbs)) {
         foreach ($thumbs as $thumb) {
             $leftJoin[$thumb] = [
                 'class' => msProductFile::class,
-                'on' => "`{$thumb}`.product_id = msProduct.id AND `{$thumb}`.parent_id != 0 AND `{$thumb}`.path LIKE '%/{$thumb}/%' AND `{$thumb}`.`position` = 0",
+                'on' => ProductThumbnailJoin::buildLeftJoinOn($modx, $thumb, $thumb),
             ];
             $select[$thumb] = "`{$thumb}`.url as '{$thumb}'";
         }

--- a/core/components/minishop3/elements/snippets/ms3_get_order.php
+++ b/core/components/minishop3/elements/snippets/ms3_get_order.php
@@ -8,6 +8,7 @@ use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductFile;
 use MiniShop3\Model\msProductOption;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Utils\ProductThumbnailJoin;
 use ModxPro\PdoTools\Fetch;
 
 /** @var modX $modx */
@@ -129,7 +130,7 @@ if (!empty($includeThumbs)) {
         foreach ($thumbs as $thumb) {
             $leftJoin[$thumb] = [
                 'class' => msProductFile::class,
-                'on' => "`{$thumb}`.product_id = msProduct.id AND `{$thumb}`.parent != 0 AND `{$thumb}`.path LIKE '%/{$thumb}/%'",
+                'on' => ProductThumbnailJoin::buildLeftJoinOn($modx, $thumb, $thumb),
             ];
             $select[$thumb] = "`{$thumb}`.url as '{$thumb}'";
         }

--- a/core/components/minishop3/elements/snippets/ms3_products.php
+++ b/core/components/minishop3/elements/snippets/ms3_products.php
@@ -9,6 +9,7 @@ use MiniShop3\Model\msProductFile;
 use MiniShop3\Model\msProductLink;
 use MiniShop3\Model\msProductOption;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Utils\ProductThumbnailJoin;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPluginEvent;
 use ModxPro\PdoTools\Fetch;
@@ -97,10 +98,9 @@ if (!empty($includeThumbs)) {
         }
         $leftJoin[$thumb] = [
             'class' => msProductFile::class,
-            'on' => "`{$thumb}`.product_id = msProduct.id AND `{$thumb}`.`position` = 0 AND `{$thumb}`.path LIKE '%/{$thumb}/%'",
+            'on' => ProductThumbnailJoin::buildLeftJoinOn($modx, $thumb, $thumb),
         ];
         $select[$thumb] = "`{$thumb}`.url as `{$thumb}`";
-        $groupby[] = "`{$thumb}`.url";
     }
 }
 

--- a/core/components/minishop3/src/Utils/ProductThumbnailJoin.php
+++ b/core/components/minishop3/src/Utils/ProductThumbnailJoin.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MiniShop3\Utils;
+
+use MiniShop3\Model\msProductFile;
+use MODX\Revolution\modX;
+
+/**
+ * Builds SQL ON conditions for joining a product thumbnail (msProductFile child row).
+ */
+final class ProductThumbnailJoin
+{
+    /**
+     * LEFT JOIN ON: one thumbnail per product — child of the main gallery image
+     * (parent_id = 0, lowest position), path contains the given size folder.
+     */
+    public static function buildLeftJoinOn(
+        modX $modx,
+        string $thumbAlias,
+        string $thumbSize,
+        string $productAlias = 'msProduct'
+    ): string {
+        $thumbAlias = self::sanitizeSqlIdentifier($thumbAlias);
+        $productAlias = self::sanitizeSqlIdentifier($productAlias);
+        $thumbSize = preg_replace('#[^\w\-/]#', '', $thumbSize);
+
+        if ($thumbAlias === '' || $productAlias === '' || $thumbSize === '') {
+            return '1 = 0';
+        }
+
+        $filesTable = $modx->getTableName(msProductFile::class);
+
+        return sprintf(
+            '`%1$s`.product_id = `%2$s`.id'
+            . ' AND `%1$s`.parent_id != 0'
+            . ' AND `%1$s`.path LIKE \'%%/%3$s/%%\''
+            . ' AND `%1$s`.parent_id = ('
+            . 'SELECT `main`.`id` FROM `%4$s` `main`'
+            . ' WHERE `main`.`product_id` = `%2$s`.`id`'
+            . ' AND `main`.`parent_id` = 0'
+            . ' AND `main`.`type` = \'image\''
+            . ' ORDER BY `main`.`position` ASC, `main`.`id` ASC'
+            . ' LIMIT 1'
+            . ')',
+            $thumbAlias,
+            $productAlias,
+            $thumbSize,
+            $filesTable
+        );
+    }
+
+    private static function sanitizeSqlIdentifier(string $name): string
+    {
+        return preg_replace('#[^\w]#', '', $name);
+    }
+}


### PR DESCRIPTION
## Описание

При `includeThumbs` в `msProducts` (и при том же параметре в mFilter) первый товар в выдаче повторялся столько раз, сколько фото в его галерее. JOIN к `ms3_product_files` подтягивал несколько превью одного размера, а `GROUP BY` по URL превью размножал строки.

Добавлен хелпер `ProductThumbnailJoin::buildLeftJoinOn()` — одно превью на товар (дочерняя запись **главного** фото: `parent_id = 0`, минимальный `position`), как в `ProductImageService::updateProductImage()`. Условие подключено в `msProducts`, `msCart`, `msGetOrder`. В `msGetOrder` исправлена опечатка `` `parent` `` вместо `parent_id`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #281

## Как это было протестировано?

Проверка по коду и `php -l` на затронутых файлах. Ручная проверка на стенде с галереей из нескольких фото рекомендуется ревьюеру.

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: beta / ветка PR
- MODX: 3.x
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Дубли первой карточки при `includeThumbs => small` | Одна карточка на товар (проверить на стенде) |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений) — не затронуто
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике проекта запись при релизе

## Дополнительные заметки

- В `ProductThumbnailJoin` санитизируются SQL-алиасы и размер папки превью; имя таблицы через `getTableName(msProductFile::class)`.
- Источник: [modx.pro #comment-146578](https://modx.pro/components/25552#comment-146578), [уточнение](https://modx.pro/components/25552#comment-146579).