### PR TITLE
fix(api): preserve null in delivery/payment numeric fields on save

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
@@ -132,7 +132,7 @@ class DeliveriesController
                           'validation_rules', 'free_delivery_amount'];
 
         foreach ($allowedFields as $field) {
-            if (isset($data[$field])) {
+            if (array_key_exists($field, $data)) {
                 $delivery->set($field, $this->prepareFieldValue($field, $data[$field]));
             }
         }
@@ -185,7 +185,7 @@ class DeliveriesController
                           'validation_rules', 'free_delivery_amount'];
 
         foreach ($allowedFields as $field) {
-            if (isset($data[$field])) {
+            if (array_key_exists($field, $data)) {
                 $delivery->set($field, $this->prepareFieldValue($field, $data[$field]));
             }
         }

--- a/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
@@ -123,7 +123,7 @@ class PaymentsController
         $allowedFields = ['name', 'description', 'price', 'logo', 'position', 'active', 'class', 'properties'];
 
         foreach ($allowedFields as $field) {
-            if (isset($data[$field])) {
+            if (array_key_exists($field, $data)) {
                 $payment->set($field, $this->prepareFieldValue($field, $data[$field]));
             }
         }
@@ -172,7 +172,7 @@ class PaymentsController
         $allowedFields = ['name', 'description', 'price', 'logo', 'position', 'active', 'class', 'properties'];
 
         foreach ($allowedFields as $field) {
-            if (isset($data[$field])) {
+            if (array_key_exists($field, $data)) {
                 $payment->set($field, $this->prepareFieldValue($field, $data[$field]));
             }
         }


### PR DESCRIPTION
## Описание

В форме настроек способа доставки очистка числового поля (например, `free_delivery_amount`) не сохранялась. После сохранения и перезагрузки старое значение возвращалось. Если вместо очистки явно ввести `0` — сохранялось корректно.

## Тип изменений

- [x] Исправление бага (non-breaking)
- [ ] Новая функциональность
- [ ] Breaking change
- [ ] Рефакторинг

## Корневая причина

PrimeVue `InputNumber` при очистке поля отправляет `null`. В `DeliveriesController::update()` / `create()` (и аналогично в `PaymentsController`) проход по `$allowedFields` использовал `isset($data[$field])` для решения, передавать ли поле в `$delivery->set()`:

```php
foreach ($allowedFields as $field) {
    if (isset($data[$field])) {  // ← false для null
        $delivery->set($field, $this->prepareFieldValue($field, $data[$field]));
    }
}
```

`isset(null)` возвращает `false`, поэтому при очистке поля строка пропускалась, и старое значение оставалось в БД. Когда пользователь вводил `0` — `isset(0) === true`, и поле сохранялось правильно.

## Решение

Заменено на `array_key_exists($field, $data)` — он корректно отличает «ключа нет в payload» от «ключ есть, но значение null». Теперь `null` доезжает до `$delivery->set()`, и xPDO для NOT NULL float-колонок (`free_delivery_amount`, `weight_price`, `distance_price` — `decimal(12,2)` default `0.0`) корректно приводит null → 0.0.

## Затронутые места

4 одинаковых вхождения:

- `DeliveriesController::create()` — строка 135
- `DeliveriesController::update()` — строка 188
- `PaymentsController::create()` — строка 126
- `PaymentsController::update()` — строка 175

## Тестирование

- PHPStan на обоих контроллерах: `[OK] No errors`.
- Ручная проверка на dev: `free_delivery_amount` очищается → сохраняется → перезагрузка → поле пустое (отображается как `0`).