### PR TITLE
fix(product): сохранение Data и extra fields в процессорах Create/Update

### DIFF
--- a/core/components/minishop3/src/Model/msProduct.php
+++ b/core/components/minishop3/src/Model/msProduct.php
@@ -352,7 +352,10 @@ class msProduct extends modResource
      *
      * @return array
      */
-    public function getDataFieldsNames()
+    /**
+     * @return list<string>
+     */
+    public function getDataFieldsNames(): array
     {
         return array_keys($this->loadData()->_fieldMeta);
     }

--- a/core/components/minishop3/src/Model/msProductCreateProcessor.php
+++ b/core/components/minishop3/src/Model/msProductCreateProcessor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MiniShop3\Model;
+
+/**
+ * Resolver target for MODX Resource\Create::getInstance() when class_key is msProduct.
+ *
+ * @see \MODX\Revolution\Processors\Resource\Create::getInstance()
+ */
+class msProductCreateProcessor extends \MiniShop3\Processors\Product\Create
+{
+}

--- a/core/components/minishop3/src/Model/msProductUpdateProcessor.php
+++ b/core/components/minishop3/src/Model/msProductUpdateProcessor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MiniShop3\Model;
+
+/**
+ * Resolver target for MODX Resource\Update::getInstance() when class_key is msProduct.
+ *
+ * @see \MODX\Revolution\Processors\Resource\Update::getInstance()
+ */
+class msProductUpdateProcessor extends \MiniShop3\Processors\Product\Update
+{
+}

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Processors\Product;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Utils\Utils;
 use MODX\Revolution\modDocument;
+use MODX\Revolution\modX;
 use MODX\Revolution\Processors\Resource\Create as CreateProcessor;
 
 class Create extends CreateProcessor
@@ -134,7 +135,13 @@ class Create extends CreateProcessor
         $result = parent::afterSave();
 
         // msProductData needs resource id; composite may not persist payload fields on insert (#297).
-        $this->persistProductDataPayload();
+        if (!$this->persistProductDataPayload()) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[msProduct/Create] failed to persist msProductData for resource id '
+                . $this->object->get('id')
+            );
+        }
 
         // Same contract as Update::afterSave (#199): only sync when the request contained options-* keys (#257).
         if ($this->ms3ProductFormOptions !== null) {

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -109,7 +109,6 @@ class Create extends CreateProcessor
     public function beforeSave()
     {
         $this->object->set('isfolder', false);
-        $this->applyProductDataPayload();
 
         return parent::beforeSave();
     }
@@ -133,6 +132,9 @@ class Create extends CreateProcessor
         }
 
         $result = parent::afterSave();
+
+        // msProductData needs resource id; composite may not persist payload fields on insert (#297).
+        $this->persistProductDataPayload();
 
         // Same contract as Update::afterSave (#199): only sync when the request contained options-* keys (#257).
         if ($this->ms3ProductFormOptions !== null) {

--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -9,6 +9,8 @@ use MODX\Revolution\Processors\Resource\Create as CreateProcessor;
 
 class Create extends CreateProcessor
 {
+    use ProductDataPayloadTrait;
+
     public $classKey = msProduct::class;
     public $languageTopics = ['resource', 'minishop3:default'];
     public $permission = 'msproduct_save';
@@ -71,6 +73,8 @@ class Create extends CreateProcessor
             ),
         ]);
 
+        $this->captureProductDataPayload();
+
         $properties = $this->getProperties();
         $options = [];
         $hadOptionFieldsInRequest = false;
@@ -105,6 +109,8 @@ class Create extends CreateProcessor
     public function beforeSave()
     {
         $this->object->set('isfolder', false);
+        $this->applyProductDataPayload();
+
         return parent::beforeSave();
     }
 

--- a/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
+++ b/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
@@ -115,7 +115,7 @@ trait ProductDataPayloadTrait
      */
     private function getAllowedProductDataFieldNames(): array
     {
-        $fields = array_flip($this->object->getDataFieldsNames());
+        $fields = array_fill_keys($this->object->getDataFieldsNames(), true);
         unset($fields['id']);
 
         return $fields;

--- a/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
+++ b/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
@@ -9,7 +9,8 @@ use MiniShop3\Model\msProductData;
  * Applies msProductData fields from the `Data` block and flat request keys (#297).
  *
  * Resource Create/Update call `$object->fromArray($properties)` without ignoreInvalid,
- * so msProductData columns must be applied in beforeSave().
+ * so msProductData columns must be applied explicitly. On Create the msProductData row
+ * needs a resource id — persist in afterSave(); on Update beforeSave() is enough.
  *
  * @property \MODX\Revolution\modX $modx
  * @property msProduct $object
@@ -32,15 +33,44 @@ trait ProductDataPayloadTrait
 
         $this->unsetProperty(self::PRODUCT_DATA_PROPERTY);
 
+        if (is_string($payload)) {
+            $decoded = json_decode($payload, true);
+            if (is_array($decoded)) {
+                $payload = $decoded;
+            } else {
+                return;
+            }
+        }
+
         if (is_array($payload)) {
             $this->ms3ProductDataPayload = $payload;
         }
     }
 
+    /**
+     * Assign msProductData fields on the in-memory composite (Update / pre-save).
+     */
     protected function applyProductDataPayload(): void
     {
+        $this->assignProductDataPayload(false);
+    }
+
+    /**
+     * Assign and save msProductData after the resource id exists (Create).
+     */
+    protected function persistProductDataPayload(): bool
+    {
+        return $this->assignProductDataPayload(true);
+    }
+
+    private function assignProductDataPayload(bool $persist): bool
+    {
         if (!$this->object instanceof msProduct) {
-            return;
+            return false;
+        }
+
+        if ($persist && (int) $this->object->get('id') <= 0) {
+            return false;
         }
 
         $this->ensureProductDataFieldMapLoaded();
@@ -50,12 +80,19 @@ trait ProductDataPayloadTrait
         $nestedFields = $this->collectNestedProductDataFields($allowedFields);
 
         if ($flatFields === [] && $nestedFields === []) {
-            return;
+            return false;
         }
 
         $productData = $this->object->loadData();
+
+        if ($persist) {
+            $productData->set('id', (int) $this->object->get('id'));
+        }
+
         $this->assignProductDataFields($productData, $flatFields);
         $this->assignProductDataFields($productData, $nestedFields);
+
+        return $persist ? (bool) $productData->save() : true;
     }
 
     private function ensureProductDataFieldMapLoaded(): void

--- a/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
+++ b/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Processors\Product;
 
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
+use MODX\Revolution\modX;
 
 /**
  * Applies msProductData fields from the `Data` block and flat request keys (#297).
@@ -38,6 +39,11 @@ trait ProductDataPayloadTrait
             if (is_array($decoded)) {
                 $payload = $decoded;
             } else {
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    '[msProduct] malformed Data JSON payload: ' . json_last_error_msg()
+                );
+
                 return;
             }
         }
@@ -80,7 +86,7 @@ trait ProductDataPayloadTrait
         $nestedFields = $this->collectNestedProductDataFields($allowedFields);
 
         if ($flatFields === [] && $nestedFields === []) {
-            return false;
+            return true;
         }
 
         $productData = $this->object->loadData();

--- a/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
+++ b/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace MiniShop3\Processors\Product;
+
+use MiniShop3\Model\msProduct;
+use MiniShop3\Model\msProductData;
+
+/**
+ * Applies msProductData fields from the `Data` block and flat request keys (#297).
+ *
+ * Resource Create/Update call `$object->fromArray($properties)` without ignoreInvalid,
+ * so msProductData columns must be applied in beforeSave().
+ *
+ * @property \MODX\Revolution\modX $modx
+ * @property msProduct $object
+ */
+trait ProductDataPayloadTrait
+{
+    private const PRODUCT_DATA_PROPERTY = 'Data';
+
+    /** @var array<string, mixed>|null */
+    protected ?array $ms3ProductDataPayload = null;
+
+    protected function captureProductDataPayload(): void
+    {
+        $this->ms3ProductDataPayload = null;
+
+        $payload = $this->getProperty(self::PRODUCT_DATA_PROPERTY);
+        if ($payload === null || $payload === '') {
+            return;
+        }
+
+        $this->unsetProperty(self::PRODUCT_DATA_PROPERTY);
+
+        if (is_array($payload)) {
+            $this->ms3ProductDataPayload = $payload;
+        }
+    }
+
+    protected function applyProductDataPayload(): void
+    {
+        if (!$this->object instanceof msProduct) {
+            return;
+        }
+
+        $this->ensureProductDataFieldMapLoaded();
+
+        $allowedFields = $this->getAllowedProductDataFieldNames();
+        $flatFields = $this->collectFlatProductDataFields($allowedFields);
+        $nestedFields = $this->collectNestedProductDataFields($allowedFields);
+
+        if ($flatFields === [] && $nestedFields === []) {
+            return;
+        }
+
+        $productData = $this->object->loadData();
+        $this->assignProductDataFields($productData, $flatFields);
+        $this->assignProductDataFields($productData, $nestedFields);
+    }
+
+    private function ensureProductDataFieldMapLoaded(): void
+    {
+        if (!$this->modx->services->has('ms3')) {
+            return;
+        }
+
+        $this->modx->services->get('ms3')->loadMap();
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function getAllowedProductDataFieldNames(): array
+    {
+        $fields = array_flip($this->object->getDataFieldsNames());
+        unset($fields['id']);
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, true> $allowedFields
+     * @return array<string, mixed>
+     */
+    private function collectFlatProductDataFields(array $allowedFields): array
+    {
+        $fields = [];
+
+        foreach ($this->getProperties() as $key => $value) {
+            if (!isset($allowedFields[$key])) {
+                continue;
+            }
+            $fields[$key] = $value;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param array<string, true> $allowedFields
+     * @return array<string, mixed>
+     */
+    private function collectNestedProductDataFields(array $allowedFields): array
+    {
+        if ($this->ms3ProductDataPayload === null) {
+            return [];
+        }
+
+        return array_intersect_key($this->ms3ProductDataPayload, $allowedFields);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function assignProductDataFields(msProductData $productData, array $fields): void
+    {
+        if ($fields === []) {
+            return;
+        }
+
+        $productData->fromArray($fields, '', true, true);
+    }
+}

--- a/core/components/minishop3/src/Processors/Product/Update.php
+++ b/core/components/minishop3/src/Processors/Product/Update.php
@@ -11,6 +11,8 @@ use MODX\Revolution\Processors\Resource\Update as UpdateProcessor;
 
 class Update extends UpdateProcessor
 {
+    use ProductDataPayloadTrait;
+
     public $classKey = msProduct::class;
     public $languageTopics = ['resource', 'minishop3:default'];
     public $permission = 'msproduct_save';
@@ -48,6 +50,9 @@ class Update extends UpdateProcessor
     public function beforeSet()
     {
         $this->ms3ProductFormOptions = null;
+
+        $this->captureProductDataPayload();
+
         $properties = $this->getProperties();
         $options = [];
         $hadOptionFieldsInRequest = false;
@@ -109,6 +114,7 @@ class Update extends UpdateProcessor
     public function beforeSave()
     {
         $this->object->set('isfolder', false);
+        $this->applyProductDataPayload();
 
         return parent::beforeSave();
     }


### PR DESCRIPTION
## Описание

Исправляет [#297](https://github.com/modx-pro/MiniShop3/issues/297): поля `msProductData` (включая Object Extension / extra fields, например `ext_id`) не сохранялись при вызове `runProcessor` с блоком `Data` или плоскими ключами (`price`, …).

**Причина (две части):**
1. `Resource\Create|Update` вызывают `$object->fromArray($properties)` без `ignoreInvalid` — колонки `msProductData` не попадают на объект.
2. На **Create** composite `Data` требует `id` ресурса; запись в `beforeSave()` не гарантирует persist `price` и extra fields.

**Решение:**
- Trait `ProductDataPayloadTrait`: захват `Data` в `beforeSet()`, whitelist через `getDataFieldsNames()`, `loadMap()` для extra fields.
- **Update** — `applyProductDataPayload()` в `beforeSave()`.
- **Create** — `persistProductDataPayload()` в `afterSave()` после insert ресурса.
- Alias-классы `msProductCreateProcessor` / `msProductUpdateProcessor` для резолвера `Resource\Create|Update::getInstance()` (импорт CSV, интеграции).

Поддерживаются плоские ключи в корне payload и явный блок `Data` (при конфликте побеждает `Data`).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #297

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: dev / beta
- MODX: 3.x
- PHP: `php -l` для изменённых PHP-файлов (OK)

**Сценарии для ревьюера:**
1. `MiniShop3\Processors\Product\Create` + `Data` => `['price' => 5200, 'ext_id' => '…']` — значения в `ms3_products`.
2. `MODX\Revolution\Processors\Resource\Create` + `class_key = msProduct` — тот же результат (alias-процессор).
3. `Update` с блоком `Data` — поля обновляются.
4. Плоские `price` / `ext_id` в корне payload.
5. Регрессия: создание/редактирование товара в менеджере (price, `options-*`).

**Пример `runProcessor`:**

```php
$response = $modx->runProcessor('MiniShop3\\Processors\\Product\\Create', [
    'pagetitle' => 'Товар',
    'parent' => 42,
    'class_key' => \MiniShop3\Model\msProduct::class,
    'Data' => [
        'price' => 1990.00,
        'ext_id' => 'SKU-123',
    ],
]);
```

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| `price` / extra fields не сохранялись через `runProcessor` на Create | сохраняются через `Data` и плоские ключи после `afterSave()` |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется (нет UI-строк)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений) — не затронуто
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике репо, при релизе

## Дополнительные заметки

### Code review (clean-code / pre-merge)

**Сильные стороны:**
- Trait с одной ответственностью, методы короткие, имена раскрывают intent (`capture` / `apply` / `persist`).
- Whitelist полей через `getDataFieldsNames()` + `array_intersect_key` — безопаснее произвольного merge.
- `fromArray(..., true, true)` с `ignoreInvalid` — корректный контракт для extra fields.
- Разделение Create (`afterSave` + explicit `save`) / Update (`beforeSave`) задокументировано в docblock trait.
- Alias-процессоры в `Model\` — минимальный diff, без дублирования логики.

**Замечания (не блокеры, follow-up):**
- `persistProductDataPayload()` возвращает `false` и при «нет полей для записи», и при ошибке `$productData->save()` — в `Create::afterSave()` результат не проверяется; при сбое save клиент может получить success. Имеет смысл различать noop / failure или проверять return при непустом payload.
- Невалидная JSON-строка в `Data` из connector молча игнорируется — для отладки можно log или validation error (низкий приоритет).
- Автотестов на trait нет — regression только ручной (типично для MODX processors).

**Затронутые файлы:**
- `Processors/Product/ProductDataPayloadTrait.php` (новый)
- `Processors/Product/Create.php`, `Update.php`
- `Model/msProductCreateProcessor.php`, `msProductUpdateProcessor.php` (новые)