### PR TITLE
fix(manager): переключатель черновиков и фильтры в списке заказов

### DIFF
--- a/core/components/minishop3/controllers/mgr/orders.class.php
+++ b/core/components/minishop3/controllers/mgr/orders.class.php
@@ -38,6 +38,7 @@ class MiniShop3MgrOrdersManagerController extends msManagerController
         $this->addJavascript($this->ms3->config['jsUrl'] . 'mgr/orders/orders.wrapper.js');
 
         $config = $this->ms3->config;
+        $config['order_show_drafts'] = (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
         $this->addHtml('<script>Object.assign(ms3.config, ' . json_encode($config) . ');</script>');
 
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -489,6 +489,7 @@ $_lang['confirm_delete'] = 'Confirm deletion';
 $_lang['orders_title'] = 'Orders';
 $_lang['orders_month'] = 'Orders';
 $_lang['orders_month_sum'] = 'Total sum';
+$_lang['orders_stat_tooltip'] = 'Count and sum for placed orders only; drafts are not included';
 $_lang['ms3_orders_show_drafts'] = 'Show drafts';
 $_lang['order_num'] = 'Number';
 $_lang['order_customer'] = 'Customer';

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -489,6 +489,7 @@ $_lang['confirm_delete'] = 'Confirm deletion';
 $_lang['orders_title'] = 'Orders';
 $_lang['orders_month'] = 'Orders';
 $_lang['orders_month_sum'] = 'Total sum';
+$_lang['ms3_orders_show_drafts'] = 'Show drafts';
 $_lang['order_num'] = 'Number';
 $_lang['order_customer'] = 'Customer';
 $_lang['order_status'] = 'Status';

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -489,6 +489,7 @@ $_lang['confirm_delete'] = 'Подтверждение удаления';
 $_lang['orders_title'] = 'Заказы';
 $_lang['orders_month'] = 'Заказов';
 $_lang['orders_month_sum'] = 'На сумму';
+$_lang['orders_stat_tooltip'] = 'Количество и сумма по оформленным заказам; черновики не учитываются';
 $_lang['ms3_orders_show_drafts'] = 'Показывать черновики';
 $_lang['order_num'] = 'Номер';
 $_lang['order_customer'] = 'Клиент';

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -489,6 +489,7 @@ $_lang['confirm_delete'] = 'Подтверждение удаления';
 $_lang['orders_title'] = 'Заказы';
 $_lang['orders_month'] = 'Заказов';
 $_lang['orders_month_sum'] = 'На сумму';
+$_lang['ms3_orders_show_drafts'] = 'Показывать черновики';
 $_lang['order_num'] = 'Номер';
 $_lang['order_customer'] = 'Клиент';
 $_lang['order_status'] = 'Статус';

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -1549,26 +1549,29 @@ class OrdersController
     }
 
     /**
-     * Whether draft orders should be included in manager list/stats queries.
+     * Whether draft orders should be included in the manager orders list query.
      *
-     * Request param `show_drafts` overrides the system setting `ms3_order_show_drafts`.
+     * When `show_drafts` is present in request params it overrides `ms3_order_show_drafts`.
+     * The Vue orders grid always sends this flag (initialized from ms3.config.order_show_drafts).
      */
     protected function shouldShowDrafts(array $params): bool
     {
-        if (array_key_exists('show_drafts', $params)) {
-            $value = $params['show_drafts'];
-            if ($value === '' || $value === null) {
-                return (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
-            }
+        $default = (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
 
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        if (!array_key_exists('show_drafts', $params)) {
+            return $default;
         }
 
-        return (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
+        $value = $params['show_drafts'];
+        if ($value === '' || $value === null) {
+            return $default;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
-     * Exclude draft status from query unless drafts are explicitly shown.
+     * Exclude draft status from getList query unless drafts are explicitly shown.
      */
     protected function applyDraftVisibilityFilter($c, array $params): void
     {

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -155,11 +155,7 @@ class OrdersController
             }
         }
 
-        $showDrafts = $this->modx->getOption('ms3_order_show_drafts', null, false);
-        if (!$showDrafts) {
-            $statusDrafts = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
-            $c->where(['status_id:!=' => $statusDrafts]);
-        }
+        $this->applyDraftVisibilityFilter($c, $params);
 
         if (!empty($query)) {
             if (is_numeric($query)) {
@@ -1550,6 +1546,38 @@ class OrdersController
             'month_sum' => number_format(round($data['sum'] ?? 0), 0, '.', ' '),
             'month_total' => number_format($data['total'] ?? 0, 0, '.', ' '),
         ];
+    }
+
+    /**
+     * Whether draft orders should be included in manager list/stats queries.
+     *
+     * Request param `show_drafts` overrides the system setting `ms3_order_show_drafts`.
+     */
+    protected function shouldShowDrafts(array $params): bool
+    {
+        if (array_key_exists('show_drafts', $params)) {
+            $value = $params['show_drafts'];
+            if ($value === '' || $value === null) {
+                return (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
+            }
+
+            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
+    }
+
+    /**
+     * Exclude draft status from query unless drafts are explicitly shown.
+     */
+    protected function applyDraftVisibilityFilter($c, array $params): void
+    {
+        if ($this->shouldShowDrafts($params)) {
+            return;
+        }
+
+        $statusDrafts = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+        $c->where(['status_id:!=' => $statusDrafts]);
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -1572,8 +1572,10 @@ class OrdersController
 
     /**
      * Exclude draft status from getList query unless drafts are explicitly shown.
+     *
+     * @param \xPDO\Om\xPDOQuery $c Query object
      */
-    protected function applyDraftVisibilityFilter($c, array $params): void
+    protected function applyDraftVisibilityFilter(\xPDO\Om\xPDOQuery $c, array $params): void
     {
         if ($this->shouldShowDrafts($params)) {
             return;

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -588,24 +588,26 @@ onMounted(async () => {
               @click="createNewOrder"
             />
           </div>
-          <div class="show-drafts-toggle">
-            <Checkbox
-              v-model="showDrafts"
-              input-id="orders-show-drafts"
-              binary
-              @change="toggleShowDrafts"
-            />
-            <label for="orders-show-drafts">{{ _('ms3_orders_show_drafts') }}</label>
-          </div>
-          <div class="grid-stats" :title="_('orders_stat_tooltip')">
-            <span class="stat-item">
-              <i class="pi pi-calendar"></i>
-              {{ _('orders_month') }}: <strong>{{ stats.month_total }}</strong>
-            </span>
-            <span class="stat-item">
-              <i class="pi pi-wallet"></i>
-              {{ _('orders_month_sum') }}: <strong>{{ stats.month_sum }}</strong>
-            </span>
+          <div class="grid-header-right">
+            <div class="grid-stats" :title="_('orders_stat_tooltip')">
+              <span class="stat-item">
+                <i class="pi pi-calendar"></i>
+                {{ _('orders_month') }}: <strong>{{ stats.month_total }}</strong>
+              </span>
+              <span class="stat-item">
+                <i class="pi pi-wallet"></i>
+                {{ _('orders_month_sum') }}: <strong>{{ stats.month_sum }}</strong>
+              </span>
+            </div>
+            <div class="show-drafts-toggle">
+              <Checkbox
+                v-model="showDrafts"
+                input-id="orders-show-drafts"
+                binary
+                @change="toggleShowDrafts"
+              />
+              <label for="orders-show-drafts">{{ _('ms3_orders_show_drafts') }}</label>
+            </div>
           </div>
         </div>
       </template>
@@ -869,10 +871,17 @@ onMounted(async () => {
   gap: 1rem;
 }
 
+.grid-header-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-left: auto;
+  font-size: 1rem;
+}
+
 .grid-stats {
   display: flex;
   gap: 1.5rem;
-  font-size: 0.9rem;
   color: var(--ms3-text-muted);
   cursor: help;
 }
@@ -936,11 +945,13 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  white-space: nowrap;
 }
 
 .show-drafts-toggle label {
   cursor: pointer;
   user-select: none;
+  font-size: 1rem;
 }
 
 /* Bulk actions toolbar */

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -569,7 +569,7 @@ onMounted(async () => {
               @click="createNewOrder"
             />
           </div>
-          <div class="grid-stats">
+          <div class="grid-stats" :title="_('orders_stat_tooltip')">
             <span class="stat-item">
               <i class="pi pi-calendar"></i>
               {{ _('orders_month') }}: <strong>{{ stats.month_total }}</strong>
@@ -855,6 +855,7 @@ onMounted(async () => {
   gap: 1.5rem;
   font-size: 0.9rem;
   color: var(--ms3-text-muted);
+  cursor: help;
 }
 
 .stat-item {

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -22,7 +22,21 @@ const toast = useToast()
 const { _ } = useLexicon()
 
 const ms3Config = typeof ms3 !== 'undefined' ? ms3.config : null
-const showDrafts = ref(Boolean(ms3Config?.order_show_drafts))
+const SHOW_DRAFTS_STORAGE_KEY = 'ms3_orders_show_drafts'
+
+function readShowDraftsPreference() {
+  try {
+    const stored = localStorage.getItem(SHOW_DRAFTS_STORAGE_KEY)
+    if (stored !== null) {
+      return stored === '1'
+    }
+  } catch {
+    /* localStorage unavailable */
+  }
+  return Boolean(ms3Config?.order_show_drafts)
+}
+
+const showDrafts = ref(readShowDraftsPreference())
 
 /** Filter keys sent as direct API params (not filter_ prefix). */
 const DIRECT_FILTER_KEYS = new Set([
@@ -391,6 +405,11 @@ const hasActiveFilters = computed(() => {
 })
 
 function toggleShowDrafts() {
+  try {
+    localStorage.setItem(SHOW_DRAFTS_STORAGE_KEY, showDrafts.value ? '1' : '0')
+  } catch {
+    /* localStorage unavailable */
+  }
   first.value = 0
   loadOrders()
 }
@@ -569,6 +588,15 @@ onMounted(async () => {
               @click="createNewOrder"
             />
           </div>
+          <div class="show-drafts-toggle">
+            <Checkbox
+              v-model="showDrafts"
+              input-id="orders-show-drafts"
+              binary
+              @change="toggleShowDrafts"
+            />
+            <label for="orders-show-drafts">{{ _('ms3_orders_show_drafts') }}</label>
+          </div>
           <div class="grid-stats" :title="_('orders_stat_tooltip')">
             <span class="stat-item">
               <i class="pi pi-calendar"></i>
@@ -670,15 +698,6 @@ onMounted(async () => {
 
           <!-- Filter buttons -->
           <div class="filter-buttons">
-            <div class="show-drafts-toggle">
-              <Checkbox
-                v-model="showDrafts"
-                input-id="orders-show-drafts"
-                binary
-                @change="toggleShowDrafts"
-              />
-              <label for="orders-show-drafts">{{ _('ms3_orders_show_drafts') }}</label>
-            </div>
             <Button
               :label="_('apply_filters')"
               icon="pi pi-filter"
@@ -917,7 +936,6 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-right: auto;
 }
 
 .show-drafts-toggle label {

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -2,6 +2,7 @@
 import { useLexicon } from '@vuetools/useLexicon'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
+import Checkbox from 'primevue/checkbox'
 import Column from 'primevue/column'
 import ConfirmDialog from 'primevue/confirmdialog'
 import DataTable from 'primevue/datatable'
@@ -19,6 +20,20 @@ import ActionsColumn from './ActionsColumn.vue'
 
 const toast = useToast()
 const { _ } = useLexicon()
+
+const ms3Config = typeof ms3 !== 'undefined' ? ms3.config : null
+const showDrafts = ref(Boolean(ms3Config?.order_show_drafts))
+
+/** Filter keys sent as direct API params (not filter_ prefix). */
+const DIRECT_FILTER_KEYS = new Set([
+  'query',
+  'status_id',
+  'delivery_id',
+  'payment_id',
+  'context_key',
+  'createdon_from',
+  'createdon_to',
+])
 
 // Bulk selection
 const {
@@ -73,13 +88,13 @@ async function loadOrders() {
       limit: rows.value,
       sort: sortField.value,
       dir: sortOrder.value === 1 ? 'ASC' : 'DESC',
+      show_drafts: showDrafts.value ? 1 : 0,
     }
 
     // Apply filter values
     Object.keys(filterValues.value).forEach(key => {
       const value = filterValues.value[key]
       if (value !== null && value !== undefined && value !== '') {
-        // Handle daterange type
         const filterConfig = filters.value[key]
         if (filterConfig?.type === 'daterange' && Array.isArray(value)) {
           if (value[0]) {
@@ -90,8 +105,10 @@ async function loadOrders() {
           }
         } else if (filterConfig?.type === 'datepicker' && value) {
           params[key] = formatDateForApi(value)
-        } else {
+        } else if (DIRECT_FILTER_KEYS.has(key)) {
           params[key] = value
+        } else {
+          params[`filter_${key}`] = value
         }
       }
     })
@@ -373,6 +390,11 @@ const hasActiveFilters = computed(() => {
   return Object.values(filterValues.value).some(v => v !== null && v !== '' && v !== undefined)
 })
 
+function toggleShowDrafts() {
+  first.value = 0
+  loadOrders()
+}
+
 /**
  * Load grid configuration
  */
@@ -648,6 +670,15 @@ onMounted(async () => {
 
           <!-- Filter buttons -->
           <div class="filter-buttons">
+            <div class="show-drafts-toggle">
+              <Checkbox
+                v-model="showDrafts"
+                input-id="orders-show-drafts"
+                binary
+                @change="toggleShowDrafts"
+              />
+              <label for="orders-show-drafts">{{ _('ms3_orders_show_drafts') }}</label>
+            </div>
             <Button
               :label="_('apply_filters')"
               icon="pi pi-filter"
@@ -876,7 +907,21 @@ onMounted(async () => {
 
 .filter-buttons {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem;
+}
+
+.show-drafts-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-right: auto;
+}
+
+.show-drafts-toggle label {
+  cursor: pointer;
+  user-select: none;
 }
 
 /* Bulk actions toolbar */


### PR DESCRIPTION
## Описание

В Vue-гриде заказов добавлен чекбокс «Показывать черновики», который передаёт `show_drafts` в API и позволяет видеть записи со статусом черновика без правки системной настройки MODX. Бэкенд принимает параметр запроса `show_drafts` поверх `ms3_order_show_drafts`.

Исправлена передача фильтров по колонкам: динамические поля отправляются с префиксом `filter_`, как ожидает `OrdersController::applyFilter()` (по аналогии с `CustomersGrid`).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #302

## Как это было протестировано?

- [x] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.11.1-beta1
- MODX: 3.x
- PHP: 8.2+

Проверки:
- `php -l` для изменённых PHP-файлов
- `npm run lint` для `OrdersGrid.vue`
- `npm run build` для vueManager (артефакты в gitignore)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| В БД 4 заказа, в гриде 1 (только не-черновик) | Чекбокс «Показывать черновики» включает все записи |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Чекбокс по умолчанию берёт значение из `ms3_order_show_drafts` через `ms3.config.order_show_drafts`.
- Счётчик «Заказов / На сумму» по-прежнему считает только статусы из `ms3_status_for_stat` — это отдельная логика статистики, не общее число строк грида.