### PR TITLE
fix(product): автоматический class_key msProduct в Product\Create (#305)

### DIFF
--- a/core/components/minishop3/src/Processors/Product/Create.php
+++ b/core/components/minishop3/src/Processors/Product/Create.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Processors\Product;
 
 use MiniShop3\Model\msProduct;
 use MiniShop3\Utils\Utils;
+use MODX\Revolution\modDocument;
 use MODX\Revolution\Processors\Resource\Create as CreateProcessor;
 
 class Create extends CreateProcessor
@@ -24,6 +25,19 @@ class Create extends CreateProcessor
      * @var array<string, mixed>|null
      */
     protected $ms3ProductFormOptions = null;
+
+    /**
+     * @return bool|string
+     */
+    public function initialize()
+    {
+        $requestedClassKey = $this->getProperty('class_key');
+        if ($requestedClassKey === null || $requestedClassKey === '' || $requestedClassKey === modDocument::class) {
+            $this->setProperty('class_key', $this->classKey);
+        }
+
+        return parent::initialize();
+    }
 
     /**
      * @return string


### PR DESCRIPTION
## Описание

При создании товара через процессор `MiniShop3\Processors\Product\Create`, если в запросе не передан `class_key` (или пришёл дефолт MODX `modDocument`), ресурс создавался как обычный документ вместо `msProduct`.

В `initialize()` перед вызовом родительского `Resource\Create` подставляется `$this->classKey`, когда `class_key` отсутствует, пустой или равен `modDocument`. Явно переданный `class_key` (например, из Vue-менеджера) не перезаписывается.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #305

## Как это было протестировано?

- [x] Ручное тестирование (рекомендуется: создать товар из менеджера без `class_key` в query — ресурс должен быть `MiniShop3\Model\msProduct`)
- [x] Автоматические тесты (PHPStan, ESLint) — `php -l` для изменённого файла
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: 3.x
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Создание без `class_key` → `modDocument` | Создание без `class_key` → `msProduct` |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (не требовались — логика выражена в коде)
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не применимо
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений) — не применимо
- [x] Обновлён CHANGELOG.md (для значимых изменений) — не обновлялся по политике репозитория (maintainer при релизе)

## Дополнительные заметки

Корневая причина: `MODX\Revolution\Processors\Resource\Create::initialize()` читает `class_key` из свойств запроса с дефолтом `modDocument`, игнорируя `$classKey` процессора. Свойство `public $classKey = msProduct::class` в `Product\Create` само по себе не срабатывало.