### PR TITLE
fix(migrations): normalize Phinx MySQL charset

### DIFF
--- a/core/components/minishop3/phinx.php
+++ b/core/components/minishop3/phinx.php
@@ -20,13 +20,81 @@ if (!isset($modx)) {
         die('MODX_CORE_PATH not defined in config.core.php');
     }
 
-    if (!class_exists('modX')) {
+    $modxClass = 'MODX\\Revolution\\modX';
+
+    if (!class_exists($modxClass)) {
         require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
     }
 
-    $modx = new modX();
+    if (!class_exists($modxClass) && class_exists('modX')) {
+        $modxClass = 'modX';
+    }
+
+    $modx = new $modxClass();
     $modx->initialize('mgr');
 }
+
+if (!function_exists('ms3PhinxExtractDsnCharset')) {
+    function ms3PhinxExtractDsnCharset(?string $dsn): ?string
+    {
+        if ($dsn === null || $dsn === '') {
+            return null;
+        }
+
+        if (preg_match('/(?:^|;)charset=([^;]+)/i', $dsn, $matches) !== 1) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+}
+
+if (!function_exists('ms3PhinxNormalizeMysqlCharset')) {
+    function ms3PhinxNormalizeMysqlCharset(?string $charset, bool $preferUtf8mb4 = false): string
+    {
+        $normalized = strtolower(trim((string) $charset));
+        $normalized = str_replace('-', '', $normalized);
+
+        return match ($normalized) {
+            '', 'utf8', 'utf8mb3' => $preferUtf8mb4 ? 'utf8mb4' : 'utf8',
+            'utf8mb4' => 'utf8mb4',
+            default => preg_replace('/[^a-z0-9_]/', '', $normalized) ?: 'utf8mb4',
+        };
+    }
+}
+
+if (!function_exists('ms3PhinxDefaultMysqlCollation')) {
+    function ms3PhinxDefaultMysqlCollation(string $charset): string
+    {
+        return match ($charset) {
+            'utf8' => 'utf8_general_ci',
+            'utf8mb4' => 'utf8mb4_unicode_ci',
+            default => $charset . '_general_ci',
+        };
+    }
+}
+
+$dsnCharset = ms3PhinxExtractDsnCharset($modx->getOption('database_dsn', null, null));
+$databaseCharset = $modx->getOption('database_charset', null, null);
+
+if ($dsnCharset !== null) {
+    $mysqlCharset = ms3PhinxNormalizeMysqlCharset($dsnCharset);
+} elseif ($databaseCharset !== null && trim((string) $databaseCharset) !== '') {
+    $mysqlCharset = ms3PhinxNormalizeMysqlCharset($databaseCharset);
+} else {
+    $mysqlCharset = ms3PhinxNormalizeMysqlCharset($modx->getOption('charset', null, 'utf8mb4'), true);
+}
+
+$mysqlCollation = $modx->getOption(
+    'database_collation',
+    null,
+    $modx->getOption(
+        'collation',
+        null,
+        ms3PhinxDefaultMysqlCollation($mysqlCharset)
+    )
+);
+
 $dbConfig = [
     'adapter' => 'mysql',
     'host' => $modx->getOption('host', null, 'localhost'),
@@ -34,8 +102,8 @@ $dbConfig = [
     'user' => $modx->getOption('username'),
     'pass' => $modx->getOption('password'),
     'port' => $modx->getOption('port', null, '3306'),
-    'charset' => $modx->getOption('charset', null, 'utf8mb4'),
-    'collation' => $modx->getOption('collation', null, 'utf8mb4_unicode_ci'),
+    'charset' => $mysqlCharset,
+    'collation' => $mysqlCollation,
     'table_prefix' => $modx->getOption('table_prefix', null, ''),
 ];
 

--- a/core/components/minishop3/tests/PhinxCharsetConfigTest.php
+++ b/core/components/minishop3/tests/PhinxCharsetConfigTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Static checks for Phinx MySQL charset configuration (without MODX).
+ *
+ * Run: php tests/PhinxCharsetConfigTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$buildConfig = static function (array $options): array {
+    $modx = new class ($options) {
+        public function __construct(private readonly array $options)
+        {
+        }
+
+        public function getOption(string $key, mixed $options = null, mixed $default = null): mixed
+        {
+            return $this->options[$key] ?? $default;
+        }
+    };
+
+    return require __DIR__ . '/../phinx.php';
+};
+
+$config = $buildConfig([
+    'dbname' => 'minishop3',
+    'username' => 'user',
+    'password' => 'secret',
+    'charset' => 'UTF-8',
+    'table_prefix' => 'modx_',
+]);
+
+$charset = $config['environments']['production']['charset'] ?? null;
+if ($charset !== 'utf8mb4') {
+    $fail("MODX charset UTF-8 must be normalized to MySQL charset utf8mb4, got {$charset}");
+}
+
+$collation = $config['environments']['production']['collation'] ?? null;
+if ($collation !== 'utf8mb4_unicode_ci') {
+    $fail("utf8mb4 charset must use utf8mb4_unicode_ci by default, got {$collation}");
+}
+
+$config = $buildConfig([
+    'dbname' => 'minishop3',
+    'username' => 'user',
+    'password' => 'secret',
+    'database_dsn' => 'mysql:host=localhost;dbname=minishop3;charset=utf8',
+    'charset' => 'UTF-8',
+    'table_prefix' => 'modx_',
+]);
+
+$charset = $config['environments']['production']['charset'] ?? null;
+if ($charset !== 'utf8') {
+    $fail("database_dsn charset must override MODX web charset, got {$charset}");
+}
+
+$config = $buildConfig([
+    'dbname' => 'minishop3',
+    'username' => 'user',
+    'password' => 'secret',
+    'database_charset' => '',
+    'database_collation' => 'utf8mb4_general_ci',
+    'charset' => 'UTF-8',
+    'table_prefix' => 'modx_',
+]);
+
+$charset = $config['environments']['production']['charset'] ?? null;
+if ($charset !== 'utf8mb4') {
+    $fail("empty database_charset must fall back to normalized MODX charset, got {$charset}");
+}
+
+$collation = $config['environments']['production']['collation'] ?? null;
+if ($collation !== 'utf8mb4_general_ci') {
+    $fail("database_collation must override default collation, got {$collation}");
+}
+
+fwrite(STDOUT, "OK PhinxCharsetConfigTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Исправляет конфигурацию Phinx-миграций, чтобы при установке MiniShop3 MySQL-соединение использовало корректный MySQL charset. Если MODX отдаёт web charset `UTF-8`, Phinx теперь нормализует его в `utf8mb4`; при этом явные `database_dsn`, `database_charset` и `database_collation` сохраняют приоритет.

Это предотвращает битую кодировку в сидированных русских темах email-уведомлений, например в поле «Тема письма» центра уведомлений после чистой установки.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #307

## Как это было протестировано?

Проверены синтаксис изменённых PHP-файлов и статические PHP-тесты для конфигурации Phinx и существующего URL подтверждения email.

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHP CLI static checks)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: не запускался, проверка статическая без bootstrap MODX
- PHP: локальный CLI

## Скриншоты (если применимо)

Не применимо.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Лексиконы не требуются: пользовательские строки не добавлялись. PHPStan и ESLint не запускались; JS/Vue не затрагивались. CHANGELOG не обновлялся, потому что в проектных правилах записи добавляются при подготовке релиза.

Проверки:

```bash
php -l core/components/minishop3/phinx.php
php -l core/components/minishop3/tests/PhinxCharsetConfigTest.php
php core/components/minishop3/tests/PhinxCharsetConfigTest.php
php core/components/minishop3/tests/EmailVerificationUrlTest.php
```