### PR TITLE
fix(api): per-field null payload semantics in Manager API (#289)

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -637,6 +637,8 @@ class OrdersController
         $address->set('createdon', time());
 
         // Address fields from params
+        // Safe to use array_key_exists: new entity, no previous value to silently overwrite;
+        // all address columns are nullable VARCHAR/TEXT.
         $addressFields = [
             'first_name', 'last_name', 'phone', 'email',
             'country', 'index', 'region', 'city', 'metro',
@@ -644,7 +646,7 @@ class OrdersController
             'comment', 'text_address'
         ];
         foreach ($addressFields as $field) {
-            if (isset($params[$field])) {
+            if (array_key_exists($field, $params)) {
                 $address->set($field, $params[$field]);
             }
         }
@@ -1145,34 +1147,42 @@ class OrdersController
         $updated = false;
         $changes = [];
 
+        // Per-field null semantics:
+        //   - `options` (JSON): null = explicit clear from frontend (OrderView getOptionsForSave())
+        //   - `count`/`price`/`weight` (numeric): null skipped — coercing null to 0/1 would
+        //     silently destroy data when a partial payload accidentally carries `null`
+        //     (PrimeVue InputNumber on clear, third-party API, batch scripts).
+        //     Frontend must send explicit 0 / valid number to actually update these.
+        $nullClearable = ['options'];
+
         foreach ($allowedFields as $field) {
-            if (isset($params[$field])) {
-                $oldValue = $orderProduct->get($field);
-                $value = $params[$field];
-
-                // Validate count
-                if ($field === 'count') {
-                    $value = max(1, (int)$value);
-                }
-
-                // Validate price/weight
-                if (in_array($field, ['price', 'weight'])) {
-                    $value = max(0, (float)$value);
-                }
-
-                // Handle options (JSON)
-                if ($field === 'options' && is_array($value)) {
-                    $value = json_encode($value, JSON_UNESCAPED_UNICODE);
-                }
-
-                // Track changes for logging
-                if ($oldValue != $value) {
-                    $changes[$field] = ['old' => $oldValue, 'new' => $value];
-                }
-
-                $orderProduct->set($field, $value);
-                $updated = true;
+            if (!array_key_exists($field, $params)) {
+                continue;
             }
+            $value = $params[$field];
+
+            if ($value === null && !in_array($field, $nullClearable, true)) {
+                continue;
+            }
+
+            $oldValue = $orderProduct->get($field);
+
+            if ($field === 'count') {
+                $value = max(1, (int)$value);
+            } elseif (in_array($field, ['price', 'weight'], true)) {
+                $value = max(0, (float)$value);
+            } elseif (is_array($value)) {
+                // options (JSON) — null passes through, arrays get encoded
+                $value = json_encode($value, JSON_UNESCAPED_UNICODE);
+            }
+
+            // Track changes for logging
+            if ($oldValue != $value) {
+                $changes[$field] = ['old' => $oldValue, 'new' => $value];
+            }
+
+            $orderProduct->set($field, $value);
+            $updated = true;
         }
 
         if (!$updated) {

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -1167,13 +1167,20 @@ class OrdersController
 
             $oldValue = $orderProduct->get($field);
 
-            if ($field === 'count') {
-                $value = max(1, (int)$value);
-            } elseif (in_array($field, ['price', 'weight'], true)) {
-                $value = max(0, (float)$value);
-            } elseif (is_array($value)) {
-                // options (JSON) — null passes through, arrays get encoded
-                $value = json_encode($value, JSON_UNESCAPED_UNICODE);
+            switch ($field) {
+                case 'count':
+                    $value = max(1, (int)$value);
+                    break;
+                case 'price':
+                case 'weight':
+                    $value = max(0, (float)$value);
+                    break;
+                case 'options':
+                    // null passes through (clear), arrays get encoded as JSON
+                    if (is_array($value)) {
+                        $value = json_encode($value, JSON_UNESCAPED_UNICODE);
+                    }
+                    break;
             }
 
             // Track changes for logging

--- a/core/components/minishop3/src/Services/Customer/CustomerAddressManager.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerAddressManager.php
@@ -229,8 +229,16 @@ class CustomerAddressManager
             }
         }
 
-        // Regenerate hash if address changed
-        if (isset($data['city']) || isset($data['street']) || isset($data['building']) || isset($data['room'])) {
+        // Regenerate hash if address changed.
+        // array_key_exists (not isset) — null in payload is a legitimate clear of an
+        // address component and must trigger hash recalc, otherwise the cleared address
+        // keeps its old hash and breaks dedup.
+        if (
+            array_key_exists('city', $data)
+            || array_key_exists('street', $data)
+            || array_key_exists('building', $data)
+            || array_key_exists('room', $data)
+        ) {
             $address->set('hash', $this->generateHash(array_merge($address->toArray(), $data)));
         }
 

--- a/core/components/minishop3/src/Services/ExtraFieldsService.php
+++ b/core/components/minishop3/src/Services/ExtraFieldsService.php
@@ -296,10 +296,23 @@ class ExtraFieldsService
 
         $allowedFields = ['label', 'description', 'xtype', 'active', 'select_options'];
 
+        // Per-field null semantics:
+        //   - `description`, `select_options` (optional text/json): null = clear
+        //   - `label`, `xtype`, `active` (required for rendering): null skipped — a partial
+        //     payload with `xtype: null` would silently break the field's UI.
+        $nullClearable = ['description', 'select_options'];
+
         foreach ($allowedFields as $fieldName) {
-            if (isset($data[$fieldName])) {
-                $field->set($fieldName, $data[$fieldName]);
+            if (!array_key_exists($fieldName, $data)) {
+                continue;
             }
+            $value = $data[$fieldName];
+
+            if ($value === null && !in_array($fieldName, $nullClearable, true)) {
+                continue;
+            }
+
+            $field->set($fieldName, $value);
         }
 
         if (!$field->save()) {


### PR DESCRIPTION
## Описание

Альтернатива закрытому PR #295. Решает ту же задачу (`InputNumber` шлёт `null` при очистке поля, `isset()` его игнорирует), но **per-field**, чтобы не сломать контракт Manager API.

Замена `isset()` → `array_key_exists()` сделана **точечно**, с явным правилом, что означает `null` для каждого поля:

- Где `null` = «очистить» (текстовые nullable, JSON-словари, новые сущности) — обрабатывается.
- Где `null` = «не задано» (числовые с coercion, типизированные required-поля) — пропускается.

Без этого разделения partial payload с `count: null` или `price: null` (бажный фронт, сторонняя интеграция, batch-скрипт) тихо обнуляет позиции заказа — финансовый и логистический риск.

## Что сделано

### `OrdersController::create()` — addressFields (новый заказ)
`array_key_exists`. Безопасно: новая запись, нет «старого значения», все адресные поля nullable.

### `OrdersController::updateProduct()` — позиция заказа
Per-field семантика:

| Поле | `null` в payload |
|---|---|
| `options` (JSON) | очистить (контракт `OrderView.getOptionsForSave()`) |
| `count`, `price`, `weight` | **пропустить** — `null` неотличим от партиального update, coercion в 0/1 опасен |

Чтобы реально очистить `price`/`weight`/`count` — фронт должен слать явный `0` или валидное число.

### `ExtraFieldsService::updateField()` — настройка extra field
Per-field семантика:

| Поле | `null` в payload |
|---|---|
| `description`, `select_options` | очистить |
| `label`, `xtype`, `active` | **пропустить** — `xtype: null` ломает рендер, `active: null` молча выключает |

### `CustomerAddressManager::update()` — пересчёт hash
`array_key_exists`. Безопасно (это триггер, не `set()`). При явной очистке адресной части (`city: null` и т.д.) hash перерасчитывается — иначе остаётся старый, дедуп ломается.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность
- [ ] Breaking change
- [ ] Рефакторинг
- [ ] Документация
- [ ] Другое

## Связанные Issues / PR

- Closes #289
- Supersedes #295 (закрыт — `isset` → `array_key_exists` без per-field разбора молча ломал контракт API)
- Связано: #287 (`DeliveriesController` / `PaymentsController` — там аналогичный паттерн уже исправлен)

## Как протестировано

- [x] PHPStan по изменённым файлам — без новых ошибок.
- [x] Синхронизировано на dev (`D:\laragon\www\ms3`), кэш сброшен.
- [ ] Ручное тестирование в Vue Manager — рекомендуется maintainer'у:

**Сценарии проверки:**

1. **Очистка `options` позиции** → `options` обнуляются в БД (`payload: { options: null }`).
2. **Очистка `price` в `InputNumber` без отдельной правки фронта** → значение в БД **не меняется** (skip-семантика). Чтобы реально обнулить — нужен явный `0`. **Это намеренное изменение контракта** vs PR #295.
3. **Partial payload `{ count: null, options: {...} }`** → `count` сохраняется как был, `options` применяются. (В #295 этот payload сбрасывал `count` в 1.)
4. **Очистка адресных полей клиента** (`city: null`) → hash пересчитывается.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены комментарии в сложных местах (объяснение per-field семантики null)
- [x] Не ломает существующую функциональность (наоборот, не вносит breaking change в контракт API)
- [ ] Лексиконы — не требуется
- [x] PHPStan проходит без новых ошибок
- [ ] ESLint — не требуется (Vue не менялся)
- [ ] CHANGELOG.md — добавит maintainer при релизе

## Trade-off vs PR #295

Эта реализация **не исправляет** один сценарий из #289 «InputNumber для price/weight очистился → значение в БД сбросилось до 0». Для этого нужна правка на Vue-стороне: при очистке `InputNumber` для числового поля отправлять `0`, а не `null`.

Альтернатива — обнулять server-side, как делал #295, — обнаруживает destructive coercion для любого partial payload, ломает контракт API и непредсказуема для сторонних клиентов. Безопасность приоритетнее.

Frontend-фикс — отдельный issue / PR.
