### PR TITLE
fix(import): split multi-value option columns in CSV import

### DIFF
--- a/core/components/minishop3/src/Controllers/Options/Types/msOptionType.php
+++ b/core/components/minishop3/src/Controllers/Options/Types/msOptionType.php
@@ -30,6 +30,11 @@ abstract class msOptionType
         $this->config = array_merge($this->config, $config);
     }
 
+    public static function isMultiValueType(?string $type): bool
+    {
+        return $type !== null && in_array(strtolower($type), ['combomultiple', 'combocolors', 'combooptions'], true);
+    }
+
     /**
      * @param $criteria
      *

--- a/core/components/minishop3/src/Services/Option/OptionLoaderService.php
+++ b/core/components/minishop3/src/Services/Option/OptionLoaderService.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Services\Option;
 
+use MiniShop3\Controllers\Options\Types\msOptionType;
 use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msCategoryOption;
 use MiniShop3\Model\msOption;
@@ -353,8 +354,7 @@ class OptionLoaderService
      */
     protected function convertPreloadedValue(array $values, string $optionType)
     {
-        $multiTypes = ['combomultiple', 'combocolors', 'combooptions'];
-        if (in_array(strtolower($optionType), $multiTypes, true)) {
+        if (msOptionType::isMultiValueType($optionType)) {
             $result = [];
             foreach ($values as $val) {
                 if ($val !== '') {

--- a/core/components/minishop3/src/Utils/ImportCSV.php
+++ b/core/components/minishop3/src/Utils/ImportCSV.php
@@ -2,11 +2,13 @@
 
 namespace MiniShop3\Utils;
 
+use MiniShop3\Controllers\Options\Types\msOptionType;
 use MiniShop3\MiniShop3;
+use MiniShop3\Model\msOption;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
-use MiniShop3\Model\msProductOption;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Services\Option\OptionService;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 use xPDO\xPDO;
@@ -605,31 +607,50 @@ class ImportCSV
         }
     }
 
-    /**
-     * Process product options
-     */
     private function processOptions(int $productId, array $optionData): void
     {
+        $keys = array_values(array_filter(array_keys($optionData), static fn($key): bool => $key !== ''));
+        if ($keys === []) {
+            return;
+        }
+
+        $typesByKey = $this->loadOptionTypesByKey($keys);
+        $parsedOptions = [];
+
         foreach ($optionData as $key => $value) {
-            if (empty($key)) {
+            if ($key === '') {
                 continue;
             }
 
-            // Find or create option
-            $option = $this->modx->getObject(msProductOption::class, [
-                'product_id' => $productId,
-                'key' => $key,
-            ]);
-
-            if (!$option) {
-                $option = $this->modx->newObject(msProductOption::class);
-                $option->set('product_id', $productId);
-                $option->set('key', $key);
-            }
-
-            $option->set('value', $value);
-            $option->save();
+            $parsedOptions[$key] = Utils::parseImportedOptionValue(
+                $value,
+                msOptionType::isMultiValueType($typesByKey[$key] ?? null)
+            );
         }
+
+        /** @var OptionService $optionService */
+        $optionService = $this->modx->services->get('ms3_option_service');
+        $optionService->saveProductOptions($productId, $parsedOptions, false);
+    }
+
+    private function loadOptionTypesByKey(array $keys): array
+    {
+        $query = $this->modx->newQuery(msOption::class);
+        $query->select(['key', 'type']);
+        $query->where(['key:IN' => $keys]);
+
+        if (!$query->prepare() || !$query->stmt->execute()) {
+            return [];
+        }
+
+        $typesByKey = [];
+        while ($row = $query->stmt->fetch(\PDO::FETCH_ASSOC)) {
+            if (is_string($row['key'] ?? null) && is_string($row['type'] ?? null)) {
+                $typesByKey[$row['key']] = $row['type'];
+            }
+        }
+
+        return $typesByKey;
     }
 
     private function processGallery(array $resource, array $gallery): void

--- a/core/components/minishop3/src/Utils/Utils.php
+++ b/core/components/minishop3/src/Utils/Utils.php
@@ -269,6 +269,30 @@ class Utils
         return is_array($decoded) ? $decoded : $value;
     }
 
+    /**
+     * Parse option values coming from CSV import.
+     *
+     * CSV import accepts the same JSON array format as the product form. For known multi-value
+     * option types it also accepts a comma-separated cell value, matching the manager UI chips.
+     *
+     * @param mixed $value Raw CSV cell value
+     * @param bool $isMultiValueType Whether the option type stores multiple values
+     * @return mixed Parsed array for multi-value cells, otherwise scalar value unchanged
+     */
+    public static function parseImportedOptionValue($value, bool $isMultiValueType)
+    {
+        $value = self::decodeOptionValue($value);
+
+        if (!$isMultiValueType || !is_string($value)) {
+            return $value;
+        }
+
+        return array_values(array_filter(
+            array_map('trim', explode(',', $value)),
+            static fn(string $item): bool => $item !== ''
+        ));
+    }
+
     public static function getVendorId($modx, $name)
     {
         $criteria = [

--- a/core/components/minishop3/tests/UtilsParseImportedOptionValueTest.php
+++ b/core/components/minishop3/tests/UtilsParseImportedOptionValueTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Static checks for CSV option value parsing (without MODX).
+ *
+ * Run: php tests/UtilsParseImportedOptionValueTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Utils\Utils;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertSame(
+    ['flour', 'water', 'salt'],
+    Utils::parseImportedOptionValue('flour, water, salt', true),
+    'multi comma-separated value'
+);
+
+$assertSame(
+    ['flour', 'water'],
+    Utils::parseImportedOptionValue('["flour","water"]', true),
+    'multi JSON array value'
+);
+
+$assertSame(
+    'flour, water',
+    Utils::parseImportedOptionValue('flour, water', false),
+    'single scalar with comma'
+);
+
+$assertSame(
+    [],
+    Utils::parseImportedOptionValue('', true),
+    'empty multi value'
+);
+
+$assertSame(
+    '',
+    Utils::parseImportedOptionValue('', false),
+    'empty single value'
+);
+
+fwrite(STDOUT, "OK UtilsParseImportedOptionValueTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Исправляет импорт CSV для многозначных опций `option.*`: значения опций типов `comboOptions`, `comboMultiple` и `comboColors` теперь разбираются как JSON-массив или список через запятую и сохраняются через существующий `OptionSyncService`.

До исправления CSV-ячейка вроде `"мука, вода, соль"` сохранялась одной записью в `ms3_product_options`. Теперь для многозначного типа создаются отдельные значения, как при сохранении карточки товара из менеджера. Для одиночных и неизвестных типов строки с запятыми остаются скаляром, чтобы не ломать текстовые опции.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #309

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка `fix/309-csv-import-multi-options`
- MODX: не запускался локально
- PHP: 8.4.17

Проверки:
- `php -l` для изменённых PHP-файлов
- `php core/components/minishop3/tests/UtilsParseImportedOptionValueTest.php`
- `git diff --check`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| N/A | N/A |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок — не запускался
- [x] ESLint проходит без ошибок (для JS/Vue изменений) — не затронуто
- [x] Обновлён CHANGELOG.md (для значимых изменений) — по политике репозитория не требуется

## Дополнительные заметки

`ImportCSV.php` остаётся ниже порога в 1000 строк. Полный ручной прогон импорта через Manager UI не выполнялся в этой сессии.