### PR TITLE
fix(category): auto-inject msCategory class_key in Category\Create processor

### DIFF
--- a/core/components/minishop3/src/Processors/Category/Create.php
+++ b/core/components/minishop3/src/Processors/Category/Create.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Processors\Category;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCategory;
+use MODX\Revolution\modDocument;
 use MODX\Revolution\Processors\Resource\Create as CreateProcessor;
 
 class Create extends CreateProcessor
@@ -13,6 +14,19 @@ class Create extends CreateProcessor
     public $permission = 'mscategory_save';
     public $beforeSaveEvent = 'OnBeforeDocFormSave';
     public $afterSaveEvent = 'OnDocFormSave';
+
+    /**
+     * @return bool|string
+     */
+    public function initialize()
+    {
+        $requestedClassKey = $this->getProperty('class_key');
+        if ($requestedClassKey === null || $requestedClassKey === '' || $requestedClassKey === modDocument::class) {
+            $this->setProperty('class_key', $this->classKey);
+        }
+
+        return parent::initialize();
+    }
 
     /**
      * @return string


### PR DESCRIPTION
## Описание

Симметричный фикс к [#306](https://github.com/modx-pro/MiniShop3/pull/306) для msCategory.

`MODX\Revolution\Processors\Resource\Create::initialize()` читает `class_key` из properties запроса с дефолтом `modDocument`, **игнорируя `$classKey` процессора**. Без override'а вызов `Category\Create` через `Resource\Create::getInstance()` (или любой путь без explicit `class_key` в payload) создавал ресурс как `modDocument` вместо `msCategory`.

Override `initialize()` подставляет `$this->classKey` (= `msCategory::class`) в payload, когда `class_key` отсутствует / пустой / равен `modDocument`. Явно переданный `class_key` — сохраняется.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность
- [ ] Breaking change
- [ ] Рефакторинг
- [ ] Документация

## Связанные Issues / PR

- Симметрично #306 для msProduct (мержнут).
- Замечание из ревью #306 — тот же баг был обнаружен в `Category\Create`.

## Как протестировано

- [x] PHPStan на изменённом файле — без новых ошибок.
- [x] Синхронизировано на dev, кэш сброшен.
- [ ] Ручное тестирование — рекомендуется maintainer'у: создать категорию из менеджера без `class_key` в query (или через `runProcessor` `Resource\Create` с msCategory без явного class_key), ресурс должен быть `MiniShop3\Model\msCategory`, не `modDocument`.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Не ломает существующую функциональность
- [ ] Лексиконы — не требуется
- [x] PHPStan проходит
- [ ] ESLint — не требуется
- [ ] CHANGELOG — добавит maintainer при релизе

## Дополнительные заметки

Diff копия из #306 с заменой `msProduct` → `msCategory`. Логика идентична. Альтернатива через trait обсуждалась в ревью #306 — отложена как follow-up, если когда-нибудь появится третий ресурс-наследник (msVariation и т.п.).
