### PR TITLE
refactor(manager): expose direct filter keys from backend

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -16,11 +16,20 @@ use MODX\Revolution\modX;
  */
 class CustomersController
 {
+    protected const DIRECT_FILTER_KEYS = [
+        'query',
+    ];
+
     protected modX $modx;
 
     public function __construct(modX $modx)
     {
         $this->modx = $modx;
+    }
+
+    public static function getDirectFilterKeys(): array
+    {
+        return self::DIRECT_FILTER_KEYS;
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Manager/GridConfigController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/GridConfigController.php
@@ -12,6 +12,11 @@ use MODX\Revolution\modX;
  */
 class GridConfigController
 {
+    private const DIRECT_FILTER_KEY_PROVIDERS = [
+        'orders' => OrdersController::class,
+        'customers' => CustomersController::class,
+    ];
+
     /** @var modX */
     protected $modx;
 
@@ -49,12 +54,25 @@ class GridConfigController
         $includeHidden = !empty($params['include_hidden']);
         $config = $this->service->getGridConfig($gridKey, $includeHidden);
 
-        $payload = ['columns' => $config];
+        $payload = [
+            'columns' => $config,
+            'direct_filter_keys' => $this->getDirectFilterKeys($gridKey),
+        ];
         if ($gridKey === 'category-products') {
             $payload['editor_references'] = GridEditorReferenceRegistry::listForClient();
         }
 
         return Response::success($payload)->getData();
+    }
+
+    private function getDirectFilterKeys(string $gridKey): array
+    {
+        $provider = self::DIRECT_FILTER_KEY_PROVIDERS[$gridKey] ?? null;
+        if (!$provider || !method_exists($provider, 'getDirectFilterKeys')) {
+            return [];
+        }
+
+        return $provider::getDirectFilterKeys();
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -46,10 +46,17 @@ class OrdersController
         'delivery_id',
         'payment_id',
         'context_key',
-        'createdon_from',
+        'createdon_from', // date keys handled in applyDirectFilters(), not in FIELD_MAP
         'createdon_to',
     ];
 
+    protected const DIRECT_FILTER_INT_KEYS = [
+        'status_id',
+        'delivery_id',
+        'payment_id',
+    ];
+
+    /** Param key => msOrder column for direct (unprefixed) filter params. */
     protected const DIRECT_FILTER_FIELD_MAP = [
         'status_id' => 'status_id',
         'delivery_id' => 'delivery_id',
@@ -1626,6 +1633,12 @@ class OrdersController
         }
     }
 
+    /**
+     * Apply direct (unprefixed) filter params to an orders query.
+     *
+     * @param \xPDO\Om\xPDOQuery $c Query object
+     * @param array $params Request parameters
+     */
     protected function applyDirectFilters($c, array $params): void
     {
         foreach (self::DIRECT_FILTER_FIELD_MAP as $paramKey => $fieldName) {
@@ -1634,7 +1647,7 @@ class OrdersController
                 continue;
             }
 
-            if (in_array($paramKey, ['status_id', 'delivery_id', 'payment_id'], true)) {
+            if (in_array($paramKey, self::DIRECT_FILTER_INT_KEYS, true)) {
                 $value = (int)$value;
             }
 

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -40,6 +40,29 @@ use MODX\Revolution\modX;
  */
 class OrdersController
 {
+    protected const DIRECT_FILTER_KEYS = [
+        'query', // handled separately in getList(), not via applyDirectFilters
+        'status_id',
+        'delivery_id',
+        'payment_id',
+        'context_key',
+        'createdon_from',
+        'createdon_to',
+    ];
+
+    protected const DIRECT_FILTER_FIELD_MAP = [
+        'status_id' => 'status_id',
+        'delivery_id' => 'delivery_id',
+        'payment_id' => 'payment_id',
+        'context_key' => 'context',
+    ];
+
+    protected const ADDRESS_FILTER_KEYS = [
+        'customer',
+        'email',
+        'phone',
+    ];
+
     protected modX $modx;
     protected ?OrderLogService $orderLog = null;
     protected ?Utils $ms3Utils = null;
@@ -50,6 +73,11 @@ class OrdersController
 
         // Ensure extra fields are loaded into xPDO map
         $this->loadExtraFieldsMap();
+    }
+
+    public static function getDirectFilterKeys(): array
+    {
+        return self::DIRECT_FILTER_KEYS;
     }
 
     /**
@@ -183,31 +211,7 @@ class OrdersController
             }
         }
 
-        // Direct filter params (from filter config)
-        if ($statusId = ($params['status_id'] ?? null)) {
-            $c->where(['status_id' => (int)$statusId]);
-        }
-        if ($deliveryId = ($params['delivery_id'] ?? null)) {
-            $c->where(['delivery_id' => (int)$deliveryId]);
-        }
-        if ($paymentId = ($params['payment_id'] ?? null)) {
-            $c->where(['payment_id' => (int)$paymentId]);
-        }
-        if ($contextKey = ($params['context_key'] ?? null)) {
-            $c->where(['context' => $contextKey]);
-        }
-
-        // Date range filters
-        if ($dateFrom = ($params['createdon_from'] ?? $params['date_start'] ?? null)) {
-            $c->where([
-                'msOrder.createdon:>=' => date('Y-m-d 00:00:00', strtotime($dateFrom)),
-            ]);
-        }
-        if ($dateTo = ($params['createdon_to'] ?? $params['date_end'] ?? null)) {
-            $c->where([
-                'msOrder.createdon:<=' => date('Y-m-d 23:59:59', strtotime($dateTo)),
-            ]);
-        }
+        $this->applyDirectFilters($c, $params);
 
         // Legacy params for backward compatibility
         if ($customer = ($params['customer'] ?? null)) {
@@ -1492,6 +1496,10 @@ class OrdersController
     {
         $c = $this->modx->newQuery(msOrder::class);
 
+        if ($this->hasAddressFilter($params)) {
+            $c->leftJoin(msOrderAddress::class, 'Address', '`Address`.order_id = msOrder.id');
+        }
+
         // Filter by statuses for statistics (ms3_status_for_stat)
         // Only count orders with these statuses (e.g. paid, completed)
         $statusForStat = $this->modx->getOption('ms3_status_for_stat', null, '2,3');
@@ -1510,31 +1518,7 @@ class OrdersController
             }
         }
 
-        // Direct filter params
-        if ($statusId = ($params['status_id'] ?? null)) {
-            $c->where(['status_id' => (int)$statusId]);
-        }
-        if ($deliveryId = ($params['delivery_id'] ?? null)) {
-            $c->where(['delivery_id' => (int)$deliveryId]);
-        }
-        if ($paymentId = ($params['payment_id'] ?? null)) {
-            $c->where(['payment_id' => (int)$paymentId]);
-        }
-        if ($contextKey = ($params['context_key'] ?? null)) {
-            $c->where(['context' => $contextKey]);
-        }
-
-        // Date range filters
-        if ($dateFrom = ($params['createdon_from'] ?? $params['date_start'] ?? null)) {
-            $c->where([
-                'msOrder.createdon:>=' => date('Y-m-d 00:00:00', strtotime($dateFrom)),
-            ]);
-        }
-        if ($dateTo = ($params['createdon_to'] ?? $params['date_end'] ?? null)) {
-            $c->where([
-                'msOrder.createdon:<=' => date('Y-m-d 23:59:59', strtotime($dateTo)),
-            ]);
-        }
+        $this->applyDirectFilters($c, $params);
 
         // Calculate sum and count
         $c->select('SUM(msOrder.cost) as sum, COUNT(msOrder.id) as total');
@@ -1546,6 +1530,18 @@ class OrdersController
             'month_sum' => number_format(round($data['sum'] ?? 0), 0, '.', ' '),
             'month_total' => number_format($data['total'] ?? 0, 0, '.', ' '),
         ];
+    }
+
+    protected function hasAddressFilter(array $params): bool
+    {
+        foreach (self::ADDRESS_FILTER_KEYS as $fieldName) {
+            $value = $params['filter_' . $fieldName] ?? null;
+            if ($value !== null && $value !== '') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1627,6 +1623,36 @@ class OrdersController
                 break;
             default:
                 break;
+        }
+    }
+
+    protected function applyDirectFilters($c, array $params): void
+    {
+        foreach (self::DIRECT_FILTER_FIELD_MAP as $paramKey => $fieldName) {
+            $value = $params[$paramKey] ?? null;
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (in_array($paramKey, ['status_id', 'delivery_id', 'payment_id'], true)) {
+                $value = (int)$value;
+            }
+
+            $c->where([$fieldName => $value]);
+        }
+
+        $dateFrom = $params['createdon_from'] ?? $params['date_start'] ?? null;
+        if ($dateFrom) {
+            $c->where([
+                'msOrder.createdon:>=' => date('Y-m-d 00:00:00', strtotime($dateFrom)),
+            ]);
+        }
+
+        $dateTo = $params['createdon_to'] ?? $params['date_end'] ?? null;
+        if ($dateTo) {
+            $c->where([
+                'msOrder.createdon:<=' => date('Y-m-d 23:59:59', strtotime($dateTo)),
+            ]);
         }
     }
 

--- a/core/components/minishop3/tests/DirectFilterKeysTest.php
+++ b/core/components/minishop3/tests/DirectFilterKeysTest.php
@@ -30,16 +30,32 @@ $assertSame = static function (array $expected, array $actual, string $label) us
     }
 };
 
-$assertSame(
-    ['query', 'status_id', 'delivery_id', 'payment_id', 'context_key', 'createdon_from', 'createdon_to'],
-    OrdersController::getDirectFilterKeys(),
-    'orders direct filter keys'
-);
+$assertKeysInList = static function (array $keys, array $list, string $label) use ($fail): void {
+    foreach ($keys as $key) {
+        if (!in_array($key, $list, true)) {
+            $fail("{$label}: key {$key} missing from DIRECT_FILTER_KEYS");
+        }
+    }
+};
 
+$ordersReflection = new ReflectionClass(OrdersController::class);
+$ordersKeys = $ordersReflection->getConstant('DIRECT_FILTER_KEYS');
+$ordersFieldMap = $ordersReflection->getConstant('DIRECT_FILTER_FIELD_MAP');
+
+$assertSame($ordersKeys, OrdersController::getDirectFilterKeys(), 'orders getter returns DIRECT_FILTER_KEYS');
+$assertKeysInList(array_keys($ordersFieldMap), $ordersKeys, 'orders FIELD_MAP');
+
+foreach (['query', 'createdon_from', 'createdon_to'] as $separateKey) {
+    if (array_key_exists($separateKey, $ordersFieldMap)) {
+        $fail("orders key {$separateKey} must not be in DIRECT_FILTER_FIELD_MAP");
+    }
+}
+
+$customersReflection = new ReflectionClass(CustomersController::class);
 $assertSame(
-    ['query'],
+    $customersReflection->getConstant('DIRECT_FILTER_KEYS'),
     CustomersController::getDirectFilterKeys(),
-    'customers direct filter keys'
+    'customers getter returns DIRECT_FILTER_KEYS'
 );
 
 $gridConfig = new ReflectionClass(GridConfigController::class);

--- a/core/components/minishop3/tests/DirectFilterKeysTest.php
+++ b/core/components/minishop3/tests/DirectFilterKeysTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Static checks for manager grid direct filter keys (without MODX).
+ *
+ * Run: php tests/DirectFilterKeysTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Controllers\Api\Manager\CustomersController;
+use MiniShop3\Controllers\Api\Manager\GridConfigController;
+use MiniShop3\Controllers\Api\Manager\OrdersController;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function (array $expected, array $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail(sprintf(
+            "%s:\nexpected: %s\nactual:   %s",
+            $label,
+            json_encode($expected, JSON_UNESCAPED_SLASHES),
+            json_encode($actual, JSON_UNESCAPED_SLASHES)
+        ));
+    }
+};
+
+$assertSame(
+    ['query', 'status_id', 'delivery_id', 'payment_id', 'context_key', 'createdon_from', 'createdon_to'],
+    OrdersController::getDirectFilterKeys(),
+    'orders direct filter keys'
+);
+
+$assertSame(
+    ['query'],
+    CustomersController::getDirectFilterKeys(),
+    'customers direct filter keys'
+);
+
+$gridConfig = new ReflectionClass(GridConfigController::class);
+$providers = $gridConfig->getConstant('DIRECT_FILTER_KEY_PROVIDERS');
+
+foreach (['orders' => OrdersController::class, 'customers' => CustomersController::class] as $gridKey => $provider) {
+    if (($providers[$gridKey] ?? null) !== $provider) {
+        $fail("grid-config provider missing for {$gridKey}");
+    }
+}
+
+fwrite(STDOUT, "OK DirectFilterKeysTest\n");
+exit(0);

--- a/vueManager/src/components/CustomersGrid.vue
+++ b/vueManager/src/components/CustomersGrid.vue
@@ -16,6 +16,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, nextTick, onMounted, ref } from 'vue'
 
+import { useGridFilterParams } from '../composables/useGridFilterParams.js'
 import { useSelection } from '../composables/useSelection.js'
 import request from '../request.js'
 import ActionsColumn from './ActionsColumn.vue'
@@ -42,7 +43,7 @@ const {
 })
 
 const columns = ref([])
-const directFilterKeys = ref(new Set())
+const { setDirectFilterKeys, addFilterParam } = useGridFilterParams()
 const loading = ref(false)
 const customers = ref([])
 const totalRecords = ref(0)
@@ -77,15 +78,6 @@ const CUSTOMER_GRID_DELETE_ACTION = {
   confirmTitle: 'customer_delete_confirm_title',
   confirmMessage: 'customer_delete_confirm_message',
   confirmAccept: 'delete',
-}
-
-function addFilterParam(params, key, value) {
-  if (directFilterKeys.value.has(key)) {
-    params[key] = value
-    return
-  }
-
-  params[`filter_${key}`] = value
 }
 
 /**
@@ -516,12 +508,12 @@ async function loadGridConfig() {
   try {
     const response = await request.get('/api/mgr/grid-config/customers')
     columns.value = response.columns || []
-    directFilterKeys.value = new Set(response.direct_filter_keys || [])
+    setDirectFilterKeys(response.direct_filter_keys)
     initFilters()
   } catch (error) {
     console.error('[CustomersGrid] Failed to load grid config:', error)
     columns.value = getDefaultColumns()
-    directFilterKeys.value = new Set()
+    setDirectFilterKeys([])
     initFilters()
   }
 }

--- a/vueManager/src/components/CustomersGrid.vue
+++ b/vueManager/src/components/CustomersGrid.vue
@@ -42,6 +42,7 @@ const {
 })
 
 const columns = ref([])
+const directFilterKeys = ref(new Set())
 const loading = ref(false)
 const customers = ref([])
 const totalRecords = ref(0)
@@ -78,6 +79,15 @@ const CUSTOMER_GRID_DELETE_ACTION = {
   confirmAccept: 'delete',
 }
 
+function addFilterParam(params, key, value) {
+  if (directFilterKeys.value.has(key)) {
+    params[key] = value
+    return
+  }
+
+  params[`filter_${key}`] = value
+}
+
 /**
  * Load customers list
  */
@@ -99,7 +109,7 @@ async function loadCustomers() {
     Object.keys(filterValues.value).forEach(key => {
       const value = filterValues.value[key]
       if (value !== null && value !== undefined && value !== '') {
-        params[`filter_${key}`] = value
+        addFilterParam(params, key, value)
       }
     })
 
@@ -506,10 +516,12 @@ async function loadGridConfig() {
   try {
     const response = await request.get('/api/mgr/grid-config/customers')
     columns.value = response.columns || []
+    directFilterKeys.value = new Set(response.direct_filter_keys || [])
     initFilters()
   } catch (error) {
     console.error('[CustomersGrid] Failed to load grid config:', error)
     columns.value = getDefaultColumns()
+    directFilterKeys.value = new Set()
     initFilters()
   }
 }

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -38,17 +38,6 @@ function readShowDraftsPreference() {
 
 const showDrafts = ref(readShowDraftsPreference())
 
-/** Filter keys sent as direct API params (not filter_ prefix). */
-const DIRECT_FILTER_KEYS = new Set([
-  'query',
-  'status_id',
-  'delivery_id',
-  'payment_id',
-  'context_key',
-  'createdon_from',
-  'createdon_to',
-])
-
 // Bulk selection
 const {
   selectedItems,
@@ -68,6 +57,7 @@ const {
 
 const columns = ref([])
 const filters = ref({})
+const directFilterKeys = ref(new Set())
 const loading = ref(false)
 const orders = ref([])
 const totalRecords = ref(0)
@@ -89,6 +79,15 @@ const sortedFilters = computed(() => {
     .map(([key, config]) => ({ key, ...config }))
     .sort((a, b) => (a.position || 100) - (b.position || 100))
 })
+
+function addFilterParam(params, key, value) {
+  if (directFilterKeys.value.has(key)) {
+    params[key] = value
+    return
+  }
+
+  params[`filter_${key}`] = value
+}
 
 /**
  * Load orders list
@@ -112,17 +111,23 @@ async function loadOrders() {
         const filterConfig = filters.value[key]
         if (filterConfig?.type === 'daterange' && Array.isArray(value)) {
           if (value[0]) {
-            params[filterConfig.fields?.from || `${key}_from`] = formatDateForApi(value[0])
+            addFilterParam(
+              params,
+              filterConfig.fields?.from || `${key}_from`,
+              formatDateForApi(value[0])
+            )
           }
           if (value[1]) {
-            params[filterConfig.fields?.to || `${key}_to`] = formatDateForApi(value[1])
+            addFilterParam(
+              params,
+              filterConfig.fields?.to || `${key}_to`,
+              formatDateForApi(value[1])
+            )
           }
         } else if (filterConfig?.type === 'datepicker' && value) {
-          params[key] = formatDateForApi(value)
-        } else if (DIRECT_FILTER_KEYS.has(key)) {
-          params[key] = value
+          addFilterParam(params, key, formatDateForApi(value))
         } else {
-          params[`filter_${key}`] = value
+          addFilterParam(params, key, value)
         }
       }
     })
@@ -421,9 +426,11 @@ async function loadGridConfig() {
   try {
     const response = await request.get('/api/mgr/grid-config/orders')
     columns.value = response.columns || []
+    directFilterKeys.value = new Set(response.direct_filter_keys || [])
   } catch (error) {
     console.error('[OrdersGrid] Failed to load grid config:', error)
     columns.value = getDefaultColumns()
+    directFilterKeys.value = new Set()
   }
 }
 

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -14,6 +14,7 @@ import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 
+import { useGridFilterParams } from '../composables/useGridFilterParams.js'
 import { useSelection } from '../composables/useSelection.js'
 import request from '../request.js'
 import ActionsColumn from './ActionsColumn.vue'
@@ -57,7 +58,7 @@ const {
 
 const columns = ref([])
 const filters = ref({})
-const directFilterKeys = ref(new Set())
+const { setDirectFilterKeys, addFilterParam } = useGridFilterParams()
 const loading = ref(false)
 const orders = ref([])
 const totalRecords = ref(0)
@@ -79,15 +80,6 @@ const sortedFilters = computed(() => {
     .map(([key, config]) => ({ key, ...config }))
     .sort((a, b) => (a.position || 100) - (b.position || 100))
 })
-
-function addFilterParam(params, key, value) {
-  if (directFilterKeys.value.has(key)) {
-    params[key] = value
-    return
-  }
-
-  params[`filter_${key}`] = value
-}
 
 /**
  * Load orders list
@@ -426,11 +418,11 @@ async function loadGridConfig() {
   try {
     const response = await request.get('/api/mgr/grid-config/orders')
     columns.value = response.columns || []
-    directFilterKeys.value = new Set(response.direct_filter_keys || [])
+    setDirectFilterKeys(response.direct_filter_keys)
   } catch (error) {
     console.error('[OrdersGrid] Failed to load grid config:', error)
     columns.value = getDefaultColumns()
-    directFilterKeys.value = new Set()
+    setDirectFilterKeys([])
   }
 }
 

--- a/vueManager/src/composables/useGridFilterParams.js
+++ b/vueManager/src/composables/useGridFilterParams.js
@@ -1,0 +1,29 @@
+import { ref } from 'vue'
+
+/**
+ * Grid filter param serialization using direct_filter_keys from grid-config API.
+ *
+ * Keys listed by the backend are sent as-is; others get the filter_ prefix.
+ */
+export function useGridFilterParams() {
+  const directFilterKeys = ref(new Set())
+
+  function setDirectFilterKeys(keys) {
+    directFilterKeys.value = new Set(keys || [])
+  }
+
+  function addFilterParam(params, key, value) {
+    if (directFilterKeys.value.has(key)) {
+      params[key] = value
+      return
+    }
+
+    params[`filter_${key}`] = value
+  }
+
+  return {
+    directFilterKeys,
+    setDirectFilterKeys,
+    addFilterParam,
+  }
+}


### PR DESCRIPTION
## Описание

Выносит список прямых ключей фильтров менеджерских гридов на backend и отдаёт его вместе с конфигом грида. Это убирает дублирование между Vue-гридами и PHP-контроллерами: frontend теперь решает, отправлять параметр как `key` или `filter_key`, на основе `direct_filter_keys` из `/api/mgr/grid-config/{grid_key}`.

Для заказов дополнительно переиспользуется общий обработчик direct-фильтров в списке и статистике, а stats-запрос подключает `Address` при адресных фильтрах, чтобы `filter_customer`, `filter_email` и `filter_phone` не ломали расчёт.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #314

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка `beta`
- MODX: не запускался
- PHP: локальный CLI

Проверки:
- `php -l core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php`
- `php -l core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php`
- `php -l core/components/minishop3/src/Controllers/Api/Manager/GridConfigController.php`
- `php -l core/components/minishop3/tests/DirectFilterKeysTest.php`
- `php core/components/minishop3/tests/DirectFilterKeysTest.php`
- `npx eslint src/components/OrdersGrid.vue src/components/CustomersGrid.vue`
- `git diff --check`

## Скриншоты (если применимо)

Не применимо: изменение контракта API и сериализации фильтров без визуальных изменений.

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Новые комментарии и лексиконы не требуются: сложная пользовательская логика и новые UI-строки не добавлялись. CHANGELOG не обновлялся, так как в проектных правилах записи добавляются при подготовке релиза.

PHPStan не запускался; для PHP выполнены синтаксическая проверка и статический regression-тест без MODX-окружения.