### PR TITLE
fix(order): use order address email for customer notifications (#218)

### DIFF
--- a/core/components/minishop3/src/Notifications/Channels/EmailChannel.php
+++ b/core/components/minishop3/src/Notifications/Channels/EmailChannel.php
@@ -99,6 +99,11 @@ class EmailChannel implements ChannelInterface
             return $recipient['customer']['email'] ?? null;
         }
 
+        // Address email (fallback, same order as SmsChannel phone)
+        if (!empty($recipient['address']['email'])) {
+            return $recipient['address']['email'];
+        }
+
         return null;
     }
 

--- a/core/components/minishop3/src/Services/Order/OrderStatusService.php
+++ b/core/components/minishop3/src/Services/Order/OrderStatusService.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Services\Order;
 use MiniShop3\Controllers\Payment\Payment;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderAddress;
 use MiniShop3\Model\msOrderStatus as msOrderStatusModel;
 use MiniShop3\Model\msCustomer;
 use MiniShop3\Notifications\NotificationManager;
@@ -211,10 +212,10 @@ class OrderStatusService
     /**
      * Get customer recipient data for all notification channels
      *
-     * Returns all available contact information for the customer:
-     * - email: for EmailChannel
-     * - phone: for SmsChannel
-     * - telegram_chat_id: for TelegramChannel
+     * Contact resolution order (order-scoped first, then fallbacks):
+     * 1. msOrderAddress — email/phone from this order's checkout form
+     * 2. msCustomer — fallback email/phone, plus telegram_chat_id and customer payload
+     * 3. modUserProfile — last fallback for email/phone/telegram when still empty
      *
      * @return array|null Returns null only if no contact info available
      */
@@ -229,21 +230,32 @@ class OrderStatusService
 
         $hasContact = false;
 
-        // Try to get contact info from msCustomer
+        /** @var msOrderAddress|null $address */
+        $address = $msOrder->getOne('Address');
+        if ($address) {
+            if ($email = $address->get('email')) {
+                $recipient['email'] = $email;
+                $hasContact = true;
+            }
+            if ($phone = $address->get('phone')) {
+                $recipient['phone'] = $phone;
+                $hasContact = true;
+            }
+        }
+
         /** @var msCustomer|null $customer */
         $customer = $msOrder->getOne('Customer');
         if ($customer) {
             $recipient['customer'] = $customer->toArray();
 
-            if ($email = $customer->get('email')) {
+            if (empty($recipient['email']) && ($email = $customer->get('email'))) {
                 $recipient['email'] = $email;
                 $hasContact = true;
             }
-            if ($phone = $customer->get('phone')) {
+            if (empty($recipient['phone']) && ($phone = $customer->get('phone'))) {
                 $recipient['phone'] = $phone;
                 $hasContact = true;
             }
-            // telegram_chat_id may be stored in extended fields
             $extended = $customer->get('extended');
             if (is_array($extended) && !empty($extended['telegram_chat_id'])) {
                 $recipient['telegram_chat_id'] = $extended['telegram_chat_id'];
@@ -251,7 +263,7 @@ class OrderStatusService
             }
         }
 
-        // Fallback/supplement from modUserProfile
+        // Fallback from modUserProfile when order address / customer data is missing
         $userId = $msOrder->get('user_id');
         if ($userId) {
             /** @var modUserProfile|null $profile */

--- a/core/components/minishop3/src/Services/Order/OrderStatusService.php
+++ b/core/components/minishop3/src/Services/Order/OrderStatusService.php
@@ -213,9 +213,11 @@ class OrderStatusService
      * Get customer recipient data for all notification channels
      *
      * Contact resolution order (order-scoped first, then fallbacks):
-     * 1. msOrderAddress — email/phone from this order's checkout form
+     * 1. msOrderAddress — email/phone from this order's checkout form (also in recipient['address'])
      * 2. msCustomer — fallback email/phone, plus telegram_chat_id and customer payload
      * 3. modUserProfile — last fallback for email/phone/telegram when still empty
+     *
+     * Resolved email/phone are mirrored into recipient['customer'] when present (for plugins/templates).
      *
      * @return array|null Returns null only if no contact info available
      */
@@ -233,6 +235,8 @@ class OrderStatusService
         /** @var msOrderAddress|null $address */
         $address = $msOrder->getOne('Address');
         if ($address) {
+            $recipient['address'] = $address->toArray();
+
             if ($email = $address->get('email')) {
                 $recipient['email'] = $email;
                 $hasContact = true;
@@ -269,7 +273,6 @@ class OrderStatusService
             /** @var modUserProfile|null $profile */
             $profile = $this->modx->getObject(modUserProfile::class, ['internalKey' => $userId]);
             if ($profile) {
-                // Only use profile data if customer data is missing
                 if (empty($recipient['email']) && $profile->get('email')) {
                     $recipient['email'] = $profile->get('email');
                     $hasContact = true;
@@ -284,6 +287,15 @@ class OrderStatusService
                     $recipient['telegram_chat_id'] = $extended['telegram_chat_id'];
                     $hasContact = true;
                 }
+            }
+        }
+
+        if (!empty($recipient['customer']) && is_array($recipient['customer'])) {
+            if (!empty($recipient['email'])) {
+                $recipient['customer']['email'] = $recipient['email'];
+            }
+            if (!empty($recipient['phone'])) {
+                $recipient['customer']['phone'] = $recipient['phone'];
             }
         }
 


### PR DESCRIPTION
## Описание

Customer-уведомления о смене статуса заказа теперь берут email и phone из `msOrderAddress` (контакты, указанные в форме **этого** заказа), а не из `msCustomer`, который может содержать устаревшие данные при повторном оформлении в той же сессии.

В `OrderStatusService::getCustomerRecipient()` установлен порядок источников:
1. `msOrderAddress` — email/phone заказа
2. `msCustomer` — fallback + `telegram_chat_id` и payload `customer`
3. `modUserProfile` — последний fallback

Логика создания/обновления `msCustomer` не менялась — исправлен только resolver получателя уведомлений.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #218

## Как это было протестировано?

- [x] Ручное тестирование (логическая проверка сценариев по коду)
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: —
- PHP: `php -l` на `OrderStatusService.php` — без ошибок

**Сценарии для проверки на стенде:**
1. Приватная вкладка → заказ с `alice@example.com` → уведомление на alice
2. Не закрывая вкладку → второй заказ с `bob@example.com` → уведомление на bob
3. Заказ без email в address, но с email в msCustomer → fallback на customer email

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Письмо уходит на email из msCustomer (alice) | Письмо уходит на email из msOrderAddress (bob) |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений) — не затронуто
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике репозитория добавляется maintainer'ом при релизе

## Дополнительные заметки

`getManagerRecipients()` и `Customer::getOrCreate()` не изменялись. Плагины по-прежнему могут переопределить recipient через `msOnBeforeSendNotification`.