### PR TITLE
chore(schema): sync XML with msOption / msOptionGroup model

### DIFF
--- a/core/components/minishop3/schema/minishop3.mysql.schema.xml
+++ b/core/components/minishop3/schema/minishop3.mysql.schema.xml
@@ -516,7 +516,7 @@
                index="fulltext"/>
         <field key="description" dbtype="text" phptype="string" null="true"/>
         <field key="measure_unit" dbtype="tinytext" phptype="string" null="true"/>
-        <field key="modcategory_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"/>
+        <field key="option_group_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true" default="NULL"/>
         <field key="type" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index"/>
         <field key="properties" dbtype="text" phptype="json" null="true"/>
 
@@ -526,8 +526,8 @@
         <index alias="caption_ft" name="caption_ft" primary="false" unique="false" type="FULLTEXT">
             <column key="caption" length="" collation="A" null="false"/>
         </index>
-        <index alias="modcategory_id" name="modcategory_id" primary="false" unique="false" type="BTREE">
-            <column key="modcategory_id" length="" collation="A" null="false"/>
+        <index alias="option_group_id" name="option_group_id" primary="false" unique="false" type="BTREE">
+            <column key="option_group_id" length="" collation="A" null="false"/>
         </index>
         <index alias="type" name="key" primary="false" unique="false" type="BTREE">
             <column key="type" length="" collation="A" null="false"/>
@@ -537,7 +537,7 @@
                    owner="local"/>
         <composite alias="OptionProducts" class="MiniShop3\Model\msProductOption" local="key" foreign="key" cardinality="many"
                    owner="local"/>
-        <aggregate alias="Category" class="MODX\Revolution\modCategory" local="modcategory_id" foreign="id" owner="foreign"
+        <aggregate alias="Group" class="MiniShop3\Model\msOptionGroup" local="option_group_id" foreign="id" owner="foreign"
                    cardinality="one"/>
         <validation>
             <rule field="key" name="invalid" type="preg_match"
@@ -546,6 +546,28 @@
                   rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|article|price|old_price|weight|image|thumb|vendor|made_in|new|popular|favorite|tags|color|size|source|action)$)/"
                   message="ms3_option_err_reserved_key"/>
         </validation>
+    </object>
+
+    <object class="msOptionGroup" table="ms3_option_groups" extends="xPDO\Om\xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default=""/>
+        <field key="description" dbtype="text" phptype="string" null="true"/>
+        <field key="sort_order" dbtype="int" precision="10" phptype="integer" null="false" default="0"/>
+        <field key="created_at" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP"/>
+        <field key="updated_at" dbtype="timestamp" phptype="timestamp" null="true" extra="on update CURRENT_TIMESTAMP"/>
+
+        <index alias="idx_sort_order" name="idx_sort_order" primary="false" unique="false" type="BTREE">
+            <column key="sort_order" length="" collation="A" null="false"/>
+        </index>
+
+        <!--
+          Group does NOT own its options — defining this as `composites` would
+          make $group->remove() cascade-delete every msOption in the group,
+          which contradicts the documented behavior: deleting a group should
+          detach its options (option_group_id = NULL), not destroy them.
+          OptionGroupsController calls detachOptionsFromGroup() explicitly before remove().
+        -->
+        <aggregate alias="Options" class="MiniShop3\Model\msOption" local="id" foreign="option_group_id" cardinality="many"
+                   owner="local"/>
     </object>
 
     <object class="msCategoryOption" table="ms3_category_options" extends="xPDO\Om\xPDOObject">


### PR DESCRIPTION
## Описание

Синхронизирует `core/components/minishop3/schema/minishop3.mysql.schema.xml` с фактическими моделями в `src/Model/mysql/*` после PR #10 (msOptionGroup, 1.11.0).

Runtime source of truth — `src/Model/mysql/*`. XML-схема остаётся как справочный документ (и потенциально для внешних tooling-скриптов, которые её парсят). При мерже PR #10 XML не обновили, появился drift.

## Что меняется

### `msOption`

- Поле `modcategory_id` (FK на `modCategory`) → **`option_group_id`** (FK на `msOptionGroup`, nullable, default NULL).
- Индекс `modcategory_id` → `option_group_id`.
- Агрегат `Category → MODX\Revolution\modCategory` → **`Group → MiniShop3\Model\msOptionGroup`**.

Соответствует `src/Model/mysql/msOption.php` (строки 22, 58–66, 117–132, 153–163).

### Новый object: `msOptionGroup`

Добавлен полностью:
- Таблица `ms3_option_groups`.
- Поля: `name VARCHAR(255) NOT NULL DEFAULT ''`, `description TEXT NULL`, `sort_order INT(10) NOT NULL DEFAULT 0`, `created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`, `updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP`.
- Индекс `idx_sort_order` (BTREE на `sort_order`).
- Aggregate `Options` (local owner) — **намеренно не composite**, чтобы `$group->remove()` не каскадно удалял `msOption`-записи. `OptionGroupsController` явно вызывает `detachOptionsFromGroup()` перед remove(). Та же логика что и в `src/Model/mysql/msOptionGroup.php:81-88`.

## Тип изменений

- [ ] Исправление бага
- [ ] Новая функциональность
- [ ] Breaking change
- [x] Рефакторинг (sync артефакта документации с моделью)
- [ ] Документация
- [ ] Другое

## Связанные Issues / PR

- PR #10 (msOptionGroup в 1.11.0) — источник drift'а.
- Найдено во время release-docs-sync audit для v1.12.0-beta1.

## Как протестировано

- [x] `php -l` — syntax OK.
- [ ] Ручное тестирование — не применимо: файл runtime не используется (используется `src/Model/mysql/*` через `addPackage`).
- [ ] PHPStan — XML не анализируется.

## Чеклист

- [x] Соответствует фактической модели в коде.
- [ ] Лексиконы — n/a.
- [ ] CHANGELOG — это chore-фикс, не значимое для пользователя изменение, в CHANGELOG не пишу.

## Дополнительные заметки

Если в проекте есть консенсус, что XML-схема — устаревший артефакт и его надо удалить, дай знать — следующим PR удалю. Пока сохранил для обратной совместимости с внешним tooling.
