### PR TITLE
feat(extra-fields): add ms3-key-value field type

### DIFF
--- a/core/components/minishop3/docs/changelog.txt
+++ b/core/components/minishop3/docs/changelog.txt
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- New extra field type `ms3-key-value` (#300). Flat JSON object map (key → value) for nutrition/meta/config-style data. Backend: `key_value_config` column in `ms3_extra_fields`, `KeyValueFieldService` (decode → normalize → validate; modes `fixed` / `free`; required + numeric checks). Frontend: `KeyValueField` + `KeyValueSchemaEditor`, product data tab and order/address extra fields. Saved via product `Data` payload or Vue ProductData PUT; API/xPDO returns an associative array. Fenom: `{$nutrition.calories}`. SQL: `JSON_EXTRACT(ms3_products.nutrition, '$.calories')`. Unlike plain `json`+textarea, values bypass `prepareOptionValues()` so object keys are not destroyed.
-
 ## [1.12.0-beta1]
 
 ### Added

--- a/core/components/minishop3/docs/changelog.txt
+++ b/core/components/minishop3/docs/changelog.txt
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- New extra field type `ms3-key-value` (#300). Flat JSON object map (key → value) for nutrition/meta/config-style data. Backend: `key_value_config` column in `ms3_extra_fields`, `KeyValueFieldService` (decode → normalize → validate; modes `fixed` / `free`; required + numeric checks). Frontend: `KeyValueField` + `KeyValueSchemaEditor`, product data tab and order/address extra fields. Saved via product `Data` payload or Vue ProductData PUT; API/xPDO returns an associative array. Fenom: `{$nutrition.calories}`. SQL: `JSON_EXTRACT(ms3_products.nutrition, '$.calories')`. Unlike plain `json`+textarea, values bypass `prepareOptionValues()` so object keys are not destroyed.
+
 ## [1.12.0-beta1]
 
 ### Added

--- a/core/components/minishop3/lexicon/en/default.inc.php
+++ b/core/components/minishop3/lexicon/en/default.inc.php
@@ -174,6 +174,7 @@ $_lang['ms3_err_field_nf'] = 'Field not found';
 $_lang['ms3_err_ae'] = 'This field must be unique';
 $_lang['ms3_err_json'] = 'This field requires JSON string';
 $_lang['ms3_repeater_validation_error'] = 'Repeater field "[[+field]]": [[+error]]';
+$_lang['ms3_key_value_validation_error'] = 'Key-value field "[[+field]]": [[+error]]';
 
 $_lang['ms3_err_user_nf'] = 'User not found.';
 $_lang['ms3_err_order_nf'] = 'Order with this identifier not found.';

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -205,6 +205,7 @@ $_lang['ms3_vue_key_value_value_type_string'] = 'String';
 $_lang['ms3_vue_key_value_value_type_number'] = 'Number';
 $_lang['ms3_vue_key_value_required'] = 'Required';
 $_lang['ms3_vue_key_value_no_keys'] = 'No keys defined. Add keys in extra field settings for fixed mode.';
+$_lang['ms3_vue_key_value_duplicate_key'] = 'Duplicate key "[[+key]]". Only the first value is kept.';
 
 $_lang['ms3_vue_order_extra_fields'] = 'Additional order fields';
 $_lang['ms3_vue_order_address_extra_fields'] = 'Additional address fields';

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -161,6 +161,7 @@ $_lang['ms3_vue_xtype_textarea'] = 'Text Area';
 $_lang['ms3_vue_xtype_xcheckbox'] = 'Checkbox';
 $_lang['ms3_vue_xtype_combo_select'] = 'Dropdown List';
 $_lang['ms3_vue_xtype_repeater'] = 'Repeater (rows grid)';
+$_lang['ms3_vue_xtype_key_value'] = 'Key-Value (map)';
 $_lang['ms3_vue_xtype_combo_vendor'] = 'Vendor (combo)';
 $_lang['ms3_vue_xtype_combo_autocomplete'] = 'Autocomplete (combo)';
 $_lang['ms3_vue_xtype_combo_options'] = 'Product Options (chips)';
@@ -186,6 +187,25 @@ $_lang['ms3_vue_repeater_sortable'] = 'Drag-and-drop sorting';
 $_lang['ms3_vue_repeater_add_row'] = 'Add row';
 $_lang['ms3_vue_repeater_no_columns'] = 'Configure repeater columns in extra field settings.';
 $_lang['ms3_vue_repeater_drag_hint'] = 'Drag to reorder';
+
+// Key-Value field
+$_lang['ms3_vue_key_value_schema_label'] = 'Key-Value schema';
+$_lang['ms3_vue_key_value_schema_help'] = 'Define keys for fixed mode or use free mode for any pairs.';
+$_lang['ms3_vue_key_value_mode'] = 'Mode';
+$_lang['ms3_vue_key_value_mode_fixed'] = 'Fixed keys';
+$_lang['ms3_vue_key_value_mode_free'] = 'Free keys';
+$_lang['ms3_vue_key_value_keys'] = 'Keys';
+$_lang['ms3_vue_key_value_add_key'] = 'Add key';
+$_lang['ms3_vue_key_value_key'] = 'Key';
+$_lang['ms3_vue_key_value_label'] = 'Label';
+$_lang['ms3_vue_key_value_value'] = 'Value';
+$_lang['ms3_vue_key_value_add_pair'] = 'Add pair';
+$_lang['ms3_vue_key_value_value_type'] = 'Value type';
+$_lang['ms3_vue_key_value_value_type_string'] = 'String';
+$_lang['ms3_vue_key_value_value_type_number'] = 'Number';
+$_lang['ms3_vue_key_value_required'] = 'Required';
+$_lang['ms3_vue_key_value_no_keys'] = 'No keys defined. Add keys in extra field settings for fixed mode.';
+
 $_lang['ms3_vue_order_extra_fields'] = 'Additional order fields';
 $_lang['ms3_vue_order_address_extra_fields'] = 'Additional address fields';
 

--- a/core/components/minishop3/lexicon/ru/default.inc.php
+++ b/core/components/minishop3/lexicon/ru/default.inc.php
@@ -174,6 +174,7 @@ $_lang['ms3_err_field_nf'] = 'Поле не найдено';
 $_lang['ms3_err_ae'] = 'Это поле должно быть уникально';
 $_lang['ms3_err_json'] = 'Это поле требует JSON строку';
 $_lang['ms3_repeater_validation_error'] = 'Поле повторителя «[[+field]]»: [[+error]]';
+$_lang['ms3_key_value_validation_error'] = 'Поле key-value «[[+field]]»: [[+error]]';
 
 $_lang['ms3_err_user_nf'] = 'Пользователь не найден.';
 $_lang['ms3_err_order_nf'] = 'Заказ с таким идентификатором не найден.';

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -161,6 +161,7 @@ $_lang['ms3_vue_xtype_textarea'] = 'Текстовая область';
 $_lang['ms3_vue_xtype_xcheckbox'] = 'Флажок';
 $_lang['ms3_vue_xtype_combo_select'] = 'Выпадающий список';
 $_lang['ms3_vue_xtype_repeater'] = 'Повторитель (таблица строк)';
+$_lang['ms3_vue_xtype_key_value'] = 'Ключ-Значение (карта)';
 $_lang['ms3_vue_xtype_combo_vendor'] = 'Производитель (combo)';
 $_lang['ms3_vue_xtype_combo_autocomplete'] = 'Автодополнение (combo)';
 $_lang['ms3_vue_xtype_combo_options'] = 'Опции товара (chips)';
@@ -186,6 +187,25 @@ $_lang['ms3_vue_repeater_sortable'] = 'Сортировка перетаскив
 $_lang['ms3_vue_repeater_add_row'] = 'Добавить строку';
 $_lang['ms3_vue_repeater_no_columns'] = 'Настройте колонки повторителя в параметрах extra field.';
 $_lang['ms3_vue_repeater_drag_hint'] = 'Перетащите для изменения порядка';
+
+// Key-Value field
+$_lang['ms3_vue_key_value_schema_label'] = 'Схема Ключ-Значение';
+$_lang['ms3_vue_key_value_schema_help'] = 'Определите ключи для фиксированного режима или используйте свободный режим для любых пар.';
+$_lang['ms3_vue_key_value_mode'] = 'Режим';
+$_lang['ms3_vue_key_value_mode_fixed'] = 'Фиксированные ключи';
+$_lang['ms3_vue_key_value_mode_free'] = 'Свободные ключи';
+$_lang['ms3_vue_key_value_keys'] = 'Ключи';
+$_lang['ms3_vue_key_value_add_key'] = 'Добавить ключ';
+$_lang['ms3_vue_key_value_key'] = 'Ключ';
+$_lang['ms3_vue_key_value_label'] = 'Подпись';
+$_lang['ms3_vue_key_value_value'] = 'Значение';
+$_lang['ms3_vue_key_value_add_pair'] = 'Добавить пару';
+$_lang['ms3_vue_key_value_value_type'] = 'Тип значения';
+$_lang['ms3_vue_key_value_value_type_string'] = 'Строка';
+$_lang['ms3_vue_key_value_value_type_number'] = 'Число';
+$_lang['ms3_vue_key_value_required'] = 'Обязательное';
+$_lang['ms3_vue_key_value_no_keys'] = 'Ключи не заданы. Добавьте ключи в параметрах extra field для фиксированного режима.';
+
 $_lang['ms3_vue_order_extra_fields'] = 'Дополнительные поля заказа';
 $_lang['ms3_vue_order_address_extra_fields'] = 'Дополнительные поля адреса';
 

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -205,6 +205,7 @@ $_lang['ms3_vue_key_value_value_type_string'] = 'Строка';
 $_lang['ms3_vue_key_value_value_type_number'] = 'Число';
 $_lang['ms3_vue_key_value_required'] = 'Обязательное';
 $_lang['ms3_vue_key_value_no_keys'] = 'Ключи не заданы. Добавьте ключи в параметрах extra field для фиксированного режима.';
+$_lang['ms3_vue_key_value_duplicate_key'] = 'Дублирующий ключ «[[+key]]». Сохраняется только первое значение.';
 
 $_lang['ms3_vue_order_extra_fields'] = 'Дополнительные поля заказа';
 $_lang['ms3_vue_order_address_extra_fields'] = 'Дополнительные поля адреса';

--- a/core/components/minishop3/migrations/20260622120000_add_key_value_config_to_extra_fields.php
+++ b/core/components/minishop3/migrations/20260622120000_add_key_value_config_to_extra_fields.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Adds key_value_config column to ms3_extra_fields for ms3-key-value field schema
+ */
+final class AddKeyValueConfigToExtraFields extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('ms3_extra_fields');
+
+        if (!$table->hasColumn('key_value_config')) {
+            $table->addColumn('key_value_config', 'text', [
+                'null' => true,
+                'after' => 'repeater_config',
+                'comment' => 'JSON schema for ms3-key-value field type (mode, keys, value types, required flags)',
+            ]);
+            $table->update();
+        }
+    }
+
+    public function down(): void
+    {
+        $table = $this->table('ms3_extra_fields');
+
+        if ($table->hasColumn('key_value_config')) {
+            $table->removeColumn('key_value_config');
+            $table->update();
+        }
+    }
+}

--- a/core/components/minishop3/schema/minishop3.mysql.schema.xml
+++ b/core/components/minishop3/schema/minishop3.mysql.schema.xml
@@ -625,6 +625,7 @@
         <field key="index_type" dbtype="varchar" precision="50" phptype="string" null="true" default="NONE"/>
         <field key="select_options" dbtype="text" phptype="string" null="true"/>
         <field key="repeater_config" dbtype="text" phptype="string" null="true"/>
+        <field key="key_value_config" dbtype="text" phptype="string" null="true"/>
 
         <field key="active" dbtype="tinyint" precision="1" phptype="boolean" null="true" default="0"/>
 

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -13,6 +13,7 @@ use MiniShop3\Model\msOrderStatus;
 use MiniShop3\Model\msPayment;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
 use MiniShop3\Services\ExtraFields\RepeaterFieldService;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
@@ -1763,27 +1764,51 @@ class OrdersController
             'active' => true,
         ]);
 
-        if (!$definition || $definition->get('xtype') !== RepeaterFieldService::XTYPE) {
+        if (!$definition) {
             return ['ok' => true, 'value' => $value];
         }
 
-        /** @var RepeaterFieldService $repeaterService */
-        $repeaterService = $this->modx->services->get('ms3_repeater_field');
-        $config = $repeaterService->parseConfig($definition->get('repeater_config'));
+        if ($definition->get('xtype') === RepeaterFieldService::XTYPE) {
+            /** @var RepeaterFieldService $repeaterService */
+            $repeaterService = $this->modx->services->get('ms3_repeater_field');
+            $config = $repeaterService->parseConfig($definition->get('repeater_config'));
 
-        try {
-            return ['ok' => true, 'value' => $repeaterService->processValue($value, $config)];
-        } catch (\InvalidArgumentException $e) {
-            $this->modx->lexicon->load('minishop3:default');
+            try {
+                return ['ok' => true, 'value' => $repeaterService->processValue($value, $config)];
+            } catch (\InvalidArgumentException $e) {
+                $this->modx->lexicon->load('minishop3:default');
 
-            return [
-                'ok' => false,
-                'message' => $this->modx->lexicon('ms3_repeater_validation_error', [
-                    'field' => $fieldKey,
-                    'error' => $e->getMessage(),
-                ]),
-            ];
+                return [
+                    'ok' => false,
+                    'message' => $this->modx->lexicon('ms3_repeater_validation_error', [
+                        'field' => $fieldKey,
+                        'error' => $e->getMessage(),
+                    ]),
+                ];
+            }
         }
+
+        if ($definition->get('xtype') === KeyValueFieldService::XTYPE) {
+            /** @var KeyValueFieldService $keyValueService */
+            $keyValueService = $this->modx->services->get('ms3_key_value_field');
+            $config = $keyValueService->parseConfig($definition->get('key_value_config'));
+
+            try {
+                return ['ok' => true, 'value' => $keyValueService->processValue($value, $config)];
+            } catch (\InvalidArgumentException $e) {
+                $this->modx->lexicon->load('minishop3:default');
+
+                return [
+                    'ok' => false,
+                    'message' => $this->modx->lexicon('ms3_key_value_validation_error', [
+                        'field' => $fieldKey,
+                        'error' => $e->getMessage(),
+                    ]),
+                ];
+            }
+        }
+
+        return ['ok' => true, 'value' => $value];
     }
 
     /**

--- a/core/components/minishop3/src/Model/mysql/msExtraField.php
+++ b/core/components/minishop3/src/Model/mysql/msExtraField.php
@@ -29,6 +29,7 @@ class msExtraField extends \MiniShop3\Model\msExtraField
             'active' => 0,
             'select_options' => null,
             'repeater_config' => null,
+            'key_value_config' => null,
         ],
         'fieldMeta' => [
             'class' => [
@@ -125,6 +126,11 @@ class msExtraField extends \MiniShop3\Model\msExtraField
                 'null' => true,
             ],
             'repeater_config' => [
+                'dbtype' => 'text',
+                'phptype' => 'string',
+                'null' => true,
+            ],
+            'key_value_config' => [
                 'dbtype' => 'text',
                 'phptype' => 'string',
                 'null' => true,

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -139,6 +139,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\ExtraFieldsService::class,
             'interface' => null,
         ],
+        'ms3_key_value_field' => [
+            'class' => \MiniShop3\Services\ExtraFields\KeyValueFieldService::class,
+            'interface' => null,
+        ],
         'ms3_product_image' => [
             'class' => \MiniShop3\Services\Product\ProductImageService::class,
             'interface' => null,

--- a/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
+++ b/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
@@ -12,7 +12,7 @@ class KeyValueFieldService
     private modX $modx;
 
     /** Request-scoped cache of key-value field configs keyed by model class. */
-    private ?array $fieldsByClass = null;
+    private array $fieldsByClass = [];
 
     public function __construct(modX $modx)
     {
@@ -55,9 +55,7 @@ class KeyValueFieldService
             $config = array_merge($config, $json);
         }
 
-        if (($config['mode'] ?? '') !== 'free') {
-            $config['mode'] = 'fixed';
-        }
+        $config['mode'] = $this->resolveMode($config);
 
         if (!is_array($config['keys'])) {
             $config['keys'] = [];
@@ -93,17 +91,13 @@ class KeyValueFieldService
     {
         $config = $this->parseConfig($json);
 
-        if (($config['mode'] ?? 'fixed') === 'fixed' && empty($config['keys'])) {
+        if ($config['mode'] === 'fixed' && $config['keys'] === []) {
             return ['success' => false, 'message' => 'Key-value fixed mode requires at least one key'];
         }
 
         $keys = [];
         foreach ($config['keys'] as $item) {
-            if (!is_array($item)) {
-                return ['success' => false, 'message' => 'Invalid key definition'];
-            }
-
-            $key = trim((string)($item['key'] ?? ''));
+            $key = $item['key'];
             if ($key === '') {
                 return ['success' => false, 'message' => 'Each key definition must include a non-empty key'];
             }
@@ -154,10 +148,9 @@ class KeyValueFieldService
      */
     public function normalizeMap(array $map, array $config): array
     {
-        $mode = ($config['mode'] ?? 'fixed') === 'free' ? 'free' : 'fixed';
         $schemaMap = $this->getSchemaMap($config);
 
-        if ($mode === 'fixed') {
+        if ($this->resolveMode($config) === 'fixed') {
             $normalized = [];
             foreach ($schemaMap as $key => $item) {
                 $normalized[$key] = $this->normalizeCellValue($map[$key] ?? '', $item['valueType'] ?? 'string');
@@ -187,13 +180,12 @@ class KeyValueFieldService
     public function validateMap(array $map, array $config): array
     {
         $errors = [];
-        $mode = ($config['mode'] ?? 'fixed') === 'free' ? 'free' : 'fixed';
+        $mode = $this->resolveMode($config);
         $schemaMap = $this->getSchemaMap($config);
 
         if ($mode === 'fixed') {
             foreach ($schemaMap as $key => $item) {
-                $required = (bool)($item['required'] ?? false);
-                if (!$required) {
+                if (!($item['required'] ?? false)) {
                     continue;
                 }
 
@@ -202,42 +194,21 @@ class KeyValueFieldService
                     $errors[] = "Key {$key} is required";
                 }
             }
+        }
 
-            foreach ($map as $key => $value) {
-                if (!isset($schemaMap[$key])) {
-                    $errors[] = "Key {$key} is not allowed";
-                    continue;
-                }
-
-                if (
-                    ($schemaMap[$key]['valueType'] ?? 'string') === 'number'
-                    && $value !== null
-                    && $value !== ''
-                    && !is_numeric($value)
-                ) {
-                    $errors[] = "Key {$key} must be numeric";
-                }
-            }
-        } else {
-            $seenKeys = [];
-            foreach (array_keys($map) as $key) {
-                if (in_array($key, $seenKeys, true)) {
-                    $errors[] = "Duplicate key: {$key}";
-                    continue;
-                }
-                $seenKeys[] = $key;
+        foreach ($map as $key => $value) {
+            if ($mode === 'fixed' && !isset($schemaMap[$key])) {
+                $errors[] = "Key {$key} is not allowed";
+                continue;
             }
 
-            foreach ($map as $key => $value) {
-                if (isset($schemaMap[$key]) && ($schemaMap[$key]['valueType'] ?? 'string') === 'number') {
-                    if ($value !== null && $value !== '' && !is_numeric($value)) {
-                        $errors[] = "Key {$key} must be numeric";
-                    }
-                }
+            $valueType = $schemaMap[$key]['valueType'] ?? 'string';
+            if ($valueType === 'number' && $this->isInvalidNumericValue($value)) {
+                $errors[] = "Key {$key} must be numeric";
             }
         }
 
-        return empty($errors) ? ['ok' => true] : ['ok' => false, 'errors' => $errors];
+        return $errors === [] ? ['ok' => true] : ['ok' => false, 'errors' => $errors];
     }
 
     /**
@@ -263,10 +234,6 @@ class KeyValueFieldService
      */
     public function getKeyValueFieldsForClass(string $modelClass): array
     {
-        if ($this->fieldsByClass === null) {
-            $this->fieldsByClass = [];
-        }
-
         if (isset($this->fieldsByClass[$modelClass])) {
             return $this->fieldsByClass[$modelClass];
         }
@@ -298,7 +265,7 @@ class KeyValueFieldService
     private function getSchemaMap(array $config): array
     {
         $schema = [];
-        foreach (($config['keys'] ?? []) as $item) {
+        foreach ($config['keys'] ?? [] as $item) {
             if (!is_array($item)) {
                 continue;
             }
@@ -315,6 +282,16 @@ class KeyValueFieldService
         }
 
         return $schema;
+    }
+
+    private function resolveMode(array $config): string
+    {
+        return ($config['mode'] ?? '') === 'free' ? 'free' : 'fixed';
+    }
+
+    private function isInvalidNumericValue(mixed $value): bool
+    {
+        return $value !== null && $value !== '' && !is_numeric($value);
     }
 
     private function normalizeCellValue(mixed $rawValue, string $valueType): mixed

--- a/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
+++ b/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace MiniShop3\Services\ExtraFields;
+
+use MiniShop3\Model\msExtraField;
+use MODX\Revolution\modX;
+
+class KeyValueFieldService
+{
+    public const XTYPE = 'ms3-key-value';
+
+    private modX $modx;
+
+    /** Request-scoped cache of key-value field configs keyed by model class. */
+    private ?array $fieldsByClass = null;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    public function isKeyValueXtype(?string $xtype): bool
+    {
+        return $xtype === self::XTYPE;
+    }
+
+    public function defaultConfig(): array
+    {
+        return [
+            'mode' => 'fixed',
+            'keys' => [],
+        ];
+    }
+
+    /**
+     * @param mixed $json JSON string or array
+     * @param string|null $fieldKey Extra field key for log context when config JSON is invalid
+     */
+    public function parseConfig(mixed $json, ?string $fieldKey = null): array
+    {
+        $config = $this->defaultConfig();
+
+        if (is_string($json) && $json !== '') {
+            $decoded = json_decode($json, true);
+            if (is_array($decoded)) {
+                $config = array_merge($config, $decoded);
+            } else {
+                $context = $fieldKey !== null && $fieldKey !== '' ? " for field \"{$fieldKey}\"" : '';
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    '[ms3-key-value] malformed key_value_config JSON' . $context . ': ' . json_last_error_msg()
+                );
+            }
+        } elseif (is_array($json)) {
+            $config = array_merge($config, $json);
+        }
+
+        if (($config['mode'] ?? '') !== 'free') {
+            $config['mode'] = 'fixed';
+        }
+
+        if (!is_array($config['keys'])) {
+            $config['keys'] = [];
+        }
+
+        $normalizedKeys = [];
+        foreach ($config['keys'] as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $normalizedKeys[] = [
+                'key' => trim((string)($item['key'] ?? '')),
+                'label' => trim((string)($item['label'] ?? '')),
+                'valueType' => ($item['valueType'] ?? 'string') === 'number' ? 'number' : 'string',
+                'required' => (bool)($item['required'] ?? false),
+            ];
+        }
+        $config['keys'] = $normalizedKeys;
+
+        return $config;
+    }
+
+    public function encodeConfig(array $config): string
+    {
+        return json_encode($config, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @return array{success: bool, message?: string, config?: array}
+     */
+    public function validateConfigSchema(mixed $json): array
+    {
+        $config = $this->parseConfig($json);
+
+        if (($config['mode'] ?? 'fixed') === 'fixed' && empty($config['keys'])) {
+            return ['success' => false, 'message' => 'Key-value fixed mode requires at least one key'];
+        }
+
+        $keys = [];
+        foreach ($config['keys'] as $item) {
+            if (!is_array($item)) {
+                return ['success' => false, 'message' => 'Invalid key definition'];
+            }
+
+            $key = trim((string)($item['key'] ?? ''));
+            if ($key === '') {
+                return ['success' => false, 'message' => 'Each key definition must include a non-empty key'];
+            }
+
+            if (in_array($key, $keys, true)) {
+                return ['success' => false, 'message' => "Duplicate key in schema: {$key}"];
+            }
+            $keys[] = $key;
+        }
+
+        return ['success' => true, 'config' => $config];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function decodeValue(mixed $value): array
+    {
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            if (!is_array($decoded) || array_is_list($decoded)) {
+                throw new \InvalidArgumentException('Key-value value must be a JSON object');
+            }
+
+            return $decoded;
+        }
+
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                throw new \InvalidArgumentException(
+                    'Key-value value must be an object map, list arrays are not allowed'
+                );
+            }
+
+            return $value;
+        }
+
+        throw new \InvalidArgumentException('Key-value value must be an object');
+    }
+
+    /**
+     * @param array<string, mixed> $map
+     * @return array<string, mixed>
+     */
+    public function normalizeMap(array $map, array $config): array
+    {
+        $mode = ($config['mode'] ?? 'fixed') === 'free' ? 'free' : 'fixed';
+        $schemaMap = $this->getSchemaMap($config);
+
+        if ($mode === 'fixed') {
+            $normalized = [];
+            foreach ($schemaMap as $key => $item) {
+                $normalized[$key] = $this->normalizeCellValue($map[$key] ?? '', $item['valueType'] ?? 'string');
+            }
+
+            return $normalized;
+        }
+
+        $normalized = [];
+        foreach ($map as $rawKey => $rawValue) {
+            $key = trim((string)$rawKey);
+            if ($key === '') {
+                continue;
+            }
+
+            $valueType = $schemaMap[$key]['valueType'] ?? 'string';
+            $normalized[$key] = $this->normalizeCellValue($rawValue, $valueType);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $map
+     * @return array{ok: bool, errors?: list<string>}
+     */
+    public function validateMap(array $map, array $config): array
+    {
+        $errors = [];
+        $mode = ($config['mode'] ?? 'fixed') === 'free' ? 'free' : 'fixed';
+        $schemaMap = $this->getSchemaMap($config);
+
+        if ($mode === 'fixed') {
+            foreach ($schemaMap as $key => $item) {
+                $required = (bool)($item['required'] ?? false);
+                if (!$required) {
+                    continue;
+                }
+
+                $value = $map[$key] ?? null;
+                if ($value === null || $value === '') {
+                    $errors[] = "Key {$key} is required";
+                }
+            }
+
+            foreach ($map as $key => $value) {
+                if (!isset($schemaMap[$key])) {
+                    $errors[] = "Key {$key} is not allowed";
+                    continue;
+                }
+
+                if (
+                    ($schemaMap[$key]['valueType'] ?? 'string') === 'number'
+                    && $value !== null
+                    && $value !== ''
+                    && !is_numeric($value)
+                ) {
+                    $errors[] = "Key {$key} must be numeric";
+                }
+            }
+        } else {
+            $seenKeys = [];
+            foreach (array_keys($map) as $key) {
+                if (in_array($key, $seenKeys, true)) {
+                    $errors[] = "Duplicate key: {$key}";
+                    continue;
+                }
+                $seenKeys[] = $key;
+            }
+
+            foreach ($map as $key => $value) {
+                if (isset($schemaMap[$key]) && ($schemaMap[$key]['valueType'] ?? 'string') === 'number') {
+                    if ($value !== null && $value !== '' && !is_numeric($value)) {
+                        $errors[] = "Key {$key} must be numeric";
+                    }
+                }
+            }
+        }
+
+        return empty($errors) ? ['ok' => true] : ['ok' => false, 'errors' => $errors];
+    }
+
+    /**
+     * Decode, validate and normalize key-value payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function processValue(mixed $value, array $config): array
+    {
+        $map = $this->decodeValue($value);
+        $normalized = $this->normalizeMap($map, $config);
+        $validation = $this->validateMap($normalized, $config);
+
+        if (!$validation['ok']) {
+            throw new \InvalidArgumentException(implode('; ', $validation['errors'] ?? []));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, array> field key => parsed config
+     */
+    public function getKeyValueFieldsForClass(string $modelClass): array
+    {
+        if ($this->fieldsByClass === null) {
+            $this->fieldsByClass = [];
+        }
+
+        if (isset($this->fieldsByClass[$modelClass])) {
+            return $this->fieldsByClass[$modelClass];
+        }
+
+        $map = [];
+        $query = $this->modx->newQuery(msExtraField::class);
+        $query->where([
+            'class' => $modelClass,
+            'xtype' => self::XTYPE,
+            'active' => true,
+        ]);
+
+        foreach ($this->modx->getIterator(msExtraField::class, $query) as $field) {
+            $key = (string)$field->get('key');
+            if ($key === '') {
+                continue;
+            }
+            $map[$key] = $this->parseConfig($field->get('key_value_config'), $key);
+        }
+
+        $this->fieldsByClass[$modelClass] = $map;
+
+        return $map;
+    }
+
+    /**
+     * @return array<string, array{key: string, label: string, valueType: string, required: bool}>
+     */
+    private function getSchemaMap(array $config): array
+    {
+        $schema = [];
+        foreach (($config['keys'] ?? []) as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $key = trim((string)($item['key'] ?? ''));
+            if ($key === '') {
+                continue;
+            }
+            $schema[$key] = [
+                'key' => $key,
+                'label' => trim((string)($item['label'] ?? '')),
+                'valueType' => ($item['valueType'] ?? 'string') === 'number' ? 'number' : 'string',
+                'required' => (bool)($item['required'] ?? false),
+            ];
+        }
+
+        return $schema;
+    }
+
+    private function normalizeCellValue(mixed $rawValue, string $valueType): mixed
+    {
+        if (is_string($rawValue)) {
+            $value = trim($rawValue);
+        } elseif (is_scalar($rawValue) || $rawValue === null) {
+            $value = trim((string)$rawValue);
+        } else {
+            $value = trim((string)json_encode($rawValue, JSON_UNESCAPED_UNICODE));
+        }
+
+        if ($valueType === 'number') {
+            return $this->castNumericValue($value);
+        }
+
+        return $value;
+    }
+
+    private function castNumericValue(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (!is_numeric($value)) {
+            return $value;
+        }
+
+        $stringValue = trim((string)$value);
+        if ($stringValue === '') {
+            return '';
+        }
+
+        return str_contains($stringValue, '.') ? (float)$stringValue : (int)$stringValue;
+    }
+}

--- a/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
+++ b/core/components/minishop3/src/Services/ExtraFields/KeyValueFieldService.php
@@ -81,7 +81,14 @@ class KeyValueFieldService
 
     public function encodeConfig(array $config): string
     {
-        return json_encode($config, JSON_UNESCAPED_UNICODE);
+        $encoded = json_encode($config, JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            throw new \InvalidArgumentException(
+                'Failed to encode key_value_config: ' . json_last_error_msg()
+            );
+        }
+
+        return $encoded;
     }
 
     /**
@@ -197,11 +204,6 @@ class KeyValueFieldService
         }
 
         foreach ($map as $key => $value) {
-            if ($mode === 'fixed' && !isset($schemaMap[$key])) {
-                $errors[] = "Key {$key} is not allowed";
-                continue;
-            }
-
             $valueType = $schemaMap[$key]['valueType'] ?? 'string';
             if ($valueType === 'number' && $this->isInvalidNumericValue($value)) {
                 $errors[] = "Key {$key} must be numeric";
@@ -212,7 +214,9 @@ class KeyValueFieldService
     }
 
     /**
-     * Decode, validate and normalize key-value payload.
+     * Decode, normalize, then validate key-value payload.
+     *
+     * Fixed mode strips unknown keys during normalize (strip-first contract).
      *
      * @return array<string, mixed>
      */
@@ -321,15 +325,16 @@ class KeyValueFieldService
             return $value;
         }
 
-        if (!is_numeric($value)) {
-            return $value;
-        }
-
         $stringValue = trim((string)$value);
         if ($stringValue === '') {
             return '';
         }
 
-        return str_contains($stringValue, '.') ? (float)$stringValue : (int)$stringValue;
+        $float = filter_var($stringValue, FILTER_VALIDATE_FLOAT);
+        if ($float === false) {
+            return $value;
+        }
+
+        return $float == (int)$float ? (int)$float : $float;
     }
 }

--- a/core/components/minishop3/src/Services/ExtraFieldsService.php
+++ b/core/components/minishop3/src/Services/ExtraFieldsService.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Services;
 
 use MiniShop3\Model\msExtraField;
 use MiniShop3\Model\msProductField;
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
 use MiniShop3\Services\ExtraFields\RepeaterFieldService;
 use MiniShop3\Utils\ExtraFields;
 use MODX\Revolution\modX;
@@ -33,6 +34,10 @@ class ExtraFieldsService
         $repeaterError = $this->applyRepeaterConstraints($data);
         if ($repeaterError !== null) {
             return $repeaterError;
+        }
+        $keyValueError = $this->applyKeyValueConstraints($data);
+        if ($keyValueError !== null) {
+            return $keyValueError;
         }
 
         $validation = $this->validateFieldData($data);
@@ -64,7 +69,10 @@ class ExtraFieldsService
         }
 
         @unlink($migrationFile);
-        $this->modx->log(modX::LOG_LEVEL_INFO, "[ExtraFieldsService] Migration file deleted: " . basename($migrationFile));
+        $this->modx->log(
+            modX::LOG_LEVEL_INFO,
+            "[ExtraFieldsService] Migration file deleted: " . basename($migrationFile)
+        );
 
         $this->extraFieldsUtil->loadMap();
         $this->extraFieldsUtil->clearCache();
@@ -109,7 +117,10 @@ class ExtraFieldsService
         }
 
         @unlink($migrationFile);
-        $this->modx->log(modX::LOG_LEVEL_INFO, "[ExtraFieldsService] Migration file deleted: " . basename($migrationFile));
+        $this->modx->log(
+            modX::LOG_LEVEL_INFO,
+            "[ExtraFieldsService] Migration file deleted: " . basename($migrationFile)
+        );
 
         // Only delete msProductField for product-related models
         if ($field->get('class') === 'MiniShop3\\Model\\msProductData') {
@@ -260,7 +271,6 @@ class ExtraFieldsService
                 'success' => true,
                 'output' => $outputText
             ];
-
         } catch (\Exception $e) {
             $this->modx->log(modX::LOG_LEVEL_ERROR, '[ExtraFieldsService] Migration error: ' . $e->getMessage());
 
@@ -285,11 +295,19 @@ class ExtraFieldsService
             $config = ['select_options' => $extraField->get('select_options')];
         } elseif ($extraField->get('xtype') === RepeaterFieldService::XTYPE && $extraField->get('repeater_config')) {
             $config = [
-                'repeater_config' => $this->getRepeaterFieldService()->parseConfig($extraField->get('repeater_config')),
+                'repeater_config' => $this->getRepeaterFieldService()->parseConfig(
+                    $extraField->get('repeater_config')
+                ),
+            ];
+        } elseif ($extraField->get('xtype') === KeyValueFieldService::XTYPE && $extraField->get('key_value_config')) {
+            $config = [
+                'key_value_config' => $this->getKeyValueFieldService()->parseConfig(
+                    $extraField->get('key_value_config')
+                ),
             ];
         }
 
-        $width = $extraField->get('xtype') === RepeaterFieldService::XTYPE ? 12 : 6;
+        $width = $this->isWideFieldXtype($extraField->get('xtype')) ? 12 : 6;
 
         $productField->fromArray([
             'name' => $extraField->get('key'),
@@ -307,11 +325,15 @@ class ExtraFieldsService
         ]);
 
         if ($productField->save()) {
-            $this->modx->log(modX::LOG_LEVEL_INFO,
-                "[ExtraFieldsService] Auto-created msProductField: {$extraField->get('key')}");
+            $this->modx->log(
+                modX::LOG_LEVEL_INFO,
+                "[ExtraFieldsService] Auto-created msProductField: {$extraField->get('key')}"
+            );
         } else {
-            $this->modx->log(modX::LOG_LEVEL_WARN,
-                "[ExtraFieldsService] Failed to auto-create msProductField: {$extraField->get('key')}");
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                "[ExtraFieldsService] Failed to auto-create msProductField: {$extraField->get('key')}"
+            );
         }
     }
 
@@ -339,14 +361,30 @@ class ExtraFieldsService
             }
             $data['repeater_config'] = $repeaterPayload['repeater_config'] ?? null;
         }
+        if (($data['xtype'] ?? $field->get('xtype')) === KeyValueFieldService::XTYPE) {
+            $keyValuePayload = array_merge($field->toArray(), $data);
+            $keyValueError = $this->applyKeyValueConstraints($keyValuePayload);
+            if ($keyValueError !== null) {
+                return $keyValueError;
+            }
+            $data['key_value_config'] = $keyValuePayload['key_value_config'] ?? null;
+        }
 
-        $allowedFields = ['label', 'description', 'xtype', 'active', 'select_options', 'repeater_config'];
+        $allowedFields = [
+            'label',
+            'description',
+            'xtype',
+            'active',
+            'select_options',
+            'repeater_config',
+            'key_value_config',
+        ];
 
         // Per-field null semantics:
         //   - `description`, `select_options` (optional text/json): null = clear
         //   - `label`, `xtype`, `active` (required for rendering): null skipped — a partial
         //     payload with `xtype: null` would silently break the field's UI.
-        $nullClearable = ['description', 'select_options'];
+        $nullClearable = ['description', 'select_options', 'repeater_config', 'key_value_config'];
 
         foreach ($allowedFields as $fieldName) {
             if (!array_key_exists($fieldName, $data)) {
@@ -363,6 +401,9 @@ class ExtraFieldsService
 
         if ($field->get('xtype') !== RepeaterFieldService::XTYPE) {
             $field->set('repeater_config', null);
+        }
+        if ($field->get('xtype') !== KeyValueFieldService::XTYPE) {
+            $field->set('key_value_config', null);
         }
 
         if (!$field->save()) {
@@ -403,27 +444,36 @@ class ExtraFieldsService
             $config = $productField->get('config') ?: [];
             if ($extraField->get('xtype') === 'ms3-combo-select') {
                 $config['select_options'] = $extraField->get('select_options') ?: '';
-                unset($config['repeater_config']);
+                unset($config['repeater_config'], $config['key_value_config']);
             } elseif ($extraField->get('xtype') === RepeaterFieldService::XTYPE) {
                 $config['repeater_config'] = $this->getRepeaterFieldService()->parseConfig(
                     $extraField->get('repeater_config')
                 );
-                unset($config['select_options']);
-            } else {
+                unset($config['select_options'], $config['key_value_config']);
+            } elseif ($extraField->get('xtype') === KeyValueFieldService::XTYPE) {
+                $config['key_value_config'] = $this->getKeyValueFieldService()->parseConfig(
+                    $extraField->get('key_value_config')
+                );
                 unset($config['select_options'], $config['repeater_config']);
+            } else {
+                unset($config['select_options'], $config['repeater_config'], $config['key_value_config']);
             }
 
-            if ($extraField->get('xtype') === RepeaterFieldService::XTYPE) {
+            if ($this->isWideFieldXtype($extraField->get('xtype'))) {
                 $productField->set('width', 12);
             }
             $productField->set('config', !empty($config) ? $config : null);
 
             if ($productField->save()) {
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[ExtraFieldsService] Updated msProductField: {$extraField->get('key')}");
+                $this->modx->log(
+                    modX::LOG_LEVEL_INFO,
+                    "[ExtraFieldsService] Updated msProductField: {$extraField->get('key')}"
+                );
             } else {
-                $this->modx->log(modX::LOG_LEVEL_WARN,
-                    "[ExtraFieldsService] Failed to update msProductField: {$extraField->get('key')}");
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    "[ExtraFieldsService] Failed to update msProductField: {$extraField->get('key')}"
+                );
             }
         }
     }
@@ -470,11 +520,52 @@ class ExtraFieldsService
         return null;
     }
 
+    /**
+     * @param array<string, mixed> $data
+     * @return array{success: false, message: string}|null
+     */
+    private function applyKeyValueConstraints(array &$data): ?array
+    {
+        if (($data['xtype'] ?? '') !== KeyValueFieldService::XTYPE) {
+            return null;
+        }
+
+        $data['dbtype'] = 'json';
+        $data['phptype'] = 'json';
+        $data['precision'] = '';
+        $data['null'] = true;
+
+        $configValidation = $this->getKeyValueFieldService()->validateConfigSchema($data['key_value_config'] ?? '');
+        if (!$configValidation['success']) {
+            return [
+                'success' => false,
+                'message' => $configValidation['message'] ?? 'Invalid key-value configuration',
+            ];
+        }
+
+        $data['key_value_config'] = $this->getKeyValueFieldService()->encodeConfig($configValidation['config']);
+
+        return null;
+    }
+
     private function getRepeaterFieldService(): RepeaterFieldService
     {
         /** @var RepeaterFieldService $service */
         $service = $this->modx->services->get('ms3_repeater_field');
 
         return $service;
+    }
+
+    private function getKeyValueFieldService(): KeyValueFieldService
+    {
+        /** @var KeyValueFieldService $service */
+        $service = $this->modx->services->get('ms3_key_value_field');
+
+        return $service;
+    }
+
+    private function isWideFieldXtype(?string $xtype): bool
+    {
+        return in_array($xtype, [RepeaterFieldService::XTYPE, KeyValueFieldService::XTYPE], true);
     }
 }

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Services\Product;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductOption;
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
 use MiniShop3\Services\ExtraFields\RepeaterFieldService;
 use MODX\Revolution\modX;
 
@@ -35,6 +36,7 @@ class ProductDataService
     protected $modx;
 
     protected ProductRepeaterSupport $repeaterSupport;
+    protected ProductKeyValueSupport $keyValueSupport;
     protected ProductCategoryMembershipWriter $categoryWriter;
     protected ProductOptionsWriter $optionsWriter;
     protected ProductLinksWriter $linksWriter;
@@ -45,6 +47,7 @@ class ProductDataService
     {
         $this->modx = $modx;
         $this->repeaterSupport = new ProductRepeaterSupport($modx);
+        $this->keyValueSupport = new ProductKeyValueSupport($modx);
         $this->categoryWriter = new ProductCategoryMembershipWriter($modx);
         $this->optionsWriter = new ProductOptionsWriter($modx);
         $this->linksWriter = new ProductLinksWriter($modx);
@@ -67,17 +70,38 @@ class ProductDataService
         return $this->repeaterSupport->getProductRepeaterFields();
     }
 
+    protected function getKeyValueFieldService(): KeyValueFieldService
+    {
+        return $this->keyValueSupport->getKeyValueFieldService();
+    }
+
     /**
-     * Prepare object before saving: array/repeater fields, source_id, numeric casts.
+     * Overridable hook for tests (see TestableProductDataService).
+     *
+     * @return array<string, array>
+     */
+    protected function getProductKeyValueFields(): array
+    {
+        return $this->keyValueSupport->getProductKeyValueFields();
+    }
+
+    /**
+     * Prepare object before saving: array/repeater/key-value fields, source_id, numeric casts.
      */
     public function prepareObject(msProductData $productData): void
     {
         $repeaterFields = $this->getProductRepeaterFields();
+        $keyValueFields = $this->getProductKeyValueFields();
         $repeaterService = $this->getRepeaterFieldService();
+        $keyValueService = $this->getKeyValueFieldService();
 
         foreach ($productData->getArraysValues() as $name => $array) {
             if (isset($repeaterFields[$name])) {
                 $productData->set($name, $repeaterService->processValue($array, $repeaterFields[$name]));
+                continue;
+            }
+            if (isset($keyValueFields[$name])) {
+                $productData->set($name, $keyValueService->processValue($array, $keyValueFields[$name]));
                 continue;
             }
 
@@ -122,11 +146,15 @@ class ProductDataService
      */
     public function saveOptions(msProductData $productData, ?array $options = null, bool $removeOther = true): void
     {
+        $excludedJsonKeys = array_merge(
+            array_keys($this->getProductRepeaterFields()),
+            array_keys($this->getProductKeyValueFields())
+        );
         $this->optionsWriter->saveOptions(
             $productData,
             $options,
             $removeOther,
-            array_keys($this->getProductRepeaterFields())
+            $excludedJsonKeys
         );
     }
 
@@ -287,13 +315,17 @@ class ProductDataService
             return ['ok' => false, 'code' => self::ERROR_NOT_FOUND, 'message' => 'Product data not found'];
         }
 
-        // Static whitelist + active repeater extra-field keys for msProductData.
-        // Without the extra keys, repeater values get silently dropped here and
+        // Static whitelist + active repeater/key-value extra-field keys for msProductData.
+        // Without the extra keys, values get silently dropped here and
         // prepareObject() then normalises the in-memory null/empty to [] on save —
         // user input is lost with no error (#301).
         $filtered = array_intersect_key(
             $data,
-            array_flip(array_merge(self::$allowedUpdateFields, array_keys($this->getProductRepeaterFields())))
+            array_flip(array_merge(
+                self::$allowedUpdateFields,
+                array_keys($this->getProductRepeaterFields()),
+                array_keys($this->getProductKeyValueFields())
+            ))
         );
         $resourceData = array_intersect_key($data, array_flip(self::$allowedResourceFields));
 
@@ -304,6 +336,10 @@ class ProductDataService
         $repeaterError = $this->normalizeRepeaterFieldsInPayload($filtered);
         if ($repeaterError !== null) {
             return ['ok' => false, 'code' => self::ERROR_VALIDATION, 'message' => $repeaterError];
+        }
+        $keyValueError = $this->normalizeKeyValueFieldsInPayload($filtered);
+        if ($keyValueError !== null) {
+            return ['ok' => false, 'code' => self::ERROR_VALIDATION, 'message' => $keyValueError];
         }
 
         $oldValues = [];
@@ -344,6 +380,19 @@ class ProductDataService
         return $this->repeaterSupport->normalizeRepeaterFieldsInPayload(
             $payload,
             $this->getProductRepeaterFields()
+        );
+    }
+
+    /**
+     * Validate and normalize key-value extra fields in manager API payload.
+     *
+     * @param array<string, mixed> $payload
+     */
+    protected function normalizeKeyValueFieldsInPayload(array &$payload): ?string
+    {
+        return $this->keyValueSupport->normalizeKeyValueFieldsInPayload(
+            $payload,
+            $this->getProductKeyValueFields()
         );
     }
 }

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -101,7 +101,20 @@ class ProductDataService
                 continue;
             }
             if (isset($keyValueFields[$name])) {
-                $productData->set($name, $keyValueService->processValue($array, $keyValueFields[$name]));
+                try {
+                    $normalized = $keyValueService->processValue($array, $keyValueFields[$name]);
+                    $productData->set($name, $normalized);
+                } catch (\InvalidArgumentException $e) {
+                    $this->modx->lexicon->load('minishop3:default');
+                    throw new \InvalidArgumentException(
+                        $this->modx->lexicon('ms3_key_value_validation_error', [
+                            'field' => $name,
+                            'error' => $e->getMessage(),
+                        ]),
+                        0,
+                        $e
+                    );
+                }
                 continue;
             }
 

--- a/core/components/minishop3/src/Services/Product/ProductKeyValueSupport.php
+++ b/core/components/minishop3/src/Services/Product/ProductKeyValueSupport.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
+use MODX\Revolution\modX;
+
+/**
+ * Key-value extra-field metadata and payload normalization for msProductData.
+ */
+class ProductKeyValueSupport
+{
+    protected modX $modx;
+
+    /** @var array<string, array>|null */
+    protected ?array $productKeyValueFields = null;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    public function getKeyValueFieldService(): KeyValueFieldService
+    {
+        /** @var KeyValueFieldService $service */
+        $service = $this->modx->services->get('ms3_key_value_field');
+
+        return $service;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getProductKeyValueFields(): array
+    {
+        return $this->productKeyValueFields ??= $this->getKeyValueFieldService()->getKeyValueFieldsForClass(
+            msProductData::class
+        );
+    }
+
+    /**
+     * Validate and normalize key-value extra fields in manager API payload.
+     *
+     * @param array<string, mixed> $payload
+     * @param array<string, array>|null $keyValueFields When null, loads from msProductData key-value config
+     */
+    public function normalizeKeyValueFieldsInPayload(array &$payload, ?array $keyValueFields = null): ?string
+    {
+        $keyValueFields ??= $this->getProductKeyValueFields();
+        if ($keyValueFields === []) {
+            return null;
+        }
+
+        $keyValueService = $this->getKeyValueFieldService();
+        $this->modx->lexicon->load('minishop3:default');
+
+        foreach ($keyValueFields as $fieldKey => $config) {
+            if (!array_key_exists($fieldKey, $payload)) {
+                continue;
+            }
+
+            try {
+                $payload[$fieldKey] = $keyValueService->processValue($payload[$fieldKey], $config);
+            } catch (\InvalidArgumentException $e) {
+                return $this->modx->lexicon('ms3_key_value_validation_error', [
+                    'field' => $fieldKey,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return null;
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
@@ -23,7 +23,7 @@ class ProductOptionsWriter
     }
 
     /**
-     * @param list<string> $repeaterKeys Repeater JSON field keys to exclude from option sync
+     * @param list<string> $repeaterKeys Repeater/key-value JSON field keys to exclude from option sync
      */
     public function saveOptions(
         msProductData $productData,
@@ -46,7 +46,7 @@ class ProductOptionsWriter
     }
 
     /**
-     * @param list<string> $repeaterKeys
+     * @param list<string> $repeaterKeys JSON keys excluded from option sync (repeaters, key-value)
      * @return array<string, mixed>
      */
     private function collectJsonFieldOptions(msProductData $productData, array $repeaterKeys): array

--- a/core/components/minishop3/tests/Integration/Product/UpdateProductDataPermissionsTest.php
+++ b/core/components/minishop3/tests/Integration/Product/UpdateProductDataPermissionsTest.php
@@ -122,6 +122,7 @@ final class UpdateProductDataPermissionsTest extends TestCase
 
         $service = new TestableProductDataService($modx);
         $service->repeaterFields = [];
+        $service->keyValueFields = [];
 
         return $service;
     }
@@ -148,9 +149,17 @@ final class TestableProductDataService extends ProductDataService
     /** @var array<string, array> */
     public array $repeaterFields = [];
 
+    /** @var array<string, array> */
+    public array $keyValueFields = [];
+
     protected function getProductRepeaterFields(): array
     {
         return $this->repeaterFields;
+    }
+
+    protected function getProductKeyValueFields(): array
+    {
+        return $this->keyValueFields;
     }
 }
 

--- a/core/components/minishop3/tests/KeyValueFieldServiceTest.php
+++ b/core/components/minishop3/tests/KeyValueFieldServiceTest.php
@@ -133,8 +133,9 @@ $assertTrue(($valid['ok'] ?? false) === true, 'validate nutrition map ok');
 $missingRequired = $service->validateMap(['calories' => '', 'protein' => null], $nutritionConfig);
 $assertTrue(($missingRequired['ok'] ?? true) === false, 'required key fails');
 
+// validateMap runs after normalizeMap; unknown keys are already stripped (strip-first).
 $unknownKey = $service->validateMap(['calories' => '1', 'weird' => 'x'], $nutritionConfig);
-$assertTrue(($unknownKey['ok'] ?? true) === false, 'unknown fixed key fails');
+$assertTrue(($unknownKey['ok'] ?? false) === true, 'validateMap ignores unknown keys after strip-first');
 
 $freeConfig = ['mode' => 'free', 'keys' => []];
 $freeNormalized = $service->normalizeMap(['' => 'skip', ' meta ' => ' value '], $freeConfig);
@@ -165,6 +166,18 @@ $assertSame(
     ),
     'processValue strips unknown keys in fixed mode'
 );
+
+$assertSame(
+    1000,
+    $service->processValue(
+        ['calories' => '1', 'protein' => '1e3'],
+        $nutritionConfig
+    )['protein'],
+    'processValue casts exponential numeric strings'
+);
+
+$encoded = $service->encodeConfig($nutritionConfig);
+$assertTrue(is_string($encoded) && $encoded !== '', 'encodeConfig returns JSON string');
 
 fwrite(STDOUT, "OK KeyValueFieldServiceTest\n");
 exit(0);

--- a/core/components/minishop3/tests/KeyValueFieldServiceTest.php
+++ b/core/components/minishop3/tests/KeyValueFieldServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Static checks for KeyValueFieldService decode/normalize/validate (without MODX).
+ *
+ * Run: php tests/KeyValueFieldServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
+
+if (!class_exists(\MODX\Revolution\modX::class, false)) {
+    eval(<<<'PHP'
+namespace MODX\Revolution {
+    class modX
+    {
+        public const LOG_LEVEL_WARN = 2;
+
+        public function log($level, $message): void
+        {
+        }
+    }
+}
+PHP);
+}
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertTrue = static function (bool $condition, string $case) use ($fail): void {
+    if (!$condition) {
+        $fail($case);
+    }
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertThrows = static function (callable $callback, string $needle, string $case) use ($fail): void {
+    try {
+        $callback();
+        $fail($case . ': expected exception');
+    } catch (\InvalidArgumentException $e) {
+        if (!str_contains($e->getMessage(), $needle)) {
+            $fail($case . ': unexpected message ' . $e->getMessage());
+        }
+    }
+};
+
+$service = new KeyValueFieldService(new \MODX\Revolution\modX());
+
+$assertTrue($service->isKeyValueXtype(KeyValueFieldService::XTYPE), 'xtype match');
+$assertTrue(!$service->isKeyValueXtype('ms3-repeater'), 'xtype mismatch');
+
+$defaults = $service->defaultConfig();
+$assertSame('fixed', $defaults['mode'], 'default mode is fixed');
+$assertSame([], $defaults['keys'], 'default keys empty');
+
+$parsed = $service->parseConfig(['mode' => 'free', 'keys' => [['key' => ' a ', 'valueType' => 'number', 'required' => 1]]]);
+$assertSame('free', $parsed['mode'], 'parse keeps free mode');
+$assertSame('a', $parsed['keys'][0]['key'], 'parse trims key');
+$assertSame('number', $parsed['keys'][0]['valueType'], 'parse valueType number');
+$assertTrue($parsed['keys'][0]['required'] === true, 'parse required bool');
+
+$fixedEmpty = $service->validateConfigSchema(['mode' => 'fixed', 'keys' => []]);
+$assertTrue($fixedEmpty['success'] === false, 'fixed mode requires keys');
+
+$fixedOk = $service->validateConfigSchema([
+    'mode' => 'fixed',
+    'keys' => [
+        ['key' => 'calories', 'label' => 'Calories', 'valueType' => 'string', 'required' => true],
+        ['key' => 'protein', 'label' => 'Protein', 'valueType' => 'number', 'required' => false],
+    ],
+]);
+$assertTrue($fixedOk['success'] === true, 'fixed schema valid');
+
+$dup = $service->validateConfigSchema([
+    'mode' => 'fixed',
+    'keys' => [
+        ['key' => 'calories'],
+        ['key' => 'calories'],
+    ],
+]);
+$assertTrue($dup['success'] === false, 'duplicate schema keys rejected');
+
+$assertSame(
+    ['calories' => '250', 'protein' => 12],
+    $service->decodeValue('{"calories":"250","protein":12}'),
+    'decode JSON object'
+);
+
+$assertThrows(
+    static fn () => $service->decodeValue('["a","b"]'),
+    'JSON object',
+    'decode rejects JSON list'
+);
+
+$assertThrows(
+    static fn () => $service->decodeValue(['a', 'b']),
+    'object map',
+    'decode rejects PHP list'
+);
+
+$nutritionConfig = [
+    'mode' => 'fixed',
+    'keys' => [
+        ['key' => 'calories', 'label' => 'Calories', 'valueType' => 'string', 'required' => true],
+        ['key' => 'protein', 'label' => 'Protein', 'valueType' => 'number', 'required' => false],
+    ],
+];
+
+$normalized = $service->normalizeMap(
+    ['calories' => ' 250 ', 'protein' => '12', 'extra' => 'drop-me'],
+    $nutritionConfig
+);
+$assertSame(
+    ['calories' => '250', 'protein' => 12],
+    $normalized,
+    'normalize fixed keeps schema keys only'
+);
+
+$valid = $service->validateMap($normalized, $nutritionConfig);
+$assertTrue(($valid['ok'] ?? false) === true, 'validate nutrition map ok');
+
+$missingRequired = $service->validateMap(['calories' => '', 'protein' => null], $nutritionConfig);
+$assertTrue(($missingRequired['ok'] ?? true) === false, 'required key fails');
+
+$unknownKey = $service->validateMap(['calories' => '1', 'weird' => 'x'], $nutritionConfig);
+$assertTrue(($unknownKey['ok'] ?? true) === false, 'unknown fixed key fails');
+
+$freeConfig = ['mode' => 'free', 'keys' => []];
+$freeNormalized = $service->normalizeMap(['' => 'skip', ' meta ' => ' value '], $freeConfig);
+$assertSame(['meta' => 'value'], $freeNormalized, 'normalize free trims and drops empty keys');
+
+$processed = $service->processValue(
+    ['calories' => '250', 'protein' => '8.5'],
+    $nutritionConfig
+);
+$assertSame(
+    ['calories' => '250', 'protein' => 8.5],
+    $processed,
+    'processValue end-to-end'
+);
+
+$assertThrows(
+    static fn () => $service->processValue(['protein' => 1], $nutritionConfig),
+    'required',
+    'processValue fails on missing required'
+);
+
+// Fixed mode strips unknown keys before validate; processValue must not reject them.
+$assertSame(
+    ['calories' => '1', 'protein' => ''],
+    $service->processValue(
+        ['calories' => '1', 'protein' => '', 'extra' => 'ignored'],
+        $nutritionConfig
+    ),
+    'processValue strips unknown keys in fixed mode'
+);
+
+fwrite(STDOUT, "OK KeyValueFieldServiceTest\n");
+exit(0);

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -205,6 +205,17 @@
       />
     </template>
 
+    <!-- Key-Value (ms3-key-value) -->
+    <template v-else-if="fieldConfig.xtype === 'ms3-key-value'">
+      <KeyValueField v-model="localValue" :config="keyValueConfig" :disabled="disabled" />
+      <!-- Hidden input bridges Vue state to legacy MODX Resource form POST (#298). -->
+      <input
+        type="hidden"
+        :name="fieldConfig.name"
+        :value="serializeKeyValueForPost(localValue)"
+      />
+    </template>
+
     <!-- Other ExtJS combo fields (ms3-combo-category, etc) -->
     <!-- For now, we display them as simple text info since editing happens in ExtJS form -->
     <div v-else-if="isExtJSComboField" class="extjs-combo-info">
@@ -245,9 +256,11 @@ import Textarea from 'primevue/textarea'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { computed, ref, watch } from 'vue'
 
+import { getKeyValueConfigFromField, parseKeyValueModelValue, serializeKeyValueForPost } from '../utils/keyValueField.js'
 import { getRepeaterConfigFromField, parseRepeaterModelValue } from '../utils/repeaterField.js'
 import AutocompleteCombo from './AutocompleteCombo.vue'
 import FileBrowser from './FileBrowser.vue'
+import KeyValueField from './KeyValueField.vue'
 import OptionsChips from './OptionsChips.vue'
 import RepeaterField from './RepeaterField.vue'
 import VendorCombo from './VendorCombo.vue'
@@ -318,7 +331,7 @@ const isFileBrowserXtype = computed(() => {
  * Determine if field is complex type (requires hidden field with JSON)
  */
 const isComplexField = computed(() => {
-  const complexTypes = ['combobox', 'datefield', 'colorpicker', 'chips', 'multiselect', 'ms3-repeater']
+  const complexTypes = ['combobox', 'datefield', 'colorpicker', 'chips', 'multiselect']
   return complexTypes.includes(props.fieldConfig.xtype)
 })
 
@@ -353,10 +366,14 @@ const selectOptions = computed(() => {
 })
 
 const repeaterConfig = computed(() => getRepeaterConfigFromField(props.fieldConfig))
+const keyValueConfig = computed(() => getKeyValueConfigFromField(props.fieldConfig))
 
 function normalizeIncomingValue(value) {
   if (props.fieldConfig.xtype === 'ms3-repeater') {
     return parseRepeaterModelValue(value)
+  }
+  if (props.fieldConfig.xtype === 'ms3-key-value') {
+    return parseKeyValueModelValue(value)
   }
   return value
 }

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -256,8 +256,9 @@ import Textarea from 'primevue/textarea'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { computed, ref, watch } from 'vue'
 
-import { getKeyValueConfigFromField, parseKeyValueModelValue, serializeKeyValueForPost } from '../utils/keyValueField.js'
-import { getRepeaterConfigFromField, parseRepeaterModelValue } from '../utils/repeaterField.js'
+import { getKeyValueConfigFromField, serializeKeyValueForPost } from '../utils/keyValueField.js'
+import { getRepeaterConfigFromField } from '../utils/repeaterField.js'
+import { parseStructuredExtraFieldValue } from '../utils/structuredExtraField.js'
 import AutocompleteCombo from './AutocompleteCombo.vue'
 import FileBrowser from './FileBrowser.vue'
 import KeyValueField from './KeyValueField.vue'
@@ -369,13 +370,7 @@ const repeaterConfig = computed(() => getRepeaterConfigFromField(props.fieldConf
 const keyValueConfig = computed(() => getKeyValueConfigFromField(props.fieldConfig))
 
 function normalizeIncomingValue(value) {
-  if (props.fieldConfig.xtype === 'ms3-repeater') {
-    return parseRepeaterModelValue(value)
-  }
-  if (props.fieldConfig.xtype === 'ms3-key-value') {
-    return parseKeyValueModelValue(value)
-  }
-  return value
+  return parseStructuredExtraFieldValue(props.fieldConfig.xtype, value)
 }
 
 /**

--- a/vueManager/src/components/ExtraFieldsManager.vue
+++ b/vueManager/src/components/ExtraFieldsManager.vue
@@ -19,10 +19,16 @@ import { computed, onMounted, ref, watch } from 'vue'
 
 import request from '../request.js'
 import {
+  defaultKeyValueConfig,
+  KEY_VALUE_XTYPE,
+  parseKeyValueConfig,
+} from '../utils/keyValueField.js'
+import {
   defaultRepeaterConfig,
   parseRepeaterConfig,
   REPEATER_XTYPE,
 } from '../utils/repeaterField.js'
+import KeyValueSchemaEditor from './KeyValueSchemaEditor.vue'
 import RepeaterSchemaEditor from './RepeaterSchemaEditor.vue'
 
 const toast = useToast()
@@ -58,6 +64,7 @@ const fieldForm = ref({
   active: true,
   select_options: '',
   repeater_config: defaultRepeaterConfig(),
+  key_value_config: defaultKeyValueConfig(),
 })
 
 /**
@@ -94,6 +101,7 @@ const xtypeOptions = computed(() => [
   { label: _('ms3_vue_xtype_xcheckbox'), value: 'xcheckbox' },
   { label: _('ms3_vue_xtype_combo_select'), value: 'ms3-combo-select' },
   { label: _('ms3_vue_xtype_repeater'), value: REPEATER_XTYPE },
+  { label: _('ms3_vue_xtype_key_value'), value: KEY_VALUE_XTYPE },
   { label: _('ms3_vue_xtype_combo_vendor'), value: 'ms3-combo-vendor' },
   { label: _('ms3_vue_xtype_combo_autocomplete'), value: 'ms3-combo-autocomplete' },
   { label: _('ms3_vue_xtype_combo_options'), value: 'ms3-combo-options' },
@@ -147,26 +155,37 @@ const indexTypeOptions = computed(() => [
 ])
 
 const isRepeaterField = computed(() => fieldForm.value.xtype === REPEATER_XTYPE)
+const isKeyValueField = computed(() => fieldForm.value.xtype === KEY_VALUE_XTYPE)
 
 watch(
   () => fieldForm.value.xtype,
   xtype => {
-    if (xtype !== REPEATER_XTYPE) {
-      return
-    }
-
-    fieldForm.value.dbtype = 'json'
-    fieldForm.value.phptype = 'json'
-    fieldForm.value.precision = ''
-    fieldForm.value.null = true
-    if (!fieldForm.value.repeater_config?.columns?.length) {
-      fieldForm.value.repeater_config = defaultRepeaterConfig()
+    if (xtype === REPEATER_XTYPE) {
+      fieldForm.value.dbtype = 'json'
+      fieldForm.value.phptype = 'json'
+      fieldForm.value.precision = ''
+      fieldForm.value.null = true
+      if (!fieldForm.value.repeater_config?.columns?.length) {
+        fieldForm.value.repeater_config = defaultRepeaterConfig()
+      }
+    } else if (xtype === KEY_VALUE_XTYPE) {
+      fieldForm.value.dbtype = 'json'
+      fieldForm.value.phptype = 'json'
+      fieldForm.value.precision = ''
+      fieldForm.value.null = true
+      if (!fieldForm.value.key_value_config?.mode) {
+        fieldForm.value.key_value_config = defaultKeyValueConfig()
+      }
     }
   }
 )
 
 function buildRepeaterConfigPayload() {
   return JSON.stringify(parseRepeaterConfig(fieldForm.value.repeater_config))
+}
+
+function buildKeyValueConfigPayload() {
+  return JSON.stringify(parseKeyValueConfig(fieldForm.value.key_value_config))
 }
 
 /**
@@ -223,6 +242,7 @@ function openCreateDialog() {
     active: true,
     select_options: '',
     repeater_config: defaultRepeaterConfig(),
+    key_value_config: defaultKeyValueConfig(),
   }
 
   dialogVisible.value = true
@@ -254,6 +274,7 @@ function openEditDialog(field) {
     active: field.active,
     select_options: field.select_options || '',
     repeater_config: parseRepeaterConfig(field.repeater_config),
+    key_value_config: parseKeyValueConfig(field.key_value_config),
   }
 
   dialogVisible.value = true
@@ -316,6 +337,7 @@ async function createField() {
         fieldForm.value.active === 'true' ||
         fieldForm.value.active === 1,
       repeater_config: isRepeaterField.value ? buildRepeaterConfigPayload() : '',
+      key_value_config: isKeyValueField.value ? buildKeyValueConfigPayload() : '',
     }
 
     delete payload.id
@@ -367,6 +389,7 @@ async function updateField() {
       select_options:
         fieldForm.value.xtype === 'ms3-combo-select' ? fieldForm.value.select_options : '',
       repeater_config: isRepeaterField.value ? buildRepeaterConfigPayload() : '',
+      key_value_config: isKeyValueField.value ? buildKeyValueConfigPayload() : '',
     }
 
     const response = await request.put(`/api/mgr/extra-fields/${fieldForm.value.id}`, payload)
@@ -720,6 +743,13 @@ onMounted(() => {
               <RepeaterSchemaEditor v-model="fieldForm.repeater_config" />
               <small class="text-500">{{ _('ms3_vue_repeater_schema_help') }}</small>
             </div>
+
+            <!-- Key-Value schema -->
+            <div v-if="isKeyValueField" class="field col-12">
+              <label>{{ _('ms3_vue_key_value_schema_label') }}</label>
+              <KeyValueSchemaEditor v-model="fieldForm.key_value_config" />
+              <small class="text-500">{{ _('ms3_vue_key_value_schema_help') }}</small>
+            </div>
           </div>
         </Fieldset>
 
@@ -737,7 +767,7 @@ onMounted(() => {
                 option-value="value"
                 :placeholder="_('ms3_vue_dialog_xtype_select')"
                 class="w-full"
-                :disabled="isEditMode || isRepeaterField"
+                :disabled="isEditMode || isRepeaterField || isKeyValueField"
               />
             </div>
 
@@ -764,7 +794,7 @@ onMounted(() => {
                 option-value="value"
                 :placeholder="_('ms3_vue_dialog_xtype_select')"
                 class="w-full"
-                :disabled="isEditMode || isRepeaterField"
+                :disabled="isEditMode || isRepeaterField || isKeyValueField"
               />
             </div>
 

--- a/vueManager/src/components/ExtraFieldsManager.vue
+++ b/vueManager/src/components/ExtraFieldsManager.vue
@@ -20,6 +20,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import request from '../request.js'
 import {
   defaultKeyValueConfig,
+  encodeKeyValueConfig,
   KEY_VALUE_XTYPE,
   parseKeyValueConfig,
 } from '../utils/keyValueField.js'
@@ -160,32 +161,26 @@ const isKeyValueField = computed(() => fieldForm.value.xtype === KEY_VALUE_XTYPE
 watch(
   () => fieldForm.value.xtype,
   xtype => {
-    if (xtype === REPEATER_XTYPE) {
-      fieldForm.value.dbtype = 'json'
-      fieldForm.value.phptype = 'json'
-      fieldForm.value.precision = ''
-      fieldForm.value.null = true
-      if (!fieldForm.value.repeater_config?.columns?.length) {
-        fieldForm.value.repeater_config = defaultRepeaterConfig()
-      }
-    } else if (xtype === KEY_VALUE_XTYPE) {
-      fieldForm.value.dbtype = 'json'
-      fieldForm.value.phptype = 'json'
-      fieldForm.value.precision = ''
-      fieldForm.value.null = true
-      if (!fieldForm.value.key_value_config?.mode) {
-        fieldForm.value.key_value_config = defaultKeyValueConfig()
-      }
+    if (xtype !== REPEATER_XTYPE && xtype !== KEY_VALUE_XTYPE) {
+      return
+    }
+
+    fieldForm.value.dbtype = 'json'
+    fieldForm.value.phptype = 'json'
+    fieldForm.value.precision = ''
+    fieldForm.value.null = true
+
+    if (xtype === REPEATER_XTYPE && !fieldForm.value.repeater_config?.columns?.length) {
+      fieldForm.value.repeater_config = defaultRepeaterConfig()
+    }
+    if (xtype === KEY_VALUE_XTYPE && !fieldForm.value.key_value_config?.mode) {
+      fieldForm.value.key_value_config = defaultKeyValueConfig()
     }
   }
 )
 
 function buildRepeaterConfigPayload() {
   return JSON.stringify(parseRepeaterConfig(fieldForm.value.repeater_config))
-}
-
-function buildKeyValueConfigPayload() {
-  return JSON.stringify(parseKeyValueConfig(fieldForm.value.key_value_config))
 }
 
 /**
@@ -337,7 +332,7 @@ async function createField() {
         fieldForm.value.active === 'true' ||
         fieldForm.value.active === 1,
       repeater_config: isRepeaterField.value ? buildRepeaterConfigPayload() : '',
-      key_value_config: isKeyValueField.value ? buildKeyValueConfigPayload() : '',
+      key_value_config: isKeyValueField.value ? encodeKeyValueConfig(fieldForm.value.key_value_config) : '',
     }
 
     delete payload.id
@@ -389,7 +384,7 @@ async function updateField() {
       select_options:
         fieldForm.value.xtype === 'ms3-combo-select' ? fieldForm.value.select_options : '',
       repeater_config: isRepeaterField.value ? buildRepeaterConfigPayload() : '',
-      key_value_config: isKeyValueField.value ? buildKeyValueConfigPayload() : '',
+      key_value_config: isKeyValueField.value ? encodeKeyValueConfig(fieldForm.value.key_value_config) : '',
     }
 
     const response = await request.put(`/api/mgr/extra-fields/${fieldForm.value.id}`, payload)
@@ -779,7 +774,7 @@ onMounted(() => {
                 v-model="fieldForm.precision"
                 :placeholder="_('ms3_vue_dialog_precision_placeholder')"
                 class="w-full"
-                :disabled="isEditMode || isRepeaterField"
+                :disabled="isEditMode || isRepeaterField || isKeyValueField"
               />
             </div>
 

--- a/vueManager/src/components/KeyValueField.vue
+++ b/vueManager/src/components/KeyValueField.vue
@@ -24,7 +24,34 @@ const { _ } = useLexicon()
 const schema = computed(() => parseKeyValueConfig(props.config))
 
 const internalMap = ref({})
+const freeModePairs = ref([])
 let isInternalEmit = false
+let nextFreePairId = 1
+
+function createFreePairId() {
+  nextFreePairId += 1
+  return `kv-${nextFreePairId}`
+}
+
+function mapToFreePairs(map) {
+  return Object.entries(map).map(([key, value]) => ({
+    key,
+    value: value ?? '',
+    _ms3Id: createFreePairId(),
+  }))
+}
+
+function freePairsToMap(pairs) {
+  const nextMap = {}
+  for (const pair of pairs) {
+    const key = (pair.key || '').trim()
+    if (key === '') {
+      continue
+    }
+    nextMap[key] = pair.value
+  }
+  return nextMap
+}
 
 watch(
   [() => props.modelValue, () => props.config],
@@ -34,85 +61,50 @@ watch(
       return
     }
 
-    internalMap.value = normalizeKeyValueMap(
+    const normalized = normalizeKeyValueMap(
       parseKeyValueModelValue(props.modelValue),
       schema.value
     )
+    internalMap.value = normalized
+
+    if (schema.value.mode === 'free') {
+      freeModePairs.value = mapToFreePairs(normalized)
+    }
   },
   { immediate: true, deep: true }
 )
 
-function emitMap() {
-  const normalized = normalizeKeyValueMap(internalMap.value, schema.value)
+function emitMap(map) {
+  const normalized = normalizeKeyValueMap(map, schema.value)
   isInternalEmit = true
+  internalMap.value = normalized
   emit('update:modelValue', normalized)
 }
 
-// For free mode: we need an array of pairs to work with UI
-const freeModePairs = ref([])
-
-watch(
-  internalMap,
-  (newMap) => {
-    if (schema.value.mode === 'free') {
-      const pairs = Object.entries(newMap).map(([key, value]) => ({
-        key,
-        value,
-        _ms3Id: Math.random().toString(36).substring(7)
-      }))
-      // Only update if keys/values actually changed to avoid cursor jumps
-      const currentKeys = freeModePairs.value.map(p => p.key).join('|')
-      const newKeys = pairs.map(p => p.key).join('|')
-      const currentValues = freeModePairs.value.map(p => p.value).join('|')
-      const newValues = pairs.map(p => p.value).join('|')
-      
-      if (currentKeys !== newKeys || currentValues !== newValues || (freeModePairs.value.length === 0 && pairs.length > 0)) {
-        freeModePairs.value = pairs
-      }
-    }
-  },
-  { immediate: true, deep: true }
-)
-
 function updateFixedValue(key, value) {
-  internalMap.value = { ...internalMap.value, [key]: value }
-  emitMap()
+  emitMap({ ...internalMap.value, [key]: value })
+}
+
+function emitFreeModeFromPairs() {
+  emitMap(freePairsToMap(freeModePairs.value))
 }
 
 function updateFreePair(index, patch) {
-  const pair = freeModePairs.value[index]
-  const updatedPair = { ...pair, ...patch }
-  freeModePairs.value[index] = updatedPair
-  
-  // Rebuild map from pairs
-  const nextMap = {}
-  freeModePairs.value.forEach(p => {
-    if (p.key) {
-      nextMap[p.key] = p.value
-    }
-  })
-  internalMap.value = nextMap
-  emitMap()
+  freeModePairs.value[index] = { ...freeModePairs.value[index], ...patch }
+  emitFreeModeFromPairs()
 }
 
 function addFreePair() {
   freeModePairs.value.push({
     key: '',
     value: '',
-    _ms3Id: Math.random().toString(36).substring(7)
+    _ms3Id: createFreePairId(),
   })
 }
 
 function removeFreePair(index) {
   freeModePairs.value.splice(index, 1)
-  const nextMap = {}
-  freeModePairs.value.forEach(p => {
-    if (p.key) {
-      nextMap[p.key] = p.value
-    }
-  })
-  internalMap.value = nextMap
-  emitMap()
+  emitFreeModeFromPairs()
 }
 </script>
 
@@ -159,7 +151,11 @@ function removeFreePair(index) {
       </div>
 
       <div class="ms3-key-value-rows">
-        <div v-for="(pair, index) in freeModePairs" :key="pair._ms3Id" class="ms3-key-value-row free-row">
+        <div
+          v-for="(pair, index) in freeModePairs"
+          :key="pair._ms3Id"
+          class="ms3-key-value-row free-row"
+        >
           <div class="ms3-key-value-key-cell">
             <InputText
               :model-value="pair.key"

--- a/vueManager/src/components/KeyValueField.vue
+++ b/vueManager/src/components/KeyValueField.vue
@@ -1,0 +1,263 @@
+<script setup>
+import { useLexicon } from '@vuetools/useLexicon'
+import Button from 'primevue/button'
+import InputNumber from 'primevue/inputnumber'
+import InputText from 'primevue/inputtext'
+import { computed, ref, watch } from 'vue'
+
+import {
+  defaultKeyValueConfig,
+  normalizeKeyValueMap,
+  parseKeyValueConfig,
+  parseKeyValueModelValue,
+} from '../utils/keyValueField.js'
+
+const props = defineProps({
+  modelValue: { type: [Object, String], default: () => ({}) },
+  config: { type: [Object, String], default: () => defaultKeyValueConfig() },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+const { _ } = useLexicon()
+
+const schema = computed(() => parseKeyValueConfig(props.config))
+
+const internalMap = ref({})
+let isInternalEmit = false
+
+watch(
+  [() => props.modelValue, () => props.config],
+  () => {
+    if (isInternalEmit) {
+      isInternalEmit = false
+      return
+    }
+
+    internalMap.value = normalizeKeyValueMap(
+      parseKeyValueModelValue(props.modelValue),
+      schema.value
+    )
+  },
+  { immediate: true, deep: true }
+)
+
+function emitMap() {
+  const normalized = normalizeKeyValueMap(internalMap.value, schema.value)
+  isInternalEmit = true
+  emit('update:modelValue', normalized)
+}
+
+// For free mode: we need an array of pairs to work with UI
+const freeModePairs = ref([])
+
+watch(
+  internalMap,
+  (newMap) => {
+    if (schema.value.mode === 'free') {
+      const pairs = Object.entries(newMap).map(([key, value]) => ({
+        key,
+        value,
+        _ms3Id: Math.random().toString(36).substring(7)
+      }))
+      // Only update if keys/values actually changed to avoid cursor jumps
+      const currentKeys = freeModePairs.value.map(p => p.key).join('|')
+      const newKeys = pairs.map(p => p.key).join('|')
+      const currentValues = freeModePairs.value.map(p => p.value).join('|')
+      const newValues = pairs.map(p => p.value).join('|')
+      
+      if (currentKeys !== newKeys || currentValues !== newValues || (freeModePairs.value.length === 0 && pairs.length > 0)) {
+        freeModePairs.value = pairs
+      }
+    }
+  },
+  { immediate: true, deep: true }
+)
+
+function updateFixedValue(key, value) {
+  internalMap.value = { ...internalMap.value, [key]: value }
+  emitMap()
+}
+
+function updateFreePair(index, patch) {
+  const pair = freeModePairs.value[index]
+  const updatedPair = { ...pair, ...patch }
+  freeModePairs.value[index] = updatedPair
+  
+  // Rebuild map from pairs
+  const nextMap = {}
+  freeModePairs.value.forEach(p => {
+    if (p.key) {
+      nextMap[p.key] = p.value
+    }
+  })
+  internalMap.value = nextMap
+  emitMap()
+}
+
+function addFreePair() {
+  freeModePairs.value.push({
+    key: '',
+    value: '',
+    _ms3Id: Math.random().toString(36).substring(7)
+  })
+}
+
+function removeFreePair(index) {
+  freeModePairs.value.splice(index, 1)
+  const nextMap = {}
+  freeModePairs.value.forEach(p => {
+    if (p.key) {
+      nextMap[p.key] = p.value
+    }
+  })
+  internalMap.value = nextMap
+  emitMap()
+}
+</script>
+
+<template>
+  <div class="ms3-key-value-field">
+    <!-- Fixed Mode -->
+    <div v-if="schema.mode === 'fixed'" class="ms3-key-value-fixed">
+      <div v-if="!schema.keys?.length" class="ms3-key-value-empty">
+        {{ _('ms3_vue_key_value_no_keys') }}
+      </div>
+      <div v-else class="ms3-key-value-rows">
+        <div v-for="keyDef in schema.keys" :key="keyDef.key" class="ms3-key-value-row fixed-row">
+          <label class="ms3-key-value-label-cell">
+            {{ keyDef.label || keyDef.key }}
+            <span v-if="keyDef.required" class="required-mark">*</span>
+          </label>
+          <div class="ms3-key-value-value-cell">
+            <InputNumber
+              v-if="keyDef.valueType === 'number'"
+              :model-value="internalMap[keyDef.key]"
+              class="w-full"
+              :disabled="disabled"
+              :use-grouping="false"
+              @update:model-value="updateFixedValue(keyDef.key, $event)"
+            />
+            <InputText
+              v-else
+              :model-value="internalMap[keyDef.key] ?? ''"
+              class="w-full"
+              :disabled="disabled"
+              @update:model-value="updateFixedValue(keyDef.key, $event)"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Free Mode -->
+    <div v-else class="ms3-key-value-free">
+      <div class="ms3-key-value-header">
+        <span class="ms3-key-value-header-cell">{{ _('ms3_vue_key_value_key') }}</span>
+        <span class="ms3-key-value-header-cell">{{ _('ms3_vue_key_value_value') }}</span>
+        <span class="ms3-key-value-actions-col" aria-hidden="true" />
+      </div>
+
+      <div class="ms3-key-value-rows">
+        <div v-for="(pair, index) in freeModePairs" :key="pair._ms3Id" class="ms3-key-value-row free-row">
+          <div class="ms3-key-value-key-cell">
+            <InputText
+              :model-value="pair.key"
+              class="w-full"
+              :disabled="disabled"
+              :placeholder="_('ms3_vue_key_value_key')"
+              @update:model-value="updateFreePair(index, { key: $event })"
+            />
+          </div>
+          <div class="ms3-key-value-value-cell">
+            <InputText
+              :model-value="pair.value"
+              class="w-full"
+              :disabled="disabled"
+              :placeholder="_('ms3_vue_key_value_value')"
+              @update:model-value="updateFreePair(index, { value: $event })"
+            />
+          </div>
+          <Button
+            icon="pi pi-times"
+            severity="danger"
+            text
+            rounded
+            size="small"
+            class="ms3-key-value-actions-col"
+            :disabled="disabled"
+            @click="removeFreePair(index)"
+          />
+        </div>
+      </div>
+
+      <Button
+        icon="pi pi-plus"
+        :label="_('ms3_vue_key_value_add_pair')"
+        severity="secondary"
+        size="small"
+        class="ms3-key-value-add"
+        :disabled="disabled"
+        @click="addFreePair"
+      />
+    </div>
+  </div>
+</template>
+
+<style>
+.vueApp .ms3-key-value-field {
+  width: 100%;
+  border: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  background: var(--p-content-background, #fff);
+}
+
+.vueApp .ms3-key-value-empty {
+  color: var(--p-text-muted-color, #6b7280);
+  font-size: 0.875rem;
+}
+
+.vueApp .ms3-key-value-header,
+.vueApp .ms3-key-value-row {
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.vueApp .ms3-key-value-row.fixed-row {
+  grid-template-columns: 10rem 1fr;
+  margin-bottom: 0.5rem;
+}
+
+.vueApp .ms3-key-value-header,
+.vueApp .ms3-key-value-row.free-row {
+  grid-template-columns: 1fr 1fr 2.5rem;
+}
+
+.vueApp .ms3-key-value-header {
+  margin-bottom: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.vueApp .ms3-key-value-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.vueApp .ms3-key-value-label-cell {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.vueApp .ms3-key-value-field .required-mark {
+  color: var(--p-red-500, #ef4444);
+}
+
+.vueApp .ms3-key-value-add {
+  margin-top: 0.75rem;
+}
+</style>

--- a/vueManager/src/components/KeyValueField.vue
+++ b/vueManager/src/components/KeyValueField.vue
@@ -3,6 +3,7 @@ import { useLexicon } from '@vuetools/useLexicon'
 import Button from 'primevue/button'
 import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 import { computed, ref, watch } from 'vue'
 
 import {
@@ -25,6 +26,7 @@ const schema = computed(() => parseKeyValueConfig(props.config))
 
 const internalMap = ref({})
 const freeModePairs = ref([])
+const freeModeDuplicateKey = ref('')
 let isInternalEmit = false
 let nextFreePairId = 1
 
@@ -43,14 +45,33 @@ function mapToFreePairs(map) {
 
 function freePairsToMap(pairs) {
   const nextMap = {}
+  const seen = new Set()
+  let duplicate = ''
+
   for (const pair of pairs) {
     const key = (pair.key || '').trim()
     if (key === '') {
       continue
     }
+    if (seen.has(key)) {
+      duplicate = key
+      continue
+    }
+    seen.add(key)
     nextMap[key] = pair.value
   }
+
+  freeModeDuplicateKey.value = duplicate
   return nextMap
+}
+
+function freePairValueType(key) {
+  const trimmed = (key || '').trim()
+  if (!trimmed) {
+    return 'string'
+  }
+  const keyDef = (schema.value.keys || []).find(item => item.key === trimmed)
+  return keyDef?.valueType === 'number' ? 'number' : 'string'
 }
 
 watch(
@@ -66,6 +87,7 @@ watch(
       schema.value
     )
     internalMap.value = normalized
+    freeModeDuplicateKey.value = ''
 
     if (schema.value.mode === 'free') {
       freeModePairs.value = mapToFreePairs(normalized)
@@ -144,6 +166,15 @@ function removeFreePair(index) {
 
     <!-- Free Mode -->
     <div v-else class="ms3-key-value-free">
+      <Message
+        v-if="freeModeDuplicateKey"
+        severity="warn"
+        class="ms3-key-value-duplicate"
+        :closable="false"
+      >
+        {{ _('ms3_vue_key_value_duplicate_key', { key: freeModeDuplicateKey }) }}
+      </Message>
+
       <div class="ms3-key-value-header">
         <span class="ms3-key-value-header-cell">{{ _('ms3_vue_key_value_key') }}</span>
         <span class="ms3-key-value-header-cell">{{ _('ms3_vue_key_value_value') }}</span>
@@ -166,7 +197,16 @@ function removeFreePair(index) {
             />
           </div>
           <div class="ms3-key-value-value-cell">
+            <InputNumber
+              v-if="freePairValueType(pair.key) === 'number'"
+              :model-value="pair.value === '' || pair.value == null ? null : Number(pair.value)"
+              class="w-full"
+              :disabled="disabled"
+              :use-grouping="false"
+              @update:model-value="updateFreePair(index, { value: $event })"
+            />
             <InputText
+              v-else
               :model-value="pair.value"
               class="w-full"
               :disabled="disabled"
@@ -212,6 +252,10 @@ function removeFreePair(index) {
 .vueApp .ms3-key-value-empty {
   color: var(--p-text-muted-color, #6b7280);
   font-size: 0.875rem;
+}
+
+.vueApp .ms3-key-value-duplicate {
+  margin-bottom: 0.75rem;
 }
 
 .vueApp .ms3-key-value-header,

--- a/vueManager/src/components/KeyValueSchemaEditor.vue
+++ b/vueManager/src/components/KeyValueSchemaEditor.vue
@@ -1,0 +1,179 @@
+<script setup>
+import { useLexicon } from '@vuetools/useLexicon'
+import Button from 'primevue/button'
+import Checkbox from 'primevue/checkbox'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+import { computed } from 'vue'
+
+import { defaultKeyValueConfig } from '../utils/keyValueField.js'
+
+const props = defineProps({
+  modelValue: { type: Object, default: () => defaultKeyValueConfig() },
+})
+
+const emit = defineEmits(['update:modelValue'])
+const { _ } = useLexicon()
+
+const config = computed({
+  get: () => ({ ...defaultKeyValueConfig(), ...props.modelValue }),
+  set: value => emit('update:modelValue', value),
+})
+
+const modeOptions = computed(() => [
+  { label: _('ms3_vue_key_value_mode_free'), value: 'free' },
+  { label: _('ms3_vue_key_value_mode_fixed'), value: 'fixed' },
+])
+
+const valueTypeOptions = computed(() => [
+  { label: _('ms3_vue_key_value_value_type_string'), value: 'string' },
+  { label: _('ms3_vue_key_value_value_type_number'), value: 'number' },
+])
+
+function updateConfig(patch) {
+  config.value = { ...config.value, ...patch }
+}
+
+function addKey() {
+  const keys = [...(config.value.keys || [])]
+  keys.push({
+    key: `key_${keys.length + 1}`,
+    label: '',
+    valueType: 'string',
+    required: false,
+  })
+  updateConfig({ keys })
+}
+
+function removeKey(index) {
+  const keys = [...(config.value.keys || [])]
+  keys.splice(index, 1)
+  updateConfig({ keys })
+}
+
+function updateKey(index, patch) {
+  const keys = (config.value.keys || []).map((keyDef, keyIndex) => {
+    if (keyIndex !== index) {
+      return keyDef
+    }
+    return { ...keyDef, ...patch }
+  })
+  updateConfig({ keys })
+}
+</script>
+
+<template>
+  <div class="key-value-schema-editor">
+    <div class="schema-toolbar">
+      <div class="field">
+        <label>{{ _('ms3_vue_key_value_mode') }}</label>
+        <Select
+          :model-value="config.mode"
+          :options="modeOptions"
+          option-label="label"
+          option-value="value"
+          class="w-full"
+          @update:model-value="updateConfig({ mode: $event })"
+        />
+      </div>
+    </div>
+
+    <template v-if="config.mode === 'fixed'">
+      <div class="keys-header">
+        <span>{{ _('ms3_vue_key_value_keys') }}</span>
+        <Button
+          icon="pi pi-plus"
+          :label="_('ms3_vue_key_value_add_key')"
+          size="small"
+          severity="secondary"
+          @click="addKey"
+        />
+      </div>
+
+      <div v-for="(keyDef, index) in config.keys" :key="index" class="key-row">
+        <InputText
+          :model-value="keyDef.key"
+          class="key-input"
+          :placeholder="_('ms3_vue_key_value_key')"
+          @update:model-value="updateKey(index, { key: $event })"
+        />
+        <InputText
+          :model-value="keyDef.label"
+          class="key-input"
+          :placeholder="_('ms3_vue_key_value_label')"
+          @update:model-value="updateKey(index, { label: $event })"
+        />
+        <Select
+          :model-value="keyDef.valueType || 'string'"
+          :options="valueTypeOptions"
+          option-label="label"
+          option-value="value"
+          class="key-input"
+          @update:model-value="updateKey(index, { valueType: $event })"
+        />
+        <div class="key-required">
+          <Checkbox
+            :model-value="!!keyDef.required"
+            :binary="true"
+            :input-id="`key-required-${index}`"
+            @update:model-value="updateKey(index, { required: $event })"
+          />
+          <label :for="`key-required-${index}`">{{ _('ms3_vue_key_value_required') }}</label>
+        </div>
+        <Button
+          icon="pi pi-times"
+          severity="danger"
+          text
+          rounded
+          size="small"
+          @click="removeKey(index)"
+        />
+      </div>
+      <div v-if="!config.keys?.length" class="text-500 text-sm mt-2">
+        {{ _('ms3_vue_key_value_no_keys') }}
+      </div>
+    </template>
+  </div>
+</template>
+
+<style>
+.vueApp .key-value-schema-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.vueApp .key-value-schema-editor .schema-toolbar {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+.vueApp .key-value-schema-editor .keys-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.vueApp .key-value-schema-editor .key-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 10rem auto 2.5rem;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.vueApp .key-value-schema-editor .key-required {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 48rem) {
+  .vueApp .key-value-schema-editor .key-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/vueManager/src/components/OrderView.vue
+++ b/vueManager/src/components/OrderView.vue
@@ -23,7 +23,7 @@ import { useOrderFieldHelpers } from '../composables/useOrderFieldHelpers.js'
 import { useOrderFormatters } from '../composables/useOrderFormatters.js'
 import request from '../request.js'
 import { normalizeOrderPluginTab } from '../utils/orderPluginTab.js'
-import { parseRepeaterModelValue, REPEATER_XTYPE } from '../utils/repeaterField.js'
+import { parseStructuredExtraFieldValue } from '../utils/structuredExtraField.js'
 import OrderAddressTab from './order/OrderAddressTab.vue'
 import OrderHistoryTab from './order/OrderHistoryTab.vue'
 import OrderInfoTab from './order/OrderInfoTab.vue'
@@ -248,17 +248,18 @@ function groupFieldsBySection(fields, sections) {
  * Load order data
  */
 /**
- * Parse repeater extra field values from API (string JSON → array).
+ * Parse structured JSON extra fields from API (string JSON → object/array).
  */
-function hydrateRepeaterExtraFields(fields) {
+function hydrateStructuredExtraFields(fields) {
   if (!order.value || !Array.isArray(fields)) {
     return
   }
 
   for (const field of fields) {
-    if (field.xtype === REPEATER_XTYPE && field.key) {
-      order.value[field.key] = parseRepeaterModelValue(order.value[field.key])
+    if (!field.key) {
+      continue
     }
+    order.value[field.key] = parseStructuredExtraFieldValue(field.xtype, order.value[field.key])
   }
 }
 
@@ -292,8 +293,8 @@ async function loadOrder() {
       loadOrderCustomer(),
     ])
 
-    hydrateRepeaterExtraFields(orderExtraFields.value)
-    hydrateRepeaterExtraFields(addressExtraFields.value)
+    hydrateStructuredExtraFields(orderExtraFields.value)
+    hydrateStructuredExtraFields(addressExtraFields.value)
   } catch (error) {
     console.error('[OrderView] Error loading order:', error)
     toast.add({

--- a/vueManager/src/components/ProductDataFields.vue
+++ b/vueManager/src/components/ProductDataFields.vue
@@ -7,7 +7,10 @@ import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 
 import request from '../request.js'
-import { parseRepeaterModelValue, REPEATER_XTYPE } from '../utils/repeaterField.js'
+import {
+  isFullWidthExtraFieldXtype,
+  parseStructuredExtraFieldValue,
+} from '../utils/structuredExtraField.js'
 import DynamicField from './DynamicField.vue'
 
 const props = defineProps({
@@ -107,8 +110,8 @@ async function loadConfig() {
             } else {
               value = parseInt(value) || 0
             }
-          } else if (field.xtype === REPEATER_XTYPE) {
-            value = parseRepeaterModelValue(value)
+          } else {
+            value = parseStructuredExtraFieldValue(field.xtype, value)
           }
 
           fieldValues.value[fieldName] = value
@@ -263,7 +266,9 @@ onMounted(() => {
                 :key="field.name"
                 :class="[
                   'field-item',
-                  field.xtype === REPEATER_XTYPE ? 'col-12' : `col-${field.width || 4}`,
+                  isFullWidthExtraFieldXtype(field.xtype)
+                    ? 'col-12'
+                    : `col-${field.width || 4}`,
                   { 'field-checkbox': field.xtype === 'xcheckbox' || field.xtype === 'checkbox' },
                 ]"
               >

--- a/vueManager/src/components/order/OrderExtraFieldsSection.vue
+++ b/vueManager/src/components/order/OrderExtraFieldsSection.vue
@@ -4,6 +4,7 @@ import Fieldset from 'primevue/fieldset'
 import { computed, inject } from 'vue'
 
 import { ORDER_CONTEXT_KEY } from '../../composables/orderContext.js'
+import { KEY_VALUE_XTYPE } from '../../utils/keyValueField.js'
 import { REPEATER_XTYPE } from '../../utils/repeaterField.js'
 import DynamicField from '../DynamicField.vue'
 
@@ -31,13 +32,15 @@ function getFieldConfig(field) {
     description: field.description || '',
     config: {
       repeater_config: field.repeater_config,
+      key_value_config: field.key_value_config,
     },
     repeater_config: field.repeater_config,
+    key_value_config: field.key_value_config,
   }
 }
 
 function getWidthClass(field) {
-  return field.xtype === REPEATER_XTYPE ? 'col-12' : 'col-6'
+  return [REPEATER_XTYPE, KEY_VALUE_XTYPE].includes(field.xtype) ? 'col-12' : 'col-6'
 }
 </script>
 

--- a/vueManager/src/components/order/OrderExtraFieldsSection.vue
+++ b/vueManager/src/components/order/OrderExtraFieldsSection.vue
@@ -4,8 +4,7 @@ import Fieldset from 'primevue/fieldset'
 import { computed, inject } from 'vue'
 
 import { ORDER_CONTEXT_KEY } from '../../composables/orderContext.js'
-import { KEY_VALUE_XTYPE } from '../../utils/keyValueField.js'
-import { REPEATER_XTYPE } from '../../utils/repeaterField.js'
+import { isFullWidthExtraFieldXtype } from '../../utils/structuredExtraField.js'
 import DynamicField from '../DynamicField.vue'
 
 const props = defineProps({
@@ -40,7 +39,7 @@ function getFieldConfig(field) {
 }
 
 function getWidthClass(field) {
-  return [REPEATER_XTYPE, KEY_VALUE_XTYPE].includes(field.xtype) ? 'col-12' : 'col-6'
+  return isFullWidthExtraFieldXtype(field.xtype) ? 'col-12' : 'col-6'
 }
 </script>
 

--- a/vueManager/src/utils/keyValueField.js
+++ b/vueManager/src/utils/keyValueField.js
@@ -2,21 +2,10 @@ export const KEY_VALUE_XTYPE = 'ms3-key-value'
 
 export function defaultKeyValueConfig() {
   return {
-    mode: 'free', // 'free' or 'fixed'
-    keys: [], // Array of { key: string, label: string, valueType: 'string'|'number', required: boolean }
+    mode: 'fixed',
+    keys: [],
   }
 }
-
-/**
- * Example fixed keys config (optional):
- * {
- *   mode: 'fixed',
- *   keys: [
- *     { key: 'width', label: 'Width', valueType: 'number', required: true },
- *     { key: 'color', label: 'Color', valueType: 'string', required: false }
- *   ]
- * }
- */
 
 export function parseKeyValueConfig(raw) {
   if (!raw) {
@@ -41,6 +30,7 @@ export function parseKeyValueConfig(raw) {
   return {
     ...defaults,
     ...parsed,
+    mode: parsed.mode === 'free' ? 'free' : 'fixed',
     keys: Array.isArray(parsed.keys) ? parsed.keys : defaults.keys,
   }
 }
@@ -52,7 +42,7 @@ export function parseKeyValueModelValue(value) {
   if (typeof value === 'string' && value.trim() !== '') {
     try {
       const parsed = JSON.parse(value)
-      return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {}
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
     } catch {
       return {}
     }
@@ -62,29 +52,33 @@ export function parseKeyValueModelValue(value) {
 
 export function normalizeKeyValueMap(map, config) {
   const schema = parseKeyValueConfig(config)
-  const normalized = {}
 
   if (schema.mode === 'fixed') {
+    const normalized = {}
     for (const keyDef of schema.keys) {
-      if (!keyDef.key) continue
+      if (!keyDef.key) {
+        continue
+      }
       const value = map?.[keyDef.key]
-      if (keyDef.valueType === 'number') {
-        normalized[keyDef.key] = (value === '' || value === null || value === undefined)
-          ? null
-          : Number(value)
-      } else {
-        normalized[keyDef.key] = value ?? ''
-      }
+      normalized[keyDef.key] = keyDef.valueType === 'number'
+        ? (value === '' || value == null ? null : Number(value))
+        : (value ?? '')
     }
-  } else {
-    // Free mode: just ensure it's a flat object of scalars
-    if (map && typeof map === 'object' && !Array.isArray(map)) {
-      for (const [k, v] of Object.entries(map)) {
-        normalized[k] = v
-      }
-    }
+    return normalized
   }
 
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    return {}
+  }
+
+  const normalized = {}
+  for (const [rawKey, value] of Object.entries(map)) {
+    const key = rawKey.trim()
+    if (key === '') {
+      continue
+    }
+    normalized[key] = value
+  }
   return normalized
 }
 
@@ -97,6 +91,10 @@ export function serializeKeyValueForPost(value) {
   } catch {
     return '{}'
   }
+}
+
+export function encodeKeyValueConfig(config) {
+  return JSON.stringify(parseKeyValueConfig(config))
 }
 
 export function getKeyValueConfigFromField(fieldConfig) {

--- a/vueManager/src/utils/keyValueField.js
+++ b/vueManager/src/utils/keyValueField.js
@@ -1,0 +1,111 @@
+export const KEY_VALUE_XTYPE = 'ms3-key-value'
+
+export function defaultKeyValueConfig() {
+  return {
+    mode: 'free', // 'free' or 'fixed'
+    keys: [], // Array of { key: string, label: string, valueType: 'string'|'number', required: boolean }
+  }
+}
+
+/**
+ * Example fixed keys config (optional):
+ * {
+ *   mode: 'fixed',
+ *   keys: [
+ *     { key: 'width', label: 'Width', valueType: 'number', required: true },
+ *     { key: 'color', label: 'Color', valueType: 'string', required: false }
+ *   ]
+ * }
+ */
+
+export function parseKeyValueConfig(raw) {
+  if (!raw) {
+    return defaultKeyValueConfig()
+  }
+
+  let parsed = raw
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return defaultKeyValueConfig()
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return defaultKeyValueConfig()
+  }
+
+  const defaults = defaultKeyValueConfig()
+
+  return {
+    ...defaults,
+    ...parsed,
+    keys: Array.isArray(parsed.keys) ? parsed.keys : defaults.keys,
+  }
+}
+
+export function parseKeyValueModelValue(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    try {
+      const parsed = JSON.parse(value)
+      return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+export function normalizeKeyValueMap(map, config) {
+  const schema = parseKeyValueConfig(config)
+  const normalized = {}
+
+  if (schema.mode === 'fixed') {
+    for (const keyDef of schema.keys) {
+      if (!keyDef.key) continue
+      const value = map?.[keyDef.key]
+      if (keyDef.valueType === 'number') {
+        normalized[keyDef.key] = (value === '' || value === null || value === undefined)
+          ? null
+          : Number(value)
+      } else {
+        normalized[keyDef.key] = value ?? ''
+      }
+    }
+  } else {
+    // Free mode: just ensure it's a flat object of scalars
+    if (map && typeof map === 'object' && !Array.isArray(map)) {
+      for (const [k, v] of Object.entries(map)) {
+        normalized[k] = v
+      }
+    }
+  }
+
+  return normalized
+}
+
+export function serializeKeyValueForPost(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return '{}'
+  }
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return '{}'
+  }
+}
+
+export function getKeyValueConfigFromField(fieldConfig) {
+  if (!fieldConfig) {
+    return defaultKeyValueConfig()
+  }
+  return parseKeyValueConfig(
+    fieldConfig.config?.key_value_config
+      ?? fieldConfig.key_value_config
+      ?? fieldConfig.config
+  )
+}

--- a/vueManager/src/utils/structuredExtraField.js
+++ b/vueManager/src/utils/structuredExtraField.js
@@ -1,0 +1,16 @@
+import { KEY_VALUE_XTYPE, parseKeyValueModelValue } from './keyValueField.js'
+import { parseRepeaterModelValue, REPEATER_XTYPE } from './repeaterField.js'
+
+const STRUCTURED_EXTRA_FIELD_PARSERS = {
+  [REPEATER_XTYPE]: parseRepeaterModelValue,
+  [KEY_VALUE_XTYPE]: parseKeyValueModelValue,
+}
+
+export function isFullWidthExtraFieldXtype(xtype) {
+  return Object.prototype.hasOwnProperty.call(STRUCTURED_EXTRA_FIELD_PARSERS, xtype)
+}
+
+export function parseStructuredExtraFieldValue(xtype, value) {
+  const parser = STRUCTURED_EXTRA_FIELD_PARSERS[xtype]
+  return parser ? parser(value) : value
+}


### PR DESCRIPTION
## Описание

Тип extra field `ms3-key-value`: плоский JSON-объект (ключ → значение) с конфигом в колонке `key_value_config`.

Режимы:

* **fixed** — ключи из схемы (label, string/number, required)
* **free** — произвольные пары в UI

Backend: `KeyValueFieldService` (decode → normalize → validate, strip-first для unknown keys), Phinx-миграция, `ServiceRegistry`, `ExtraFieldsService`, `ProductDataService` (whitelist, обход `prepareOptionValues`, lexicon-ошибки в `prepareObject`), нормализация extra fields в `OrdersController`.

Frontend: `KeyValueField`, `KeyValueSchemaEditor`, `structuredExtraField.js`, `DynamicField`, `ExtraFieldsManager`, `ProductDataFields`, `OrderView`, `OrderExtraFieldsSection`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #300

## Как это было протестировано?

- [x] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**

* MiniShop3: `feat/300-key-value-extra-field` от `beta`
* MODX: не запускался
* PHP: локальный CLI

**Проверки (exit 0):**

* `php -l` — `KeyValueFieldService.php`, миграция, `ExtraFieldsService.php`, `ProductDataService.php`, `OrdersController.php`, `ServiceRegistry.php`, `msExtraField.php`, `KeyValueFieldServiceTest.php`
* `php core/components/minishop3/tests/KeyValueFieldServiceTest.php` → `OK`
* `npx eslint` — `KeyValueField.vue`, `KeyValueSchemaEditor.vue`, `keyValueField.js`, `structuredExtraField.js`, `DynamicField.vue`, `ExtraFieldsManager.vue`, `ProductDataFields.vue`, `OrderView.vue`, `OrderExtraFieldsSection.vue`

PHPStan и полный прогон на MODX не выполнялись.

## Скриншоты (если применимо)

Не приложены. Визуальная проверка форм менеджера локально.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Паттерн как у `ms3-repeater` (#301). CHANGELOG / `docs/changelog.txt` не трогали — записи при релизе.

Доработки после review:

* default `mode: fixed` согласован PHP/JS
* hydration и `col-12` в product data / заказах
* free mode: стабильные id строк, warning при дубликате ключа, `InputNumber` для schema `number`
* `prepareObject` пробрасывает lexicon-ошибку валидации
* smoke-тест `KeyValueFieldServiceTest.php`
* `encodeConfig` / numeric cast (`1e3` → `1000`)

**Вне MVP #300:** PHP dispatcher для structured xtypes; валидация на Web checkout; CSV-импорт; клиентская валидация до save; docs.modx.pro; подключение smoke-теста к CI (в репо пока нет такого workflow).