### PR TITLE
fix(product): persist clearing color/size/tags on save

### DIFF
--- a/core/components/minishop3/src/Model/msProductData.php
+++ b/core/components/minishop3/src/Model/msProductData.php
@@ -139,17 +139,19 @@ class msProductData extends xPDOSimpleObject
      */
     public function prepareOptionValues($values = null)
     {
-        if ($values) {
-            if (!is_array($values)) {
-                $values = [$values];
-            }
-            $values = array_map('trim', $values);
-            $values = array_keys(array_flip($values));
-            $values = array_diff($values, ['']);
+        if ($values === null) {
+            return null;
+        }
 
-            if (empty($values)) {
-                $values = null;
-            }
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+        $values = array_map('trim', $values);
+        $values = array_keys(array_flip($values));
+        $values = array_diff($values, ['']);
+
+        if (empty($values)) {
+            $values = null;
         }
 
         return $values;

--- a/core/components/minishop3/src/Model/msProductData.php
+++ b/core/components/minishop3/src/Model/msProductData.php
@@ -133,7 +133,7 @@ class msProductData extends xPDOSimpleObject
     }
 
     /**
-     * @param null $values
+     * @param mixed $values Array, scalar (wrapped) or null. Empty result normalizes to null.
      *
      * @return array|null
      */

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -164,8 +164,9 @@ class ProductDataService
      * via msProductOption::saveProductOptions() method
      *
      * @param msProductData $productData
-     * @param array|null $options If null: built from non-empty JSON fields on $productData only. If array: explicit
-     *                           keys/values (e.g. manager POST options-*); then $removeOther is honored.
+     * @param array|null $options If null: built from JSON fields explicitly present in POST/_fields on
+     *                           $productData (including cleared empty values). If array: explicit keys/values
+     *                           (e.g. manager POST options-*); then $removeOther is honored.
      * @param bool $removeOther When $options is non-null: if true, delete msProductOption rows whose keys are absent
      *                         from $options. When $options is null: ignored — always treated as false so category-only
      *                         options not mirrored in JSON fields are preserved (#153, #158).
@@ -180,14 +181,24 @@ class ProductDataService
 
         if ($options === null) {
             $options = [];
-            foreach ($productData->_fieldMeta as $key => $value) {
-                if ($value['phptype'] === 'json' && !empty($productData->get($key))) {
-                    if (in_array($key, $repeaterKeys, true)) {
-                        continue;
-                    }
-                    // Use field name as key, not numeric index from array_merge
-                    $options[$key] = $productData->get($key);
+            $reflection = new \ReflectionClass($productData);
+            $property = $reflection->getProperty('_fields');
+            $property->setAccessible(true);
+            $rawFields = $property->getValue($productData);
+
+            foreach ($productData->_fieldMeta as $key => $meta) {
+                if (($meta['phptype'] ?? '') !== 'json') {
+                    continue;
                 }
+                if (in_array($key, $repeaterKeys, true)) {
+                    continue;
+                }
+                if (!array_key_exists($key, $rawFields)) {
+                    continue;
+                }
+
+                $fieldValue = $productData->get($key);
+                $options[$key] = !empty($fieldValue) ? $fieldValue : null;
             }
         }
 

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -163,6 +163,13 @@
           :value="val"
         />
       </template>
+      <!-- Empty array must still POST so ProductDataPayloadTrait clears the field (#324) -->
+      <input
+        v-else
+        type="hidden"
+        :name="`${fieldConfig.name}[]`"
+        value=""
+      />
     </template>
 
     <!-- Dropdown select (ms3-combo-select) -->


### PR DESCRIPTION
## Описание

Исправлена очистка стандартных JSON-полей товара (`color`, `size`, `tags`) на вкладке «Данные товара» в менеджере.

При удалении всех chips Vue-компонент `ms3-combo-options` не отправлял hidden inputs в legacy POST формы MODX. `ProductDataPayloadTrait` трактовал отсутствие ключа как «поле не меняли», и старое значение оставалось в `msProductData`.

Изменения:
- **`DynamicField.vue`**: sentinel hidden input `field[]=` при пустом массиве (по аналогии с repeater, #301).
- **`ProductDataService::saveOptions()`**: синхронизация явно очищенных JSON-полей в `msProductOption` через reflection на `_fields`.
- **`msProductData::prepareOptionValues()`**: нормализация пустого массива `[]` в `null`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #324

## Как это было протестировано?

- [x] Ручное тестирование (сценарий из issue: заполнить → сохранить → очистить → сохранить → reload)
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.12.0-beta1
- MODX: —
- PHP: `php -l` на изменённых файлах; `npm run lint` для `DynamicField.vue`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике репозитория добавляется при релизе

## Дополнительные заметки

После merge потребуется `npm run build` в `vueManager/` для обновления артефактов в `assets/components/minishop3/js/mgr/vue-dist/`.