### PR TITLE
chore(api): remove dead field-config override endpoints

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -73,10 +73,6 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->updatePageFields($params);
         });
-        $router->delete('/page-fields/{page_key}/{field_name}', function($params) use ($modx) {
-            $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
-            return $controller->deleteFieldOverride($params);
-        });
         $router->put('/sections/{page_key}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->updateSections($params);

--- a/core/components/minishop3/src/Controllers/Api/ConfigController.php
+++ b/core/components/minishop3/src/Controllers/Api/ConfigController.php
@@ -12,7 +12,7 @@ class ConfigController extends BaseApiController
 {
     /**
      * GET /api/mgr/config/page-fields/{page_key}
-     * Get page field configuration with applied overrides
+     * Get page field configuration from ms3_product_fields
      *
      * @param array $params
      * @return Response
@@ -40,7 +40,7 @@ class ConfigController extends BaseApiController
 
     /**
      * GET /api/mgr/config/page-fields/{page_key}/all
-     * Get ALL available fields (including hidden) from model with overrides
+     * Get all available fields (including hidden) from ms3_product_fields
      *
      * @param array $params
      * @return Response
@@ -68,7 +68,7 @@ class ConfigController extends BaseApiController
 
     /**
      * PUT /api/mgr/config/page-fields/{page_key}
-     * Save bulk field overrides
+     * Save field configuration to ms3_product_fields
      *
      * @param array $params
      * @return Response
@@ -91,54 +91,18 @@ class ConfigController extends BaseApiController
             /** @var \MiniShop3\Services\ConfigService */
             $configService = $this->modx->services->get('ms3_config_service');
 
-            $success = $configService->saveFieldsConfig($pageKey, $data['fields']);
+            $success = $configService->saveFieldsConfig($data['fields']);
 
             if ($success) {
                 return Response::success([
                     'message' => 'Configuration saved successfully',
                 ]);
-            } else{
-                return Response::error('Failed to save configuration', HttpStatus::INTERNAL_SERVER_ERROR);
             }
+
+            return Response::error('Failed to save configuration', HttpStatus::INTERNAL_SERVER_ERROR);
         } catch (\Exception $e) {
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
             return Response::error('Failed to save config: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    /**
-     * DELETE /api/mgr/config/page-fields/{page_key}/{field_name}
-     * Delete override for specific field
-     *
-     * @deprecated Table ms3_field_config_overrides removed. Endpoint kept for backward compatibility.
-     * @param array $params
-     * @return Response
-     */
-    public function deleteFieldOverride(array $params): Response
-    {
-        $pageKey = $params['page_key'] ?? '';
-        $fieldName = $params['field_name'] ?? '';
-
-        if (empty($pageKey) || empty($fieldName)) {
-            return Response::error('Page key and field name are required', HttpStatus::BAD_REQUEST);
-        }
-
-        try {
-            /** @var \MiniShop3\Services\ConfigService */
-            $configService = $this->modx->services->get('ms3_config_service');
-
-            $success = $configService->removeFieldOverride($pageKey, $fieldName);
-
-            if ($success) {
-                return Response::success([
-                    'message' => 'Override removed successfully',
-                ]);
-            } else {
-                return Response::error('Failed to remove override', HttpStatus::INTERNAL_SERVER_ERROR);
-            }
-        } catch (\Exception $e) {
-            $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ConfigController] ' . $e->getMessage());
-            return Response::error('Failed to remove override: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/core/components/minishop3/src/Services/ConfigService.php
+++ b/core/components/minishop3/src/Services/ConfigService.php
@@ -23,7 +23,7 @@ class ConfigService
     }
 
     /**
-     * Get page field configuration with applied overrides
+     * Get page field configuration from ms3_product_fields
      * Returns only VISIBLE fields and sections for display in form
      *
      * @param string $pageKey Page key (product_data, product_gallery, etc.)
@@ -129,12 +129,10 @@ class ConfigService
     /**
      * Save bulk field changes to ms3_product_fields table
      *
-     * @param string $pageKey Page key
      * @param array $fields Array of fields with settings
-     * @param string $contextKey Context key (default: web)
      * @return bool
      */
-    public function saveFieldsConfig(string $pageKey, array $fields, string $contextKey = 'web'): bool
+    public function saveFieldsConfig(array $fields): bool
     {
         try {
             foreach ($fields as $fieldData) {
@@ -215,24 +213,6 @@ class ConfigService
                 "[ConfigService] Error saving fields: " . $e->getMessage());
             return false;
         }
-    }
-
-    /**
-     * Remove field override
-     *
-     * @deprecated Table ms3_field_config_overrides removed. Use ms3_product_fields for field management
-     * @param string $pageKey Page key
-     * @param string $fieldName Field name
-     * @param string $contextKey Context key (default: web)
-     * @return bool
-     */
-    public function removeFieldOverride(string $pageKey, string $fieldName, string $contextKey = 'web'): bool
-    {
-        $this->modx->log(
-            modX::LOG_LEVEL_WARN,
-            'ConfigService::removeFieldOverride() is deprecated. Table ms3_field_config_overrides has been removed. Use ms3_product_fields instead.'
-        );
-        return true;
     }
 
     /**
@@ -355,20 +335,20 @@ class ConfigService
                 $hidden = isset($section['hidden']) ? (bool)$section['hidden'] : false;
                 $sortOrder = $index;
 
-                $override = $this->modx->getObject('MiniShop3\\Model\\msPageSection', [
+                $pageSection = $this->modx->getObject('MiniShop3\\Model\\msPageSection', [
                     'page_key' => $pageKey,
                     'section_key' => $sectionKey,
                 ]);
 
-                if (!$override) {
-                    $override = $this->modx->newObject('MiniShop3\\Model\\msPageSection');
-                    $override->set('page_key', $pageKey);
-                    $override->set('section_key', $sectionKey);
-                    $override->set('is_default', $isDefault);
+                if (!$pageSection) {
+                    $pageSection = $this->modx->newObject('MiniShop3\\Model\\msPageSection');
+                    $pageSection->set('page_key', $pageKey);
+                    $pageSection->set('section_key', $sectionKey);
+                    $pageSection->set('is_default', $isDefault);
                 }
 
-                $override->set('hidden', $hidden);
-                $override->set('sort_order', $sortOrder);
+                $pageSection->set('hidden', $hidden);
+                $pageSection->set('sort_order', $sortOrder);
 
                 // Build config from passed data
                 // Use array_key_exists() instead of isset() to handle null values correctly
@@ -381,11 +361,11 @@ class ConfigService
                 }
 
                 // Always update config field (even if empty, to clear old values)
-                $override->set('config', !empty($config) ? json_encode($config, JSON_UNESCAPED_UNICODE) : null);
+                $pageSection->set('config', !empty($config) ? json_encode($config, JSON_UNESCAPED_UNICODE) : null);
 
-                if (!$override->save()) {
+                if (!$pageSection->save()) {
                     $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR,
-                        "[ConfigService] Failed to save section override: {$sectionKey}");
+                        "[ConfigService] Failed to save section: {$sectionKey}");
                     return false;
                 }
             }

--- a/core/components/minishop3/src/Services/FieldConfigManager.php
+++ b/core/components/minishop3/src/Services/FieldConfigManager.php
@@ -308,24 +308,6 @@ class FieldConfigManager
     }
 
     /**
-     * Save field configuration to database
-     *
-     * @deprecated Table ms3_field_config_overrides removed. Use ConfigService::saveFieldsConfig() for ms3_product_fields
-     * @param string $pageKey
-     * @param array $fields
-     * @param string $contextKey
-     * @return bool
-     */
-    public function saveFieldsConfig(string $pageKey, array $fields, string $contextKey = 'web'): bool
-    {
-        $this->modx->log(
-            modX::LOG_LEVEL_WARN,
-            'FieldConfigManager::saveFieldsConfig() is deprecated'
-        );
-        return true;
-    }
-
-    /**
      * Get lexicon value with fallback logic
      *
      * Logic:

--- a/core/components/minishop3/tests/ConfigRoutePermissionsTest.php
+++ b/core/components/minishop3/tests/ConfigRoutePermissionsTest.php
@@ -60,7 +60,6 @@ $expected = [
     'GET /api/mgr/config/page-fields/{page_key}/all' => null,
     'GET /api/mgr/config/sections/{page_key}' => null,
     'PUT /api/mgr/config/page-fields/{page_key}' => 'mssetting_save',
-    'DELETE /api/mgr/config/page-fields/{page_key}/{field_name}' => 'mssetting_save',
     'PUT /api/mgr/config/sections/{page_key}' => 'mssetting_save',
     'DELETE /api/mgr/config/sections/{page_key}/{section_key}' => 'mssetting_save',
 ];
@@ -80,6 +79,11 @@ foreach ($registered as $route) {
 
 foreach ($expected as $routeKey => $permission) {
     $assertSame($permission, $actual[$routeKey] ?? null, "route {$routeKey}");
+}
+
+$removedFieldOverride = 'DELETE /api/mgr/config/page-fields/{page_key}/{field_name}';
+if (array_key_exists($removedFieldOverride, $actual)) {
+    $fail("route {$removedFieldOverride} should be absent after #347");
 }
 
 $unknown = array_diff(array_keys($actual), array_keys($expected));
@@ -107,7 +111,6 @@ $modx->setPermissions([]);
 $assertDenied($router, 'PUT', '/api/mgr/config/page-fields/order', 'PUT page-fields');
 $assertDenied($router, 'DELETE', '/api/mgr/config/sections/order/main', 'DELETE section');
 $assertDenied($router, 'PUT', '/api/mgr/config/sections/order', 'PUT sections');
-$assertDenied($router, 'DELETE', '/api/mgr/config/page-fields/order/title', 'DELETE field override');
 
 fwrite(STDOUT, "OK ConfigRoutePermissionsTest\n");
 exit(0);


### PR DESCRIPTION
## Описание

Удаляет deprecated override API после drop таблицы `ms3_field_config_overrides`: маршрут `DELETE /api/mgr/config/page-fields/{page_key}/{field_name}`, `ConfigController::deleteFieldOverride`, no-op `ConfigService::removeFieldOverride` и `FieldConfigManager::saveFieldsConfig`.

Актуальный путь сохранён: `PUT /api/mgr/config/page-fields/{page_key}` → `ConfigService::saveFieldsConfig(array $fields)` пишет в `ms3_product_fields`. Убраны неиспользуемые параметры `$pageKey`/`$contextKey` у save.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [x] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #347

## Как это было протестировано?

- [x] Ручное тестирование
- [ ] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

Grep: callers deprecated API = 0. Vue зовёт только GET/PUT page-fields. `php -l` на изменённых PHP.

**Конфигурация тестирования:**
- MiniShop3: ветка `chore/remove-dead-field-config-overrides-347`
- MODX: —
- PHP: локальный `php -l`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| — | — |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

`DELETE …/page-fields/{page_key}/{field_name}` больше нет (раньше был no-op success). Внешние клиенты получат 404 роутера. `OrderService::save/remove` @deprecated не трогали — отдельно, как в issue.