### PR TITLE
fix(import): read processor object in startImport

### DIFF
--- a/vueManager/src/components/ImportProducts.vue
+++ b/vueManager/src/components/ImportProducts.vue
@@ -187,33 +187,34 @@ const startImport = async () => {
       debug: debugMode.value,
     })
 
-    importId.value = response.import_id || ''
+    // Processor envelope: { success, message, object: { … } }
+    const data = response.object || response
+    importId.value = data.import_id || ''
 
-    if (response.scheduled) {
+    if (data.scheduled) {
       importResult.value = {
         success: true,
         message: _('ms3_import_scheduled_success'),
         scheduled: true,
       }
       importCompleted.value = true
-      importRunning.value = false
     } else if (!useScheduler.value) {
       importResult.value = {
         success: response.success !== false,
-        total: response.total || 0,
-        created: response.created || 0,
-        updated: response.updated || 0,
-        errors: response.errors || 0,
-        skipped: response.skipped || 0,
+        total: data.total || 0,
+        created: data.created || 0,
+        updated: data.updated || 0,
+        errors: data.errors || 0,
+        skipped: data.skipped || 0,
       }
       importCompleted.value = true
-      importRunning.value = false
     }
   } catch (err) {
     console.error('Import failed:', err)
     importResult.value = { success: false, message: err.message || _('ms3_import_error') }
-    importRunning.value = false
     importCompleted.value = true
+  } finally {
+    importRunning.value = false
   }
 }
 


### PR DESCRIPTION
## Описание

`startImport` читал `scheduled` / `total` с корня ответа connector, хотя процессор кладёт их в `object`. Из‑за этого при Scheduler `importRunning` зависал в `true`, а в sync-режиме счётчики были нулями.

Исправление: `const data = response.object || response` (как в `loadAvailableFields` / `previewFile` / upload) и `finally { importRunning = false }`. Флаг `success` берётся с корня envelope.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #370

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

ESLint: `vueManager/src/components/ImportProducts.vue`. Ручной прогон импорта (Scheduler / sync) в mgr не гонял в этой сессии.

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/370-import-start-response-object`
- MODX: —
- PHP: —

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| — | — |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Не #291. После merge стоит вручную: CSV → mapping → Start с Scheduler (ожидается сообщение «запланировано», ProgressBar гаснет) и sync без Scheduler (ненулевые счётчики из object).