### PR TITLE
fix(order): return error when status save fails

### DIFF
--- a/core/components/minishop3/src/Services/Order/OrderStatusService.php
+++ b/core/components/minishop3/src/Services/Order/OrderStatusService.php
@@ -146,25 +146,27 @@ class OrderStatusService
 
         $msOrder->set('status_id', $statusId);
 
-        if ($msOrder->save()) {
-            $this->orderLog->add($msOrder->get('id'), $statusId, 'status');
+        if (!$msOrder->save()) {
+            return $this->modx->lexicon('ms3_err_unknown');
+        }
 
-            $response = $this->ms3->utils->invokeEvent('msOnChangeOrderStatus', [
-                'msOrder' => $msOrder,
-                'old_status' => $oldStatus?->get('id'),
-                'status' => $statusId,
-            ]);
-            if (!$response['success']) {
-                return $response['message'];
-            }
+        $this->orderLog->add($msOrder->get('id'), $statusId, 'status');
 
-            // Send notifications via NotificationManager (unless skipped)
-            // Use output buffering to prevent any stray output from Fenom/pdoTools
-            if (!$skipNotifications) {
-                ob_start();
-                $this->sendNotifications($msOrder, $status, $oldStatus);
-                ob_end_clean();
-            }
+        $response = $this->ms3->utils->invokeEvent('msOnChangeOrderStatus', [
+            'msOrder' => $msOrder,
+            'old_status' => $oldStatus?->get('id'),
+            'status' => $statusId,
+        ]);
+        if (!$response['success']) {
+            return $response['message'];
+        }
+
+        // Send notifications via NotificationManager (unless skipped)
+        // Use output buffering to prevent any stray output from Fenom/pdoTools
+        if (!$skipNotifications) {
+            ob_start();
+            $this->sendNotifications($msOrder, $status, $oldStatus);
+            ob_end_clean();
         }
 
         return true;


### PR DESCRIPTION
## Описание

`OrderStatusService::change` при `msOrder::save() === false` больше не возвращает `true`. Callers (`OrderSubmitHandler`, finalize, mgr, customer cancel) получают `ms3_err_unknown` и не идут по success-path.

Логика выровнена early-return: лог/события/уведомления только после успешного save.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #376

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

`php -l` на `OrderStatusService.php`. Симуляцию fail save на живом MODX не гонял.

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/376-order-status-save-false`
- MODX: —
- PHP: локальный `php -l`

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| — | — |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Не #207. Атомарность submit (create event до status) — вне scope, как в issue. Callers уже проверяют `$result !== true`.