### PR TITLE
feat(order): EmptyOrder events and Order::set validation errors

### DIFF
--- a/core/components/minishop3/src/Controllers/Order/Order.php
+++ b/core/components/minishop3/src/Controllers/Order/Order.php
@@ -345,20 +345,32 @@ class Order
 
     /**
      * Set multiple order fields at once
+     *
+     * No batch msOn*SetOrder events in MS2/MS3: each field goes through add() and
+     * msOnBeforeAddToOrder / msOnAddToOrder (with returnedValues). This method only
+     * aggregates per-field failures for the API response.
      */
     public function set(array $order): array
     {
         $this->initDraft();
         $this->ensureOrderLoaded();
 
-        // TODO: Event before set
-        // TODO: Collect array of possible validation errors
+        $errors = [];
         foreach ($order as $key => $value) {
-            $this->add($key, $value);
+            $response = $this->add($key, $value);
+            if (!$response['success']) {
+                $errors[$key] = $response['message'];
+            }
         }
-        // TODO: Event on set
 
         $this->order = $this->draftManager->toArray($this->draft);
+
+        if (!empty($errors)) {
+            return $this->error('ms3_order_err_validation', [
+                'order' => $this->order,
+                'errors' => $errors,
+            ]);
+        }
 
         return $this->success('ms3_order_set_success', ['order' => $this->order]);
     }
@@ -399,7 +411,10 @@ class Order
             return $this->success('ms3_order_clean_success');
         }
 
-        $this->draftManager->clean($this->draft);
+        $result = $this->draftManager->clean($this->draft);
+        if ($result !== true) {
+            return $this->error($result !== '' ? $result : 'ms3_err_unknown');
+        }
 
         return $this->success('ms3_order_clean_success');
     }

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -102,7 +102,8 @@ class OrderDraftManager
         ];
         $msOrder->fromArray($data);
 
-        // TODO: Event before creating draft
+        // No draft-specific events in MS3 registry: msOrder::save() already fires
+        // msOnBeforeSaveOrder / msOnSaveOrder with MODE_NEW.
         $saved = $msOrder->save();
 
         if ($saved) {
@@ -113,7 +114,6 @@ class OrderDraftManager
                 'order_id' => $msOrder->get('id')
             ]);
             $msOrderAddress->save();
-            // TODO: Event after creating draft
         }
 
         return $msOrder;
@@ -200,10 +200,17 @@ class OrderDraftManager
 
     /**
      * Clean order data (reset all fields to null)
+     *
+     * @return true|string True on success, plugin error message otherwise
      */
-    public function clean(msOrder $draft): bool
+    public function clean(msOrder $draft): bool|string
     {
-        // TODO: Event before clean
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeEmptyOrder', [
+            'draft' => $draft,
+        ]);
+        if (!$response['success']) {
+            return $response['message'];
+        }
 
         // Clean address fields
         if ($draft->Address) {
@@ -227,7 +234,12 @@ class OrderDraftManager
         $draft->set('updatedon', time());
         $draft->save();
 
-        // TODO: event on clean
+        $response = $this->ms3->utils->invokeEvent('msOnEmptyOrder', [
+            'draft' => $draft,
+        ]);
+        if (!$response['success']) {
+            return $response['message'];
+        }
 
         return true;
     }

--- a/core/components/minishop3/tests/OrderDraftEventsTest.php
+++ b/core/components/minishop3/tests/OrderDraftEventsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Structural guards for draft EmptyOrder events and Order::set error aggregation (#343).
+ *
+ * Run: php tests/OrderDraftEventsTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$srcRoot = dirname(__DIR__) . '/src';
+$orderPath = $srcRoot . '/Controllers/Order/Order.php';
+$draftPath = $srcRoot . '/Services/Order/OrderDraftManager.php';
+$calculatorPath = $srcRoot . '/Services/Order/OrderCostCalculator.php';
+
+foreach (
+    [
+        $orderPath => 'Order.php',
+        $draftPath => 'OrderDraftManager.php',
+        $calculatorPath => 'OrderCostCalculator.php',
+    ] as $path => $label
+) {
+    if (!is_readable($path)) {
+        $fail("cannot read {$label}");
+    }
+}
+
+$orderSource = file_get_contents($orderPath);
+$draftSource = file_get_contents($draftPath);
+$calculatorSource = file_get_contents($calculatorPath);
+
+if ($orderSource === false || $draftSource === false || $calculatorSource === false) {
+    $fail('cannot read sources');
+}
+
+// Order::set aggregates per-field add() failures into ms3_order_err_validation + data.errors
+if (!preg_match(
+    '/function set\(array \$order\): array[\s\S]*?\$errors\s*=\s*\[[\s\S]*?\$this->add\(\$key,\s*\$value\)/',
+    $orderSource
+)) {
+    $fail('Order::set must collect per-field add() failures into $errors');
+}
+
+if (!preg_match(
+    '/function set\(array \$order\): array[\s\S]*?ms3_order_err_validation[\s\S]*?[\'"]errors[\'"]\s*=>\s*\$errors/',
+    $orderSource
+)) {
+    $fail('Order::set must return ms3_order_err_validation with data.errors');
+}
+
+// Order::clean propagates plugin refusal from draftManager->clean()
+if (!preg_match(
+    '/function clean\(\): array[\s\S]*?\$result\s*=\s*\$this->draftManager->clean\(\$this->draft\)[\s\S]*?\$result\s*!==\s*true/',
+    $orderSource
+)) {
+    $fail('Order::clean must surface draftManager->clean() plugin refusal');
+}
+
+// OrderDraftManager::clean fires EmptyOrder hooks and returns bool|string
+if (!str_contains($draftSource, "function clean(msOrder \$draft): bool|string")) {
+    $fail('OrderDraftManager::clean must return bool|string');
+}
+
+if (!str_contains($draftSource, "invokeEvent('msOnBeforeEmptyOrder'")) {
+    $fail('OrderDraftManager::clean must invoke msOnBeforeEmptyOrder');
+}
+
+if (!str_contains($draftSource, "invokeEvent('msOnEmptyOrder'")) {
+    $fail('OrderDraftManager::clean must invoke msOnEmptyOrder');
+}
+
+// GetOrderCost already lives on beta in OrderCostCalculator (not this PR's delta) —
+// keep a wiring guard so #343 AC for cost hooks stays green after EmptyOrder lands.
+if (!str_contains($calculatorSource, "invokeEvent('msOnBeforeGetOrderCost'")) {
+    $fail('OrderCostCalculator::getTotalCost must invoke msOnBeforeGetOrderCost');
+}
+
+if (!str_contains($calculatorSource, "invokeEvent('msOnGetOrderCost'")) {
+    $fail('OrderCostCalculator::getTotalCost must invoke msOnGetOrderCost');
+}
+
+if (!preg_match(
+    '/msOnGetOrderCost[\s\S]*?\$after\[\'data\'\]\[\'cost\'\][\s\S]*?\$after\[\'data\'\]\[\'cart_cost\'\][\s\S]*?\$after\[\'data\'\]\[\'delivery_cost\'\][\s\S]*?\$after\[\'data\'\]\[\'payment_cost\'\]/',
+    $calculatorSource
+)) {
+    $fail('msOnGetOrderCost must apply returnedValues for cost/cart/delivery/payment');
+}
+
+fwrite(STDOUT, "OK OrderDraftEventsTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Закрывает TODO по событиям очистки черновика и сюрфейсингу ошибок `Order::set` (без нового event bus).

* `OrderDraftManager::clean` — `msOnBeforeEmptyOrder` / `msOnEmptyOrder` (`draft`), отказ плагина уходит в API.
* `Order::set` — без batch-событий (их нет в реестре MS2/MS3); поля идут через `add()` и уже существующие `msOnBeforeAddToOrder` / `msOnAddToOrder`; ошибки валидации собираются в `data.errors`.
* Создание черновика — без отдельных CreateDraft: `msOrder::save()` уже шлёт `msOnBeforeSaveOrder` / `msOnSaveOrder` с `MODE_NEW`.
* `recalculate` — только запись агрегатов корзины; хуки стоимости на `getTotalCost`.

**GetOrderCost:** `msOnBeforeGetOrderCost` / `msOnGetOrderCost` уже заведены в `OrderCostCalculator::getTotalCost` на `beta` (с #403), поверх cart-only базы (#460/#448). Этот PR их не дублирует; smoke `OrderDraftEventsTest` держит wiring-guard.

### Пример плагина

```php
switch ($modx->event->name) {
    case 'msOnBeforeEmptyOrder':
        // $scriptProperties['draft'] — msOrder
        // $modx->event->output('Cannot clear checkout');
        break;
    case 'msOnGetOrderCost':
        $values = &$modx->event->returnedValues;
        $values['cost'] = (float) $scriptProperties['cost'] * 0.95;
        break;
}
```

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

`Order::set` при ошибке поля теперь может вернуть `success: false` и `data.errors` вместо безусловного success (раньше ошибки `add()` глотались). Storefront/Vue должны обрабатывать `success: false` от `order/set`.

## Связанные Issues

Closes #343

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0 — php -l + 41 smoke + 109 PHPUnit
```

`OrderDraftEventsTest.php`: set() errors, clean() EmptyOrder hooks, GetOrderCost wiring guard.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы — не требуется (`ms3_order_err_validation` уже есть)
- [ ] CHANGELOG — при релизе

## Дополнительные заметки

Связано с контрактом `returnedValues` (#219). Не трогает mgr OrdersController API. После неуспешного `msOnEmptyOrder` поля уже очищены — как в MS2.