### PR TITLE
fix(customer): reject expired API tokens instead of silent renew

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/AuthorizedCustomerTrait.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/AuthorizedCustomerTrait.php
@@ -3,6 +3,7 @@
 namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Services\TokenService;
 
 /**
  * Trait for Web API controllers that need to resolve the authorized customer.
@@ -26,19 +27,22 @@ trait AuthorizedCustomerTrait
 
         // Method 1: Try API token
         $tokenString = $_REQUEST['ms3_token'] ?? $_SESSION['ms3']['customer_token'] ?? '';
+        $tokenPresented = $tokenString !== '';
 
-        if (!empty($tokenString)) {
-            $tokenObj = $this->modx->getObject(\MiniShop3\Model\msCustomerToken::class, [
-                'token' => $tokenString,
-                'type' => \MiniShop3\Model\msCustomerToken::TYPE_API
-            ]);
+        if ($tokenPresented) {
+            /** @var TokenService $tokenService */
+            $tokenService = $this->modx->services->get('ms3_token_service');
+            $resolved = $tokenService->resolveApiToken($tokenString);
 
-            if ($tokenObj && !$tokenObj->isExpired()) {
-                $customer = $this->modx->getObject(msCustomer::class, $tokenObj->get('customer_id'));
+            if ($resolved['reason'] === 'ok') {
+                $customer = $this->modx->getObject(msCustomer::class, $resolved['token']->get('customer_id'));
                 if ($customer) {
                     return $customer;
                 }
             }
+
+            // Explicit token was rejected — do not fall back to session customer_id.
+            return null;
         }
 
         // Method 2: Fall back to session customer_id (consistent with TokenMiddleware)

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -76,34 +76,19 @@ class TokenMiddleware implements MiddlewareInterface
             session_start();
         }
 
-        // For non-public routes: check session first
-        if (!$isPublic && !empty($_SESSION['ms3']['customer_id'])) {
-            $customer = $this->modx->getObject(\MiniShop3\Model\msCustomer::class, $_SESSION['ms3']['customer_id']);
-            if ($customer) {
-                return null;
-            }
-        }
+        /** @var TokenService $tokenService */
+        $tokenService = $this->modx->services->get('ms3_token_service');
 
         // Resolve token from multiple sources
         $token = $this->resolveToken();
 
+        // If a token is present, always validate it (do not skip via session bypass).
         if (!empty($token)) {
-            // Validate token in DB
-            $tokenObj = $this->modx->getObject(\MiniShop3\Model\msCustomerToken::class, [
-                'token' => $token,
-                'type' => \MiniShop3\Model\msCustomerToken::TYPE_API
-            ]);
+            $resolved = $tokenService->resolveApiToken($token);
 
-            if ($tokenObj) {
-                // Auto-renew expired token
-                if ($tokenObj->isExpired()) {
-                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
-                    $newExpiresAt = date('Y-m-d H:i:s', time() + $ttl);
-                    $tokenObj->set('expires_at', $newExpiresAt);
-                    $tokenObj->save();
-                }
+            if ($resolved['reason'] === 'ok') {
+                $tokenObj = $resolved['token'];
 
-                // Save to session
                 if (!isset($_SESSION['ms3'])) {
                     $_SESSION['ms3'] = [];
                 }
@@ -111,30 +96,39 @@ class TokenMiddleware implements MiddlewareInterface
                 $_SESSION['ms3']['customer_id'] = $tokenObj->get('customer_id');
                 $_SESSION['ms3']['customer_token_expires'] = strtotime($tokenObj->get('expires_at'));
 
-                // Refresh cookie
                 CookieHelper::setTokenCookie($this->modx, $token);
-
-                // Ensure $_REQUEST has the token for controllers
                 $_REQUEST['ms3_token'] = $token;
 
                 return null;
             }
 
-            // Token found in request but not in DB — invalid
-            if (!$isPublic) {
+            $this->clearClientTokenState();
+
+            if ($resolved['reason'] === 'expired') {
+                if (!$isPublic) {
+                    $this->modx->log(
+                        modX::LOG_LEVEL_INFO,
+                        '[TokenMiddleware] Rejected expired API token: ' . substr($token, 0, 16) . '...'
+                    );
+                    return Response::error('ms3_err_token_expired', HttpStatus::UNAUTHORIZED);
+                }
+            } elseif (!$isPublic) {
                 $this->modx->log(
                     modX::LOG_LEVEL_ERROR,
-                    "[TokenMiddleware] Token not found in database. Token: " . substr($token, 0, 16) . "..."
+                    '[TokenMiddleware] Token not found in database. Token: ' . substr($token, 0, 16) . '...'
                 );
                 return Response::error('ms3_err_token_invalid', HttpStatus::UNAUTHORIZED);
+            }
+        } elseif (!$isPublic && !empty($_SESSION['ms3']['customer_id'])) {
+            // No token in request: allow existing session customer (browser session).
+            $customer = $this->modx->getObject(\MiniShop3\Model\msCustomer::class, $_SESSION['ms3']['customer_id']);
+            if ($customer) {
+                return null;
             }
         }
 
         // No valid token found
         if (!$isPublic) {
-            // Auto-create token for first visit
-            /** @var TokenService $tokenService */
-            $tokenService = $this->modx->services->get('ms3_token_service');
             $result = $tokenService->generateCustomerToken();
 
             if (!empty($result['token'])) {
@@ -146,6 +140,20 @@ class TokenMiddleware implements MiddlewareInterface
         }
 
         return null;
+    }
+
+    /**
+     * Clear cookie, request and session token identity after reject/expiry.
+     */
+    private function clearClientTokenState(): void
+    {
+        CookieHelper::clearTokenCookie($this->modx);
+        unset(
+            $_REQUEST['ms3_token'],
+            $_SESSION['ms3']['customer_token'],
+            $_SESSION['ms3']['customer_token_expires'],
+            $_SESSION['ms3']['customer_id']
+        );
     }
 
     /**

--- a/core/components/minishop3/src/Model/msCustomerToken.php
+++ b/core/components/minishop3/src/Model/msCustomerToken.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Model;
 
+use MiniShop3\Utils\ApiTokenExpiry;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOSimpleObject;
 
@@ -37,8 +38,7 @@ class msCustomerToken extends xPDOSimpleObject
      */
     public function isExpired()
     {
-        $expiresAt = strtotime($this->get('expires_at'));
-        return $expiresAt < time();
+        return ApiTokenExpiry::isExpiresAtBefore((string) $this->get('expires_at'), time());
     }
 
     /**

--- a/core/components/minishop3/src/Services/Customer/AuthManager.php
+++ b/core/components/minishop3/src/Services/Customer/AuthManager.php
@@ -217,8 +217,7 @@ class AuthManager
             return null;
         }
 
-        $expiresAt = strtotime($token->get('expires_at'));
-        if ($expiresAt < time()) {
+        if ($token->isExpired()) {
             $this->modx->log(
                 modX::LOG_LEVEL_DEBUG,
                 "[AuthManager] Token expired: {$tokenString}"

--- a/core/components/minishop3/src/Services/TokenService.php
+++ b/core/components/minishop3/src/Services/TokenService.php
@@ -104,6 +104,43 @@ class TokenService
     }
 
     /**
+     * Resolve an API token from the database.
+     *
+     * Expired tokens are removed (same policy as AuthManager::validateToken).
+     * Does not extend TTL and does not keep the same token string alive.
+     *
+     * @return array{token: ?msCustomerToken, reason: 'ok'|'missing'|'expired'}
+     */
+    public function resolveApiToken(string $tokenString): array
+    {
+        if ($tokenString === '') {
+            return ['token' => null, 'reason' => 'missing'];
+        }
+
+        /** @var msCustomerToken|null $tokenObj */
+        $tokenObj = $this->modx->getObject(msCustomerToken::class, [
+            'token' => $tokenString,
+            'type' => msCustomerToken::TYPE_API,
+        ]);
+
+        if (!$tokenObj) {
+            return ['token' => null, 'reason' => 'missing'];
+        }
+
+        if ($tokenObj->isExpired()) {
+            $this->modx->log(
+                modX::LOG_LEVEL_INFO,
+                '[TokenService] API token expired, removing. Token: ' . substr($tokenString, 0, 16) . '...'
+            );
+            $tokenObj->remove();
+
+            return ['token' => null, 'reason' => 'expired'];
+        }
+
+        return ['token' => $tokenObj, 'reason' => 'ok'];
+    }
+
+    /**
      * Resolve existing token or create new one
      *
      * Resolution chain:
@@ -111,34 +148,34 @@ class TokenService
      * 2. Cookie token → verify in DB (msCustomerToken type=api), restore session, return
      * 3. Generate new token → set cookie + session, return
      *
+     * Expired cookie tokens are discarded (not auto-renewed) and a new token is created.
+     *
      * @return string Token string
      */
     public function resolveOrCreateToken(): string
     {
-        // 1. Check session
+        // 1. Check session (re-validate against DB — do not trust session TTL alone)
         $sessionToken = $this->getCustomerToken();
         if ($sessionToken) {
-            CookieHelper::setTokenCookie($this->modx, $sessionToken);
-            return $sessionToken;
+            $resolved = $this->resolveApiToken($sessionToken);
+            if ($resolved['reason'] === 'ok') {
+                CookieHelper::setTokenCookie($this->modx, $sessionToken);
+                return $sessionToken;
+            }
+
+            $this->clearCustomerToken();
+            CookieHelper::clearTokenCookie($this->modx);
+            unset($_SESSION['ms3']['customer_id']);
         }
 
         // 2. Check cookie
         $cookieToken = CookieHelper::getTokenFromCookie();
         if (!empty($cookieToken)) {
-            $tokenObj = $this->modx->getObject(msCustomerToken::class, [
-                'token' => $cookieToken,
-                'type' => msCustomerToken::TYPE_API,
-            ]);
+            $resolved = $this->resolveApiToken($cookieToken);
 
-            if ($tokenObj) {
-                // Auto-renew expired token
-                if ($tokenObj->isExpired()) {
-                    $ttl = (int)$this->modx->getOption('ms3_customer_token_ttl', null, 604800);
-                    $tokenObj->set('expires_at', date('Y-m-d H:i:s', time() + $ttl));
-                    $tokenObj->save();
-                }
+            if ($resolved['reason'] === 'ok') {
+                $tokenObj = $resolved['token'];
 
-                // Restore session
                 if (!isset($_SESSION['ms3'])) {
                     $_SESSION['ms3'] = [];
                 }
@@ -150,10 +187,13 @@ class TokenService
                     $_SESSION['ms3']['customer_id'] = $customerId;
                 }
 
-                // Refresh cookie TTL
                 CookieHelper::setTokenCookie($this->modx, $cookieToken);
 
                 return $cookieToken;
+            }
+
+            if ($resolved['reason'] === 'expired' || $resolved['reason'] === 'missing') {
+                CookieHelper::clearTokenCookie($this->modx);
             }
         }
 

--- a/core/components/minishop3/src/Utils/ApiTokenExpiry.php
+++ b/core/components/minishop3/src/Utils/ApiTokenExpiry.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MiniShop3\Utils;
+
+/**
+ * Pure helpers for API token expiry checks (no MODX/xPDO).
+ */
+final class ApiTokenExpiry
+{
+    /**
+     * Whether expires_at is strictly before $timestamp.
+     *
+     * Invalid/unparseable dates are treated as expired.
+     */
+    public static function isExpiresAtBefore(string $expiresAt, int $timestamp): bool
+    {
+        $expires = strtotime($expiresAt);
+        if ($expires === false) {
+            return true;
+        }
+
+        return $expires < $timestamp;
+    }
+}

--- a/core/components/minishop3/tests/ApiTokenExpiryPolicyTest.php
+++ b/core/components/minishop3/tests/ApiTokenExpiryPolicyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Static checks for API token expiry policy (without MODX).
+ *
+ * Expired TYPE_API tokens must be rejected/removed — never silently extended
+ * while keeping the same token string (issue #371).
+ *
+ * Run: php tests/ApiTokenExpiryPolicyTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Utils\ApiTokenExpiry;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$now = 1_700_000_000;
+
+if (!ApiTokenExpiry::isExpiresAtBefore(date('Y-m-d H:i:s', $now - 1), $now)) {
+    $fail('past expires_at must be expired');
+}
+
+if (ApiTokenExpiry::isExpiresAtBefore(date('Y-m-d H:i:s', $now + 1), $now)) {
+    $fail('future expires_at must not be expired');
+}
+
+if (ApiTokenExpiry::isExpiresAtBefore(date('Y-m-d H:i:s', $now), $now)) {
+    $fail('expires_at equal to now must not be expired (strict <)');
+}
+
+if (!ApiTokenExpiry::isExpiresAtBefore('not-a-date', $now)) {
+    $fail('unparseable expires_at must be treated as expired');
+}
+
+$middleware = file_get_contents(dirname(__DIR__) . '/src/Middleware/TokenMiddleware.php');
+if ($middleware === false) {
+    $fail('cannot read TokenMiddleware.php');
+}
+if (str_contains($middleware, 'Auto-renew expired token')) {
+    $fail('TokenMiddleware must not auto-renew expired tokens');
+}
+if (!str_contains($middleware, 'ms3_err_token_expired')) {
+    $fail('TokenMiddleware must reject expired tokens with ms3_err_token_expired');
+}
+if (!str_contains($middleware, 'clearClientTokenState')) {
+    $fail('TokenMiddleware must clear full client token state on reject');
+}
+
+$tokenServiceSource = file_get_contents(dirname(__DIR__) . '/src/Services/TokenService.php');
+if ($tokenServiceSource === false) {
+    $fail('cannot read TokenService.php');
+}
+if (str_contains($tokenServiceSource, 'Auto-renew expired token')) {
+    $fail('TokenService must not auto-renew expired tokens');
+}
+if (!str_contains($tokenServiceSource, 'function resolveApiToken')) {
+    $fail('TokenService must expose resolveApiToken as the canonical expiry gate');
+}
+
+fwrite(STDOUT, "OK ApiTokenExpiryPolicyTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Истёкший `TYPE_API` токен больше не продлевается с тем же string. `TokenService::resolveApiToken()` удаляет запись (как `AuthManager::validateToken`), `TokenMiddleware` на protected routes отвечает `401` + `ms3_err_token_expired`, чистит cookie и session (`customer_id` тоже).

Без этого утечка Bearer/cookie давала бессрочный доступ. `/token/refresh` (#334) — отдельный баг; здесь только reject, не rotation.

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #371

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Middleware/TokenMiddleware.php
php -l src/Services/TokenService.php
php -l src/Utils/ApiTokenExpiry.php
php tests/ApiTokenExpiryPolicyTest.php
# остальные smoke:
for f in tests/*Test.php; do php "$f"; done
```

- [x] Ручное тестирование
- [x] Автоматические тесты (`ApiTokenExpiryPolicyTest` + existing smoke)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/371-expired-api-token-no-renew`
- MODX: не требуется для smoke
- PHP: 8.4 локально

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — ключ `ms3_err_token_expired` уже был
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Анонимная корзина с истёкшим token: первый protected-запрос → 401; cookie сброшен; следующий запрос без token получит новый anonymous token (корзина по старому ключу может стать недоступна — ожидаемо без working refresh).
- Session без token в запросе по-прежнему допускает `customer_id` в PHP session; если token есть (Bearer/cookie) — всегда валидируется в БД.
- Follow-up: живой `/token/refresh` (#334 / #351).