### PR TITLE
fix(vue-manager): clean vue-dist before Vite build

### DIFF
--- a/vueManager/package.json
+++ b/vueManager/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "rimraf ../assets/components/minishop3/js/mgr/vue-dist ../assets/components/minishop3/css/mgr/vue-dist",
+    "clean:vue-dist": "rimraf ../assets/components/minishop3/js/mgr/vue-dist ../assets/components/minishop3/css/mgr/vue-dist",
+    "prebuild": "npm run clean:vue-dist",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",

--- a/vueManager/vite.config.js
+++ b/vueManager/vite.config.js
@@ -5,11 +5,13 @@ import prefixSelector from 'postcss-prefix-selector'
 import { defineConfig } from 'vite'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
+// outDir is the repo root — never set emptyOutDir:true here.
+// Orphan hashed chunks are removed by `npm run clean:vue-dist` (prebuild).
 const output = {
   dir: '../',
   assetFileNames: 'assets/components/minishop3/css/mgr/vue-dist/[name].min[extname]', // css files
   chunkFileNames: 'assets/components/minishop3/js/mgr/vue-dist/[name]-[hash].min.js', // js chunks (hash avoids stale cache)
-  entryFileNames: 'assets/components/minishop3/js/mgr/vue-dist/[name].min.js', // main js file (entry point)
+  entryFileNames: 'assets/components/minishop3/js/mgr/vue-dist/[name].min.js', // fixed entry names for MODX
 }
 
 const DevInput = {
@@ -130,6 +132,9 @@ export default defineConfig(({ command }) => {
     // command === 'build'
     return {
       build: {
+        // Safe: outDir is '../' (repo root). Full wipe would delete the project.
+        // vue-dist dirs are cleaned by package.json prebuild → clean:vue-dist.
+        emptyOutDir: false,
         rollupOptions: {
           output,
           input: ProdInput,


### PR DESCRIPTION
## Описание

Перед `npm run build` полностью очищаются `js/mgr/vue-dist` и `css/mgr/vue-dist`. Старый `prebuild` удалял только `index*.min.js`, поэтому хешированные chunks (`FileBrowser-*`, `request-*`, `ActionsColumn-*`, …) копились.

`emptyOutDir: true` нельзя: `outDir` в Vite — корень репозитория (`../`). В конфиге явно `emptyOutDir: false` + комментарий. Vendor-сборка не трогалась.

`vue-dist` в `.gitignore` — в PR нет удаления артефактов из git, только скрипт очистки.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #340

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Gate E:**
- `cd vueManager && npm run lint` → exit 0
- `npm run build` ×2 → exit 0
- До: **132** JS-файла, **5.7M** (`js/mgr/vue-dist`)
- После clean+build: **52** JS-файла, **1.9M**; CSS **29** файлов, **920K**
- Второй build: те же счётчики (`stable=yes`)
- Entry smoke на диске: `orders`, `order`, `customers`, `deliveries`, `payments`, `vendors`, `statuses`, `links`, `options`, `category-products`, `help`, `main` → OK
- `ActionsColumn-*.min.js` копий: **1** (было десятки)

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-340-clean-vue-dist`
- MODX: n/a (build-only; browser smoke менеджера — на ревью)
- PHP: n/a

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [x] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Ручной smoke в менеджере (orders / products / settings) перед merge желателен — AC issue.
- `npm run clean:vue-dist` можно вызывать отдельно без сборки.