### PR TITLE
fix(manager-api): tighten ACL on customers and category products

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -22,7 +22,9 @@
  */
 
 use MiniShop3\Router\Middleware\AuthMiddleware;
+use MiniShop3\Router\Middleware\AnyPermissionMiddleware;
 use MiniShop3\Router\Middleware\PermissionMiddleware;
+use MiniShop3\Services\Category\CategoryProductActionPermissions;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 
@@ -291,13 +293,16 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'mssetting_save')
     ]);
 
+    // Customers: permissions align with legacy Customer* processors (#378)
     $router->group('/customers', function($router) use ($modx) {
         $router->get('', function($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->getList($allParams);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_list')
+        ]);
         // Bulk delete - must be before /{id} route
         $router->delete('/bulk', function($params) use ($modx) {
             $input = file_get_contents('php://input');
@@ -305,11 +310,15 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->bulkDelete($data);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_remove')
+        ]);
         $router->get('/{id}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->get($params);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_view')
+        ]);
 
         $router->put('/{id}', function($params) use ($modx) {
             $input = file_get_contents('php://input');
@@ -318,15 +327,21 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->update($data);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_save')
+        ]);
         $router->delete('/{id}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->delete($params);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_remove')
+        ]);
         $router->get('/{id}/addresses', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
             return $controller->getList($params);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_list')
+        ]);
         $router->post('/{id}/addresses', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
@@ -334,7 +349,9 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
             return $controller->create($data);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_save')
+        ]);
         $router->put('/{id}/addresses/{address_id}', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
@@ -343,19 +360,20 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
             return $controller->update($data);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_save')
+        ]);
         $router->delete('/{id}/addresses/{address_id}', function($params) use ($modx) {
             $params['address_id'] = $params['address_id'] ?? null;
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
             return $controller->delete($params);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msorder_remove')
+        ]);
+    });
 
-    }, [
-        new PermissionMiddleware($modx, 'view_document')
-    ]);
-
-    // Category products routes
+    // Category products: read vs mutate permissions (#378)
     $router->group('/categories', function($router) use ($modx) {
         // Get products in category
         $router->get('/{id}/products', function($params) use ($modx) {
@@ -363,12 +381,16 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->getList($allParams);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'view_document')
+        ]);
         // Get filters configuration
         $router->get('/{id}/products/filters', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->getFilters($params);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'view_document')
+        ]);
         // Sort products (drag-drop)
         $router->post('/{id}/products/sort', function($params) use ($modx) {
             $input = file_get_contents('php://input');
@@ -377,7 +399,9 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->sort($allParams);
-        });
+        }, [
+            new PermissionMiddleware($modx, 'msproduct_save')
+        ]);
         // Bulk delete products
         $router->delete('/{id}/products/bulk', function($params) use ($modx) {
             $input = file_get_contents('php://input');
@@ -386,8 +410,10 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->bulkDelete($allParams);
-        });
-        // Multiple product actions
+        }, [
+            new PermissionMiddleware($modx, 'msproduct_delete')
+        ]);
+        // Multiple product actions — gate any product mutation perm; exact check per method in controller
         $router->post('/{id}/products/multiple', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
@@ -395,7 +421,12 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->multiple($allParams);
-        });
+        }, [
+            new AnyPermissionMiddleware(
+                $modx,
+                CategoryProductActionPermissions::mutationPermissions()
+            )
+        ]);
         // Toggle product publish status
         $router->post('/{id}/products/{productId}/publish', function($params) use ($modx) {
             $input = file_get_contents('php://input');
@@ -404,11 +435,10 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->publish($allParams);
-        });
-
-    }, [
-        new PermissionMiddleware($modx, 'view_document')
-    ]);
+        }, [
+            new PermissionMiddleware($modx, 'msproduct_publish')
+        ]);
+    });
 
     $router->group('/deliveries', function($router) use ($modx) {
         $router->get('', function($params) use ($modx) {

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -6,6 +6,7 @@ use MiniShop3\Model\msCategory;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Category\CategoryProductActionPermissions;
 use MiniShop3\Services\Category\CategoryProductsListService;
 use MiniShop3\Services\FilterConfigManager;
 use MODX\Revolution\modX;
@@ -167,6 +168,20 @@ class CategoryProductsController
             return Response::error('Method is required', HttpStatus::BAD_REQUEST)->getData();
         }
 
+        $permission = CategoryProductActionPermissions::forMethod($method);
+        if ($permission === null) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                "[CategoryProductsController] Unknown method: {$method}"
+            );
+
+            return Response::error('Unknown method', HttpStatus::BAD_REQUEST)->getData();
+        }
+
+        if ($denied = $this->denyWithoutPermission($permission)) {
+            return $denied;
+        }
+
         if (empty($ids) || !is_array($ids)) {
             return Response::error('Product IDs array is required', HttpStatus::BAD_REQUEST)->getData();
         }
@@ -191,50 +206,14 @@ class CategoryProductsController
                 continue;
             }
 
-            $result = false;
-
-            switch ($method) {
-                case 'publish':
-                    $product->set('published', 1);
-                    $product->set('publishedon', time());
-                    $product->set('publishedby', $this->modx->user->get('id'));
-                    $result = $product->save();
-                    break;
-
-                case 'unpublish':
-                    $product->set('published', 0);
-                    $product->set('publishedon', 0);
-                    $product->set('publishedby', 0);
-                    $result = $product->save();
-                    break;
-
-                case 'delete':
-                    $product->set('deleted', 1);
-                    $product->set('deletedon', time());
-                    $product->set('deletedby', $this->modx->user->get('id'));
-                    $result = $product->save();
-                    break;
-
-                case 'undelete':
-                    $product->set('deleted', 0);
-                    $product->set('deletedon', 0);
-                    $product->set('deletedby', 0);
-                    $result = $product->save();
-                    break;
-
-                case 'show':
-                    $product->set('hidemenu', 0);
-                    $result = $product->save();
-                    break;
-
-                case 'hide':
-                    $product->set('hidemenu', 1);
-                    $result = $product->save();
-                    break;
-
-                default:
-                    $this->modx->log(modX::LOG_LEVEL_WARN, "[CategoryProductsController] Unknown method: {$method}");
-            }
+            $result = match ($method) {
+                'publish' => $this->applyPublish($product, true),
+                'unpublish' => $this->applyPublish($product, false),
+                'delete' => $this->applyDelete($product, true),
+                'undelete' => $this->applyDelete($product, false),
+                'show' => $this->applyHideMenu($product, false),
+                'hide' => $this->applyHideMenu($product, true),
+            };
 
             if ($result) {
                 $success++;
@@ -283,6 +262,10 @@ class CategoryProductsController
             return Response::error('Product ID is required', HttpStatus::BAD_REQUEST)->getData();
         }
 
+        if ($denied = $this->denyWithoutPermission('msproduct_publish')) {
+            return $denied;
+        }
+
         $product = $this->modx->getObject(msProduct::class, $productId);
 
         if (!$product) {
@@ -294,16 +277,7 @@ class CategoryProductsController
             $published = $product->get('published') ? 0 : 1;
         }
 
-        $product->set('published', $published);
-        if ($published) {
-            $product->set('publishedon', time());
-            $product->set('publishedby', $this->modx->user->get('id'));
-        } else {
-            $product->set('publishedon', 0);
-            $product->set('publishedby', 0);
-        }
-
-        if (!$product->save()) {
+        if (!$this->applyPublish($product, (bool) $published)) {
             return Response::error('Failed to update product', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
         }
 
@@ -311,6 +285,60 @@ class CategoryProductsController
             'id' => $productId,
             'published' => $published,
         ], $published ? 'Product published' : 'Product unpublished')->getData();
+    }
+
+    private function denyWithoutPermission(string $permission): ?array
+    {
+        if ($this->modx->hasPermission($permission)) {
+            return null;
+        }
+
+        $this->modx->log(
+            modX::LOG_LEVEL_WARN,
+            '[CategoryProductsController] Access denied for permission ' . $permission
+            . ' (user id ' . (int)($this->modx->user?->get('id') ?? 0) . ')'
+        );
+
+        return Response::error(
+            "Access denied. Required permission: {$permission}",
+            HttpStatus::FORBIDDEN
+        )->getData();
+    }
+
+    private function applyPublish(msProduct $product, bool $published): bool
+    {
+        return $this->setAuditedFlag($product, 'published', 'publishedon', 'publishedby', $published);
+    }
+
+    private function applyDelete(msProduct $product, bool $deleted): bool
+    {
+        return $this->setAuditedFlag($product, 'deleted', 'deletedon', 'deletedby', $deleted);
+    }
+
+    private function setAuditedFlag(
+        msProduct $product,
+        string $flag,
+        string $onField,
+        string $byField,
+        bool $enabled
+    ): bool {
+        $product->set($flag, $enabled ? 1 : 0);
+        if ($enabled) {
+            $product->set($onField, time());
+            $product->set($byField, $this->modx->user->get('id'));
+        } else {
+            $product->set($onField, 0);
+            $product->set($byField, 0);
+        }
+
+        return $product->save();
+    }
+
+    private function applyHideMenu(msProduct $product, bool $hidemenu): bool
+    {
+        $product->set('hidemenu', $hidemenu ? 1 : 0);
+
+        return $product->save();
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -183,7 +183,7 @@ class CategoryProductsController
                     modX::LOG_LEVEL_WARN,
                     '[CategoryProductsController] Access denied for permission '
                     . ($access['permission'] ?? '')
-                    . ' (user id ' . (int)($this->modx->user?->get('id') ?? 0) . ')'
+                    . ' (user id ' . (int)($this->modx->user->get('id') ?? 0) . ')'
                 );
             }
 
@@ -214,6 +214,8 @@ class CategoryProductsController
                 continue;
             }
 
+            // $method is already validated by CategoryProductActionPermissions::evaluate()
+            // above (unknown → 400 before this loop); default is defensive/unreachable.
             $result = match ($method) {
                 'publish' => $this->applyPublish($product, true),
                 'unpublish' => $this->applyPublish($product, false),
@@ -221,6 +223,7 @@ class CategoryProductsController
                 'undelete' => $this->applyDelete($product, false),
                 'show' => $this->applyHideMenu($product, false),
                 'hide' => $this->applyHideMenu($product, true),
+                default => false,
             };
 
             if ($result) {
@@ -304,7 +307,7 @@ class CategoryProductsController
         $this->modx->log(
             modX::LOG_LEVEL_WARN,
             '[CategoryProductsController] Access denied for permission ' . $permission
-            . ' (user id ' . (int)($this->modx->user?->get('id') ?? 0) . ')'
+            . ' (user id ' . (int)($this->modx->user->get('id') ?? 0) . ')'
         );
 
         return Response::error(

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -168,18 +168,26 @@ class CategoryProductsController
             return Response::error('Method is required', HttpStatus::BAD_REQUEST)->getData();
         }
 
-        $permission = CategoryProductActionPermissions::forMethod($method);
-        if ($permission === null) {
-            $this->modx->log(
-                modX::LOG_LEVEL_WARN,
-                "[CategoryProductsController] Unknown method: {$method}"
-            );
+        $access = CategoryProductActionPermissions::evaluate(
+            $method,
+            fn(string $permission): bool => $this->modx->hasPermission($permission)
+        );
+        if (!$access['allowed']) {
+            if ($access['reason'] === 'unknown_method') {
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    "[CategoryProductsController] Unknown method: {$method}"
+                );
+            } else {
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    '[CategoryProductsController] Access denied for permission '
+                    . ($access['permission'] ?? '')
+                    . ' (user id ' . (int)($this->modx->user?->get('id') ?? 0) . ')'
+                );
+            }
 
-            return Response::error('Unknown method', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if ($denied = $this->denyWithoutPermission($permission)) {
-            return $denied;
+            return Response::error($access['message'], $access['status'])->getData();
         }
 
         if (empty($ids) || !is_array($ids)) {

--- a/core/components/minishop3/src/Router/HttpStatus.php
+++ b/core/components/minishop3/src/Router/HttpStatus.php
@@ -15,6 +15,7 @@ final class HttpStatus
     public const CREATED = 201;
     public const BAD_REQUEST = 400;
     public const UNAUTHORIZED = 401;
+    public const FORBIDDEN = 403;
     public const NOT_FOUND = 404;
     public const METHOD_NOT_ALLOWED = 405;
     public const CONFLICT = 409;

--- a/core/components/minishop3/src/Router/Middleware/AnyPermissionMiddleware.php
+++ b/core/components/minishop3/src/Router/Middleware/AnyPermissionMiddleware.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MiniShop3\Router\Middleware;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MODX\Revolution\modX;
+
+/**
+ * Allow the request when the user has at least one of the listed permissions.
+ */
+class AnyPermissionMiddleware implements MiddlewareInterface
+{
+    protected modX $modx;
+
+    /** @var list<string> */
+    protected array $permissions;
+
+    /**
+     * @param list<string> $permissions
+     */
+    public function __construct(modX $modx, array $permissions)
+    {
+        $this->modx = $modx;
+        $this->permissions = array_values(array_filter($permissions, static fn($p) => is_string($p) && $p !== ''));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(array $params)
+    {
+        foreach ($this->permissions as $permission) {
+            if ($this->modx->hasPermission($permission)) {
+                return null;
+            }
+        }
+
+        $required = $this->permissions !== []
+            ? implode(' or ', $this->permissions)
+            : '(none configured)';
+
+        return Response::error(
+            "Access denied. Required permission: {$required}",
+            HttpStatus::FORBIDDEN
+        );
+    }
+}

--- a/core/components/minishop3/src/Router/Middleware/AnyPermissionMiddleware.php
+++ b/core/components/minishop3/src/Router/Middleware/AnyPermissionMiddleware.php
@@ -22,7 +22,7 @@ class AnyPermissionMiddleware implements MiddlewareInterface
     public function __construct(modX $modx, array $permissions)
     {
         $this->modx = $modx;
-        $this->permissions = array_values(array_filter($permissions, static fn($p) => is_string($p) && $p !== ''));
+        $this->permissions = array_values(array_filter($permissions, static fn(string $p): bool => $p !== ''));
     }
 
     /**

--- a/core/components/minishop3/src/Router/Middleware/PermissionMiddleware.php
+++ b/core/components/minishop3/src/Router/Middleware/PermissionMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Router\Middleware;
 
+use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MODX\Revolution\modX;
 
@@ -31,7 +32,7 @@ class PermissionMiddleware implements MiddlewareInterface
         if (!$this->modx->hasPermission($this->permission)) {
             return Response::error(
                 "Access denied. Required permission: {$this->permission}",
-                403
+                HttpStatus::FORBIDDEN
             );
         }
 

--- a/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MiniShop3\Services\Category;
+
+/** Maps category product bulk/multiple actions to MODX permissions (#378). */
+final class CategoryProductActionPermissions
+{
+    /**
+     * Permissions that may authorize POST …/products/multiple (route gate).
+     *
+     * @return list<string>
+     */
+    public static function mutationPermissions(): array
+    {
+        return ['msproduct_publish', 'msproduct_delete', 'msproduct_save'];
+    }
+
+    public static function forMethod(string $method): ?string
+    {
+        return match ($method) {
+            'publish', 'unpublish' => 'msproduct_publish',
+            'delete', 'undelete' => 'msproduct_delete',
+            'show', 'hide' => 'msproduct_save',
+            default => null,
+        };
+    }
+}

--- a/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3\Services\Category;
 
+use MiniShop3\Router\HttpStatus;
+
 /** Maps category product bulk/multiple actions to MODX permissions (#378). */
 final class CategoryProductActionPermissions
 {
@@ -23,5 +25,49 @@ final class CategoryProductActionPermissions
             'show', 'hide' => 'msproduct_save',
             default => null,
         };
+    }
+
+    /**
+     * Evaluate access for a bulk/multiple action before any product mutation.
+     *
+     * @param callable(string):bool $hasPermission
+     * @return array{
+     *     allowed: bool,
+     *     status: int,
+     *     message: string,
+     *     permission: ?string,
+     *     reason: 'ok'|'unknown_method'|'forbidden'
+     * }
+     */
+    public static function evaluate(string $method, callable $hasPermission): array
+    {
+        $permission = self::forMethod($method);
+        if ($permission === null) {
+            return [
+                'allowed' => false,
+                'status' => HttpStatus::BAD_REQUEST,
+                'message' => 'Unknown method',
+                'permission' => null,
+                'reason' => 'unknown_method',
+            ];
+        }
+
+        if (!$hasPermission($permission)) {
+            return [
+                'allowed' => false,
+                'status' => HttpStatus::FORBIDDEN,
+                'message' => "Access denied. Required permission: {$permission}",
+                'permission' => $permission,
+                'reason' => 'forbidden',
+            ];
+        }
+
+        return [
+            'allowed' => true,
+            'status' => HttpStatus::OK,
+            'message' => '',
+            'permission' => $permission,
+            'reason' => 'ok',
+        ];
     }
 }

--- a/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
+++ b/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
@@ -1,7 +1,10 @@
 <?php
 
 /**
- * Permission map for category product bulk actions (#378).
+ * Permission map and authz evaluate() for category product bulk actions (#378).
+ *
+ * Covers 403/400 decisions used by CategoryProductsController::multiple()
+ * without bootstrapping MODX.
  *
  * Run: php tests/CategoryProductActionPermissionsTest.php
  */
@@ -10,6 +13,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\Category\CategoryProductActionPermissions;
 
 $fail = static function (string $message): never {
@@ -47,5 +51,55 @@ $assertSame(
     $mutation,
     'mutationPermissions'
 );
+
+$denyAll = static fn(string $permission): bool => false;
+$allowAll = static fn(string $permission): bool => true;
+$allowOnly = static function (string $allowed) {
+    return static fn(string $permission): bool => $permission === $allowed;
+};
+
+// Unknown method → 400 (contract change vs old silent loop → 500)
+$unknown = CategoryProductActionPermissions::evaluate('not-a-method', $denyAll);
+$assertSame(false, $unknown['allowed'], 'unknown allowed');
+$assertSame(HttpStatus::BAD_REQUEST, $unknown['status'], 'unknown status');
+$assertSame('unknown_method', $unknown['reason'], 'unknown reason');
+$assertSame('Unknown method', $unknown['message'], 'unknown message');
+
+// Missing permission → 403 before any product mutation
+$forbidden = CategoryProductActionPermissions::evaluate('delete', $denyAll);
+$assertSame(false, $forbidden['allowed'], 'forbidden allowed');
+$assertSame(HttpStatus::FORBIDDEN, $forbidden['status'], 'forbidden status');
+$assertSame('forbidden', $forbidden['reason'], 'forbidden reason');
+$assertSame('msproduct_delete', $forbidden['permission'], 'forbidden permission');
+$assertSame(
+    'Access denied. Required permission: msproduct_delete',
+    $forbidden['message'],
+    'forbidden message'
+);
+
+// Wrong permission for method → still 403 (no escalation via method param)
+$wrongPerm = CategoryProductActionPermissions::evaluate('publish', $allowOnly('msproduct_delete'));
+$assertSame(false, $wrongPerm['allowed'], 'wrongPerm allowed');
+$assertSame(HttpStatus::FORBIDDEN, $wrongPerm['status'], 'wrongPerm status');
+$assertSame('msproduct_publish', $wrongPerm['permission'], 'wrongPerm permission');
+
+// Authorized → ok (controller may proceed to load products)
+$ok = CategoryProductActionPermissions::evaluate('delete', $allowOnly('msproduct_delete'));
+$assertSame(true, $ok['allowed'], 'ok allowed');
+$assertSame(HttpStatus::OK, $ok['status'], 'ok status');
+$assertSame('ok', $ok['reason'], 'ok reason');
+
+// bulkDelete path forces method=delete before evaluate (same 403 semantics)
+$bulkMethod = 'delete';
+$bulk = CategoryProductActionPermissions::evaluate($bulkMethod, $denyAll);
+$assertSame(HttpStatus::FORBIDDEN, $bulk['status'], 'bulkDelete-equivalent status');
+$assertSame('msproduct_delete', $bulk['permission'], 'bulkDelete-equivalent permission');
+
+// publish() defense-in-depth uses the same forbidden shape for msproduct_publish
+$publishDenied = CategoryProductActionPermissions::evaluate('publish', $denyAll);
+$assertSame(HttpStatus::FORBIDDEN, $publishDenied['status'], 'publish denied status');
+$assertSame('msproduct_publish', $publishDenied['permission'], 'publish denied permission');
+
+$assertSame(true, CategoryProductActionPermissions::evaluate('show', $allowAll)['allowed'], 'show allowAll');
 
 fwrite(STDOUT, "OK: CategoryProductActionPermissionsTest\n");

--- a/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
+++ b/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Permission map for category product bulk actions (#378).
+ *
+ * Run: php tests/CategoryProductActionPermissionsTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Category\CategoryProductActionPermissions;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+foreach ([
+    ['publish', 'msproduct_publish'],
+    ['unpublish', 'msproduct_publish'],
+    ['delete', 'msproduct_delete'],
+    ['undelete', 'msproduct_delete'],
+    ['show', 'msproduct_save'],
+    ['hide', 'msproduct_save'],
+    ['unknown', null],
+    ['', null],
+] as [$method, $expected]) {
+    $assertSame(
+        $expected,
+        CategoryProductActionPermissions::forMethod($method),
+        "forMethod({$method})"
+    );
+}
+
+$mutation = CategoryProductActionPermissions::mutationPermissions();
+sort($mutation);
+$assertSame(
+    ['msproduct_delete', 'msproduct_publish', 'msproduct_save'],
+    $mutation,
+    'mutationPermissions'
+);
+
+fwrite(STDOUT, "OK: CategoryProductActionPermissionsTest\n");


### PR DESCRIPTION
## Описание

Мутации покупателей и товаров категории в Manager API были доступны с одним `view_document`. Content editor мог удалять клиентов и публиковать товары, хотя inline product-data уже требовал `msproduct_save`.

Права выровнены с legacy processors: customers → `msorder_list|view|save|remove`; category products → `view_document` только на GET, `msproduct_save` на sort, `msproduct_delete` на bulk, `msproduct_publish` на publish; `/multiple` — route gate (`AnyPermissionMiddleware`) + точная проверка по `method` через `CategoryProductActionPermissions::evaluate()`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #378

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-378-manager-api-permissions`
- MODX: n/a (unit)
- PHP: локальный CLI

Команды (exit 0):
- `php -l` на затронутых PHP
- `php tests/CategoryProductActionPermissionsTest.php` — map + **403 forbidden** + **400 unknown method** + no escalation via wrong permission
- остальные `tests/*.php`

Ручной сценарий issue (роль только с `view_document` → DELETE customer / publish) на стенде не гоняли.

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

### Смена контракта: unknown `method` в POST `/products/multiple`

| | Было | Стало |
|--|------|-------|
| Неизвестный `method` | warn в лог → цикл без мутаций → **500** «No products were updated» | сразу **400** «Unknown method» (до обработки `ids`) |
| Нет permission | фактически доступ при `view_document` | **403** с текстом `Required permission: …` |

Клиенты, которые ожидали 500 на мусорный `method`, получат 400. Семантика корректнее; это осознанное ужесточение ответа, не silent break бизнес-логики.

### Permission ↔ routes (этот PR)

| Route group | Permission |
|-------------|------------|
| GET `/customers`, addresses list | `msorder_list` |
| GET `/customers/{id}` | `msorder_view` |
| PUT customer / address create+update | `msorder_save` |
| DELETE customer / bulk / address | `msorder_remove` |
| GET category products / filters | `view_document` |
| POST sort | `msproduct_save` |
| DELETE bulk | `msproduct_delete` |
| POST publish | `msproduct_publish` |
| POST multiple | any of publish/delete/save + per-method `evaluate()` |

### Notes for reviewers

- `grid-config` и orders group — вне scope (#378).
- Authz decisions для `/multiple` покрыты unit-тестом `evaluate()` (без полного MODX bootstrap).
- Review follow-up: тесты 403/400 + явный контракт unknown method.