### PR TITLE
fix(manager-api): require mssetting_save for config writes

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -49,6 +49,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         ]);
     })->middleware(new AuthMiddleware($modx, 'mgr'));
 
+    // Config reads: any authenticated mgr (product forms load page-fields without settings perm)
     $router->group('/config', function($router) use ($modx) {
         $router->get('/page-fields/{page_key}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
@@ -58,6 +59,14 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->getAllPageFields($params);
         });
+        $router->get('/sections/{page_key}', function($params) use ($modx) {
+            $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
+            return $controller->getSections($params);
+        });
+    });
+
+    // Config writes: mssetting_save — same gate as model-fields / extra-fields writes (#381)
+    $router->group('/config', function($router) use ($modx) {
         $router->put('/page-fields/{page_key}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->updatePageFields($params);
@@ -65,10 +74,6 @@ $router->group('/api/mgr', function($router) use ($modx) {
         $router->delete('/page-fields/{page_key}/{field_name}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->deleteFieldOverride($params);
-        });
-        $router->get('/sections/{page_key}', function($params) use ($modx) {
-            $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
-            return $controller->getSections($params);
         });
         $router->put('/sections/{page_key}', function($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
@@ -78,8 +83,9 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->deleteSection($params);
         });
-
-    });
+    }, [
+        new PermissionMiddleware($modx, 'mssetting_save')
+    ]);
 
     $router->group('/models', function($router) use ($modx) {
         $router->get('/{alias}/fields', function($params) use ($modx) {

--- a/core/components/minishop3/tests/ConfigRoutePermissionsTest.php
+++ b/core/components/minishop3/tests/ConfigRoutePermissionsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Router-level check: /api/mgr/config writes require mssetting_save; reads stay Auth-only (#381).
+ *
+ * Run: php tests/ConfigRoutePermissionsTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Router\Middleware\PermissionMiddleware;
+use MiniShop3\Router\Router;
+use MODX\Revolution\modX;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail(sprintf(
+            "%s:\nexpected: %s\nactual:   %s",
+            $label,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+};
+
+$permissionFromMiddlewares = static function (array $middlewares): ?string {
+    $found = null;
+    foreach ($middlewares as $middleware) {
+        if (!$middleware instanceof PermissionMiddleware) {
+            continue;
+        }
+        $reflection = new ReflectionProperty(PermissionMiddleware::class, 'permission');
+        $permission = $reflection->getValue($middleware);
+        $found = $permission;
+    }
+
+    return $found;
+};
+
+$_SERVER['HTTP_MODAUTH'] = 'test-modauth-token';
+
+$modx = new modX();
+$router = new Router($modx);
+$router->loadRoutes(dirname(__DIR__) . '/config/routes/manager.php');
+$router->build();
+
+$routesProperty = new ReflectionProperty(Router::class, 'routes');
+$registered = $routesProperty->getValue($router);
+
+$expected = [
+    'GET /api/mgr/config/page-fields/{page_key}' => null,
+    'GET /api/mgr/config/page-fields/{page_key}/all' => null,
+    'GET /api/mgr/config/sections/{page_key}' => null,
+    'PUT /api/mgr/config/page-fields/{page_key}' => 'mssetting_save',
+    'DELETE /api/mgr/config/page-fields/{page_key}/{field_name}' => 'mssetting_save',
+    'PUT /api/mgr/config/sections/{page_key}' => 'mssetting_save',
+    'DELETE /api/mgr/config/sections/{page_key}/{section_key}' => 'mssetting_save',
+];
+
+$actual = [];
+foreach ($registered as $route) {
+    $pattern = $route['pattern'] ?? '';
+    if (!str_starts_with($pattern, '/api/mgr/config')) {
+        continue;
+    }
+    $method = is_array($route['method'] ?? null)
+        ? implode('|', $route['method'])
+        : (string) ($route['method'] ?? '');
+    $key = strtoupper($method) . ' ' . $pattern;
+    $actual[$key] = $permissionFromMiddlewares($route['middlewares'] ?? []);
+}
+
+foreach ($expected as $routeKey => $permission) {
+    $assertSame($permission, $actual[$routeKey] ?? null, "route {$routeKey}");
+}
+
+$unknown = array_diff(array_keys($actual), array_keys($expected));
+if ($unknown !== []) {
+    $fail('unexpected config routes: ' . implode(', ', $unknown));
+}
+
+$assertDenied = static function (
+    Router $router,
+    string $method,
+    string $uri,
+    string $label
+) use ($assertSame, $fail): void {
+    $response = $router->dispatch($uri, $method);
+    $data = $response->getData();
+    $assertSame(403, $response->getStatusCode(), "{$label}: status");
+    $assertSame(false, $data['success'] ?? null, "{$label}: success");
+    if (!str_contains((string) ($data['message'] ?? ''), 'mssetting_save')) {
+        $fail("{$label}: message should mention mssetting_save");
+    }
+};
+
+// Runtime: no mssetting_save → write 403; GET still reaches handler (not 403 from permission)
+$modx->setPermissions([]);
+$assertDenied($router, 'PUT', '/api/mgr/config/page-fields/order', 'PUT page-fields');
+$assertDenied($router, 'DELETE', '/api/mgr/config/sections/order/main', 'DELETE section');
+$assertDenied($router, 'PUT', '/api/mgr/config/sections/order', 'PUT sections');
+$assertDenied($router, 'DELETE', '/api/mgr/config/page-fields/order/title', 'DELETE field override');
+
+fwrite(STDOUT, "OK ConfigRoutePermissionsTest\n");
+exit(0);

--- a/core/components/minishop3/tests/stubs/ModxStub.php
+++ b/core/components/minishop3/tests/stubs/ModxStub.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MODX\Revolution;
+
+/**
+ * Minimal modX stub for standalone router permission tests (no full MODX install).
+ */
+class modX
+{
+    /** @var object|null */
+    public $user;
+
+    /** @var object|null */
+    public $context;
+
+    /** @var array<string, bool> */
+    private array $permissions = [];
+
+    public function __construct()
+    {
+        $this->context = new class {
+            public function get(string $key): string
+            {
+                return $key === 'key' ? 'mgr' : '';
+            }
+        };
+
+        $this->user = new class {
+            public function isAuthenticated(string $context): bool
+            {
+                return $context === 'mgr';
+            }
+
+            public function getUserToken(string $contextKey): string
+            {
+                return 'test-modauth-token';
+            }
+        };
+    }
+
+    /**
+     * @param list<string> $permissions
+     */
+    public function setPermissions(array $permissions): void
+    {
+        $this->permissions = array_fill_keys($permissions, true);
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return !empty($this->permissions[$permission]);
+    }
+
+    public function log($level, $message): void
+    {
+    }
+}


### PR DESCRIPTION
## Описание

Группа `/api/mgr/config` (PUT/DELETE page-fields и sections) была доступна любому аутентифицированному менеджеру — только outer `AuthMiddleware`, без `PermissionMiddleware`.

Мутации закрыты `mssetting_save` (как write у соседних settings-групп). GET оставлен на mgr Auth: формы товара (`ProductDataFields`) читают page-fields без права настроек.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #381

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Gate E (exit codes):**
- `php -l` manager.php / ConfigRoutePermissionsTest / ModxStub → 0
- `php core/components/minishop3/tests/ConfigRoutePermissionsTest.php` → 0 (`OK`)
- red-green: без middleware на write → fail (`actual: NULL`); с фиксом → 0

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-381-config-mssetting-save`
- MODX: n/a (Router + stub modX)
- PHP: 8.x локально

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок (для JS/Vue изменений)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- GET не под `mssetting_save` намеренно: иначе роль с `msproduct_save` без settings не откроет конфиг полей на карточке товара. Issue про write; read/write split как у заказов (#377).
- Review: блокеров нет; security OK; medium про GET закрыт split-ом.