### PR TITLE
fix(manager): ограничить payload /deliveries-active whitelist'ом

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -940,22 +940,10 @@ $router->group('/api/mgr', function($router) use ($modx) {
         return \MiniShop3\Router\Response::success(['results' => $results])->getData();
     });
 
-    // Dropdown list of active deliveries (for order forms)
+    // Dropdown list of active deliveries (for order forms; no properties/class secrets)
     $router->get('/deliveries-active', function($params) use ($modx) {
-        $modx->lexicon->load('minishop3:default');
-        $results = [];
-        $collection = $modx->getIterator(\MiniShop3\Model\msDelivery::class, ['active' => 1]);
-        foreach ($collection as $item) {
-            $data = $item->toArray();
-            if (!empty($data['name']) && str_starts_with($data['name'], 'ms3_')) {
-                $translated = $modx->lexicon($data['name']);
-                if ($translated !== $data['name']) {
-                    $data['name'] = $translated;
-                }
-            }
-            $results[] = $data;
-        }
-        return \MiniShop3\Router\Response::success(['results' => $results])->getData();
+        $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
+        return $controller->getActiveDropdown($params);
     });
 
     $router->group('/grid-config', function($router) use ($modx) {

--- a/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
@@ -18,11 +18,54 @@ use MODX\Revolution\modX;
  */
 class DeliveriesController
 {
+    /**
+     * Public fields for GET /api/mgr/deliveries-active (order-form dropdown).
+     *
+     * Must never include integration secrets: properties, class, validation_rules.
+     */
+    public const ACTIVE_DROPDOWN_FIELDS = [
+        'id',
+        'name',
+        'price',
+        'active',
+        'position',
+    ];
+
     protected modX $modx;
 
     public function __construct(modX $modx)
     {
         $this->modx = $modx;
+    }
+
+    /**
+     * Active deliveries for order-form dropdowns (no integration secrets).
+     * GET /api/mgr/deliveries-active
+     */
+    public function getActiveDropdown(array $params = []): array
+    {
+        $this->modx->lexicon->load('minishop3:default');
+
+        $q = $this->modx->newQuery(msDelivery::class, ['active' => 1]);
+        $q->sortby('position', 'ASC');
+
+        $results = [];
+        foreach ($this->modx->getIterator(msDelivery::class, $q) as $delivery) {
+            $results[] = $this->formatActiveDropdownItem($delivery);
+        }
+
+        return Response::success(['results' => $results])->getData();
+    }
+
+    /**
+     * Project a delivery row to the dropdown whitelist (no MODX required).
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    public static function projectActiveDropdownFields(array $data): array
+    {
+        return array_intersect_key($data, array_flip(self::ACTIVE_DROPDOWN_FIELDS));
     }
 
     /**
@@ -374,6 +417,32 @@ class DeliveriesController
             'validation_rules' => $delivery->get('validation_rules'),
             'free_delivery_amount' => (float)$delivery->get('free_delivery_amount'),
         ];
+    }
+
+    /**
+     * Dropdown row: whitelist only + translated name.
+     */
+    protected function formatActiveDropdownItem(msDelivery $delivery): array
+    {
+        $data = [];
+        foreach (self::ACTIVE_DROPDOWN_FIELDS as $field) {
+            $raw = $delivery->get($field);
+            $data[$field] = match ($field) {
+                'id', 'position' => (int) $raw,
+                'active' => (int) (bool) $raw,
+                default => $raw,
+            };
+        }
+
+        $name = (string) ($data['name'] ?? '');
+        if ($name !== '' && str_starts_with($name, 'ms3_')) {
+            $translated = $this->modx->lexicon($name);
+            if ($translated !== $name) {
+                $data['name'] = $translated;
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/core/components/minishop3/tests/DeliveriesActiveDropdownFieldsTest.php
+++ b/core/components/minishop3/tests/DeliveriesActiveDropdownFieldsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Guards deliveries-active dropdown payload (issue #416).
+ *
+ * GET /api/mgr/deliveries-active must not leak integration secrets
+ * (properties, class, validation_rules).
+ *
+ * Run: php tests/DeliveriesActiveDropdownFieldsTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Controllers\Api\Manager\DeliveriesController;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$fields = DeliveriesController::ACTIVE_DROPDOWN_FIELDS;
+if (!is_array($fields) || $fields === []) {
+    $fail('ACTIVE_DROPDOWN_FIELDS must be a non-empty array');
+}
+
+$required = ['id', 'name', 'price', 'active', 'position'];
+foreach ($required as $field) {
+    if (!in_array($field, $fields, true)) {
+        $fail("ACTIVE_DROPDOWN_FIELDS must contain \"{$field}\"");
+    }
+}
+
+$forbidden = ['properties', 'class', 'validation_rules'];
+foreach ($forbidden as $field) {
+    if (in_array($field, $fields, true)) {
+        $fail("ACTIVE_DROPDOWN_FIELDS must not contain secret/internal field \"{$field}\"");
+    }
+}
+
+$raw = [
+    'id' => 7,
+    'name' => 'Courier',
+    'price' => '300',
+    'active' => 1,
+    'position' => 2,
+    'properties' => ['api_key' => 'secret'],
+    'class' => 'MiniShop3\\Controllers\\Delivery\\Delivery',
+    'validation_rules' => '{"phone":"required"}',
+    'description' => 'should not leak',
+];
+
+$projected = DeliveriesController::projectActiveDropdownFields($raw);
+
+foreach ($forbidden as $field) {
+    if (array_key_exists($field, $projected)) {
+        $fail("projected payload must not contain \"{$field}\"");
+    }
+}
+
+if (array_key_exists('description', $projected)) {
+    $fail('projected payload must not contain non-whitelist field "description"');
+}
+
+foreach ($required as $field) {
+    if (!array_key_exists($field, $projected)) {
+        $fail("projected payload must keep \"{$field}\"");
+    }
+}
+
+if ($projected['id'] !== 7 || $projected['name'] !== 'Courier' || $projected['position'] !== 2) {
+    $fail('projected field values must not be altered');
+}
+
+// Guard: production formatter must loop the same whitelist (source scan).
+$controllerSource = file_get_contents(__DIR__ . '/../src/Controllers/Api/Manager/DeliveriesController.php');
+if ($controllerSource === false) {
+    $fail('cannot read DeliveriesController.php');
+}
+if (!str_contains($controllerSource, 'foreach (self::ACTIVE_DROPDOWN_FIELDS as $field)')) {
+    $fail('formatActiveDropdownItem must iterate ACTIVE_DROPDOWN_FIELDS (not ad-hoc toArray)');
+}
+if (preg_match('/function formatActiveDropdownItem.*?toArray\(/s', $controllerSource)) {
+    $fail('formatActiveDropdownItem must not call toArray()');
+}
+
+fwrite(STDOUT, "OK DeliveriesActiveDropdownFieldsTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

`GET /api/mgr/deliveries-active` отдавал полный `$item->toArray()` модели `msDelivery`. В ответ попадали `properties`, `class`, `validation_rules` и прочие внутренние поля интеграций доставки. Маршрут доступен любому аутентифицированному менеджеру (только Auth, без `mssetting_save`).

Изменения:

- Обработчик перенесён в `DeliveriesController::getActiveDropdown()`.
- Ответ строится по whitelist `ACTIVE_DROPDOWN_FIELDS`: `id`, `name`, `price`, `active`, `position`.
- Сохранён перевод имён `ms3_*` через lexicon; добавлена сортировка по `position`.
- `active` остаётся integer `0|1`, как в прежнем `toArray()`.

**Контракт:** с `/deliveries-active` больше не приходят `properties` / `class` / `validation_rules` / `description` / `logo` и т.п. Полный CRUD по-прежнему на `/api/mgr/deliveries` под `mssetting_save`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [x] Другое: урезание payload dropdown (намеренный security-fix shape)

## Связанные Issues

Closes #416

## Как это было протестировано?

- [x] Автоматические тесты
- [x] Live smoke на локальном MODX (`project.test`)

**Команды и результат:**

```
php -l .../DeliveriesController.php                         # exit 0
php -l .../config/routes/manager.php                         # exit 0
php tests/DeliveriesActiveDropdownFieldsTest.php             # OK (exit 0)
php tests/DirectFilterKeysTest.php                           # OK (exit 0)
```

Red-green: добавление `properties` в whitelist валит тест; после отката — OK.

Live: `getActiveDropdown()` → 9 доставок, ключи только `id,name,price,active,position`, без secrets.

**Конфигурация тестирования:**
- MiniShop3: beta / Manager REST
- MODX: 3.x
- PHP: 8.2+

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают Vue OrderView (endpoint там не используется; combo идёт через model-fields)
- [ ] Лексиконы (не требуются)
- [x] Затронутые PHP-файлы проходят `php -l`

## Дополнительные заметки

Out of scope (как в issue):

- `/statuses-dropdown` по-прежнему отдаёт `toArray()`; у статусов нет `properties`/`class` как у доставок — отдельная задача при необходимости.
- Auth-only на маршруте без `PermissionMiddleware` сохранён (dropdown для форм заказа).