### PR TITLE
fix(api): omit customer secrets from profile/add responses

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MODX\Revolution\modX;
 use Rakit\Validation\Validator;
 
@@ -126,7 +127,7 @@ class CustomerProfileController
 
         return $this->success(
             $this->modx->lexicon('ms3_customer_profile_updated'),
-            ['customer' => $customer->toArray()]
+            ['customer' => CustomerPublicDto::fromCustomer($customer)]
         );
     }
 
@@ -204,7 +205,7 @@ class CustomerProfileController
             $this->modx->lexicon('ms3_customer_profile_updated'),
             [
                 $key => $customer->get($key),
-                'customer' => $customer->toArray(),
+                'customer' => CustomerPublicDto::fromCustomer($customer),
             ]
         );
     }

--- a/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Customer;
+
+use MiniShop3\Model\msCustomer;
+
+/**
+ * Public customer payload for Web API responses (no secrets / lock internals).
+ */
+final class CustomerPublicDto
+{
+    /**
+     * Fields allowed in public customer JSON (fail-closed for new columns).
+     *
+     * @var list<string>
+     */
+    private const PUBLIC_FIELDS = [
+        'id',
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+        'email_verified_at',
+        'is_active',
+        'created_at',
+        'updated_at',
+        'last_login_at',
+        'orders_count',
+        'total_spent',
+        'last_order_at',
+        'privacy_accepted_at',
+    ];
+
+    /**
+     * @param array<string, mixed> $customerFields
+     * @return array<string, mixed>
+     */
+    public static function fromArray(array $customerFields): array
+    {
+        return array_intersect_key($customerFields, array_flip(self::PUBLIC_FIELDS));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function fromCustomer(msCustomer $customer): array
+    {
+        return self::fromArray($customer->toArray());
+    }
+}

--- a/core/components/minishop3/tests/CustomerPublicDtoTest.php
+++ b/core/components/minishop3/tests/CustomerPublicDtoTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Static checks for public customer DTO (without MODX).
+ *
+ * Run: php tests/CustomerPublicDtoTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Customer\CustomerPublicDto;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$input = [
+    'id' => 42,
+    'user_id' => 7,
+    'first_name' => 'Ada',
+    'last_name' => 'Lovelace',
+    'email' => 'ada@example.com',
+    'phone' => '+10000000000',
+    'password' => '$2y$10$notarealhash',
+    'token' => 'session-or-api-secret',
+    'email_verified_at' => '2026-01-02 03:04:05',
+    'is_active' => true,
+    'is_blocked' => true,
+    'privacy_ip' => '203.0.113.10',
+    'failed_login_attempts' => 3,
+    'blocked_until' => '2026-01-01 00:00:00',
+    'created_at' => '2025-01-01 00:00:00',
+    'updated_at' => '2025-06-01 00:00:00',
+    'last_login_at' => '2025-12-01 00:00:00',
+    'orders_count' => 2,
+    'total_spent' => 99.5,
+    'last_order_at' => '2025-11-01 00:00:00',
+    'privacy_accepted_at' => '2025-01-01 00:00:00',
+    'future_secret_column' => 'must-not-leak',
+];
+
+$expected = [
+    'id' => 42,
+    'first_name' => 'Ada',
+    'last_name' => 'Lovelace',
+    'email' => 'ada@example.com',
+    'phone' => '+10000000000',
+    'email_verified_at' => '2026-01-02 03:04:05',
+    'is_active' => true,
+    'created_at' => '2025-01-01 00:00:00',
+    'updated_at' => '2025-06-01 00:00:00',
+    'last_login_at' => '2025-12-01 00:00:00',
+    'orders_count' => 2,
+    'total_spent' => 99.5,
+    'last_order_at' => '2025-11-01 00:00:00',
+    'privacy_accepted_at' => '2025-01-01 00:00:00',
+];
+
+$public = CustomerPublicDto::fromArray($input);
+
+if ($public !== $expected) {
+    $fail(sprintf(
+        "public payload mismatch:\nexpected: %s\nactual:   %s",
+        json_encode($expected, JSON_UNESCAPED_SLASHES),
+        json_encode($public, JSON_UNESCAPED_SLASHES)
+    ));
+}
+
+foreach (['password', 'token', 'privacy_ip', 'failed_login_attempts', 'blocked_until', 'is_blocked', 'user_id', 'future_secret_column'] as $hidden) {
+    if (array_key_exists($hidden, $public)) {
+        $fail("hidden field still present: {$hidden}");
+    }
+}
+
+$controllerSrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CustomerProfileController.php');
+if ($controllerSrc === false) {
+    $fail('unable to read CustomerProfileController.php');
+}
+if (str_contains($controllerSrc, '$customer->toArray()')) {
+    $fail('CustomerProfileController still serializes full customer via toArray()');
+}
+if (!str_contains($controllerSrc, 'CustomerPublicDto::fromCustomer')) {
+    $fail('CustomerProfileController missing CustomerPublicDto::fromCustomer');
+}
+
+fwrite(STDOUT, "OK CustomerPublicDtoTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

`PUT /api/v1/customer/profile` и `POST /api/v1/customer/add` отдавали `$customer->toArray()` целиком: в JSON попадали `password` (hash) и `msCustomer.token`. После путей checkout, где token может совпадать с API-токеном (#369), это даёт захват сессии.

Добавлен `CustomerPublicDto` с allowlist публичных полей (fail-closed). Оба success-ответа профиля сериализуют клиента через него.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [x] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

Ответ `data.customer` больше не содержит секреты и lock/privacy-поля (`password`, `token`, `privacy_ip`, `failed_login_attempts`, `blocked_until`, `is_blocked`, `user_id`). Клиенты, которые читали эти ключи из profile/add, нужно обновить. Новые колонки модели (в т.ч. OE) в публичный payload не попадают, пока их явно не добавят в allowlist.

## Связанные Issues

Closes #410

## Как это было протестировано?

- [ ] Ручное тестирование
- [x] Автоматические тесты (PHPStan, ESLint)
- [ ] Тестирование на разных версиях PHP/MODX

**Gate E:**
- `php -l` на `CustomerPublicDto.php`, `CustomerProfileController.php`, `CustomerPublicDtoTest.php` → exit 0
- `php core/components/minishop3/tests/CustomerPublicDtoTest.php` → exit 0 (`OK CustomerPublicDtoTest`)

**Конфигурация тестирования:**
- MiniShop3: branch `fix/issue-410-customer-profile-secrets`
- MODX: n/a (static test)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — n/a, UI-строк нет
- [ ] PHPStan проходит без новых ошибок — не гонялся в этой сессии
- [x] ESLint проходит без ошибок (для JS/Vue изменений) — n/a
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — запись при релизе

## Дополнительные заметки

- Вне scope: `ProfilePageService`, legacy `Customer::getFields()` и другие `toArray()` — отдельные поверхности (#410 только profile/add JSON).
- Review: code-review + thermo-nuclear + security + silent-failure — blockers закрыты allowlist’ом после первого цикла.