### PR TITLE
fix(mgr): ACL на запись /grid-config (mssetting_save)

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -961,13 +961,18 @@ $router->group('/api/mgr', function($router) use ($modx) {
         return $controller->getActiveDropdown($params);
     });
 
-    $router->group('/grid-config', function($router) use ($modx) {
-        $router->get('/{grid_key}', function($params) use ($modx) {
+    // Read: any mgr who can open grids (view_document). Write is global msGridField — mssetting_save.
+    $router->group('/grid-config', function ($router) use ($modx) {
+        $router->get('/{grid_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\GridConfigController($modx);
             return $controller->getConfig($params);
         });
+    }, [
+        new PermissionMiddleware($modx, 'view_document')
+    ]);
 
-        $router->put('/{grid_key}', function($params) use ($modx) {
+    $router->group('/grid-config', function ($router) use ($modx) {
+        $router->put('/{grid_key}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['grid_key'] = $params['grid_key'] ?? null;
@@ -976,7 +981,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->saveConfig($data);
         });
 
-        $router->post('/{grid_key}/field', function($params) use ($modx) {
+        $router->post('/{grid_key}/field', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['grid_key'] = $params['grid_key'] ?? null;
@@ -985,7 +990,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->addField($data);
         });
 
-        $router->put('/{grid_key}/field/{field_name}', function($params) use ($modx) {
+        $router->put('/{grid_key}/field/{field_name}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['grid_key'] = $params['grid_key'] ?? null;
@@ -994,13 +999,13 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\GridConfigController($modx);
             return $controller->updateField($data);
         });
-        $router->delete('/{grid_key}/{field_name}', function($params) use ($modx) {
+
+        $router->delete('/{grid_key}/{field_name}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\GridConfigController($modx);
             return $controller->deleteField($params);
         });
-
     }, [
-        new PermissionMiddleware($modx, 'view_document')
+        new PermissionMiddleware($modx, 'mssetting_save')
     ]);
 
     $router->group('/notifications', function($router) use ($modx) {

--- a/core/components/minishop3/tests/GridConfigRouteAclTest.php
+++ b/core/components/minishop3/tests/GridConfigRouteAclTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Regression #417: /grid-config write ACL map (no MODX).
+ *
+ * Запуск: php tests/GridConfigRouteAclTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$routesFile = dirname(__DIR__) . '/config/routes/manager.php';
+$src = file_get_contents($routesFile);
+if ($src === false || $src === '') {
+    $fail('cannot read manager.php routes');
+}
+
+if (!preg_match_all(
+    "/\\\$router->group\(\s*'\/grid-config'\s*,\s*function\s*\([^)]*\)\s*use\s*\([^)]*\)\s*\{(.*?)\}\s*,\s*\[\s*new\s+PermissionMiddleware\(\s*\\\$modx\s*,\s*'([^']+)'\s*\)/s",
+    $src,
+    $matches,
+    PREG_SET_ORDER
+)) {
+    $fail('no /grid-config route groups found');
+}
+
+/** @var array<string, string> $routePerm method|path => permission */
+$routePerm = [];
+
+foreach ($matches as $match) {
+    $body = $match[1];
+    $perm = $match[2];
+
+    if (preg_match_all(
+        "/\\\$router->(get|put|post|delete)\(\s*'([^']+)'/",
+        $body,
+        $routeMatches,
+        PREG_SET_ORDER
+    )) {
+        foreach ($routeMatches as $routeMatch) {
+            $key = strtoupper($routeMatch[1]) . ' ' . $routeMatch[2];
+            if (isset($routePerm[$key]) && $routePerm[$key] !== $perm) {
+                $fail("conflicting permissions for {$key}: {$routePerm[$key]} vs {$perm}");
+            }
+            $routePerm[$key] = $perm;
+        }
+    }
+}
+
+$expected = [
+    'GET /{grid_key}' => 'view_document',
+    'PUT /{grid_key}' => 'mssetting_save',
+    'POST /{grid_key}/field' => 'mssetting_save',
+    'PUT /{grid_key}/field/{field_name}' => 'mssetting_save',
+    'DELETE /{grid_key}/{field_name}' => 'mssetting_save',
+];
+
+foreach ($expected as $key => $perm) {
+    if (($routePerm[$key] ?? null) !== $perm) {
+        $fail("{$key} must require {$perm}, got: " . var_export($routePerm[$key] ?? null, true));
+    }
+}
+
+foreach ($routePerm as $key => $perm) {
+    if (!isset($expected[$key])) {
+        $fail("unexpected grid-config route registered: {$key} ({$perm})");
+    }
+}
+
+fwrite(STDOUT, "OK GridConfigRouteAclTest\n");
+exit(0);

--- a/core/components/minishop3/tests/GridConfigRouteAclTest.php
+++ b/core/components/minishop3/tests/GridConfigRouteAclTest.php
@@ -19,12 +19,18 @@ if ($src === false || $src === '') {
     $fail('cannot read manager.php routes');
 }
 
-if (!preg_match_all(
-    "/\\\$router->group\(\s*'\/grid-config'\s*,\s*function\s*\([^)]*\)\s*use\s*\([^)]*\)\s*\{(.*?)\}\s*,\s*\[\s*new\s+PermissionMiddleware\(\s*\\\$modx\s*,\s*'([^']+)'\s*\)/s",
-    $src,
-    $matches,
-    PREG_SET_ORDER
-)) {
+$gridConfigGroupPattern =
+    "/\\\$router->group\(\s*'\/grid-config'\s*,\s*function\s*\([^)]*\)\s*use\s*\([^)]*\)"
+    . "\s*\{(.*?)\}\s*,\s*\[\s*new\s+PermissionMiddleware\(\s*\\\$modx\s*,\s*'([^']+)'\s*\)/s";
+
+if (
+    !preg_match_all(
+        $gridConfigGroupPattern,
+        $src,
+        $matches,
+        PREG_SET_ORDER
+    )
+) {
     $fail('no /grid-config route groups found');
 }
 
@@ -35,12 +41,14 @@ foreach ($matches as $match) {
     $body = $match[1];
     $perm = $match[2];
 
-    if (preg_match_all(
-        "/\\\$router->(get|put|post|delete)\(\s*'([^']+)'/",
-        $body,
-        $routeMatches,
-        PREG_SET_ORDER
-    )) {
+    if (
+        preg_match_all(
+            "/\\\$router->(get|put|post|delete)\(\s*'([^']+)'/",
+            $body,
+            $routeMatches,
+            PREG_SET_ORDER
+        )
+    ) {
         foreach ($routeMatches as $routeMatch) {
             $key = strtoupper($routeMatch[1]) . ' ' . $routeMatch[2];
             if (isset($routePerm[$key]) && $routePerm[$key] !== $perm) {


### PR DESCRIPTION
## Описание

Write-эндпойнты `/api/mgr/grid-config` больше не открыты под одним `view_document`. Глобальные колонки `msGridField` меняют только пользователи с `mssetting_save`. Чтение конфигурации грида остаётся на `view_document`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #417

Смежно с #378 / #381 (другие ACL-поверхности mgr API).

## Как это было протестировано?

```bash
cd core/components/minishop3
php tests/GridConfigRouteAclTest.php   # exit 0
composer ci:php                         # exit 0
```

Gate E (эта сессия):
- `php -l config/routes/manager.php` — OK
- `php tests/GridConfigRouteAclTest.php` — OK (полная карта method→permission)
- `composer ci:php` — OK (exit 0)
- Vue — n/a (UI без своей ACL; API отдаст 403)

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-417-grid-config-write-acl`
- MODX: n/a
- PHP: 8.2+

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы — не требуются
- [ ] PHPStan — не в этом гейте
- [x] ESLint — n/a
- [ ] CHANGELOG.md — на релизе

## Дополнительные заметки

**Карта ACL:**
| Method | Path | Permission |
|--------|------|------------|
| GET | `/{grid_key}` | `view_document` |
| PUT | `/{grid_key}` | `mssetting_save` |
| POST | `/{grid_key}/field` | `mssetting_save` |
| PUT | `/{grid_key}/field/{field_name}` | `mssetting_save` |
| DELETE | `/{grid_key}/{field_name}` | `mssetting_save` |

**UX:** вкладка «Конфигурация гридов» без `mssetting_save` получит 403 на save — ожидаемо.

**Review:** code-reviewer, thermo-nuclear, security-review; 1 fix-loop (усилен smoke-тест partition).