### PR TITLE
fix(mgr): ACL view_document на /references (PII покупателей)

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -167,7 +167,10 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->searchCustomers($params);
         });
 
-    });
+    }, [
+        // Same floor as /api/mgr/customers (#378): block PII lookup for mgr-only sessions (#415)
+        new PermissionMiddleware($modx, 'view_document')
+    ]);
 
     $router->group('/extra-fields', function($router) use ($modx) {
         $router->get('', function($params) use ($modx) {

--- a/core/components/minishop3/tests/ReferencesRouteAclTest.php
+++ b/core/components/minishop3/tests/ReferencesRouteAclTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Regression #415: /references requires view_document (customer PII).
+ *
+ * Run: php tests/ReferencesRouteAclTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$routesFile = dirname(__DIR__) . '/config/routes/manager.php';
+$src = file_get_contents($routesFile);
+if ($src === false || $src === '') {
+    $fail('cannot read manager.php routes');
+}
+
+$start = strpos($src, "\$router->group('/references'");
+if ($start === false) {
+    $fail('/references group not found');
+}
+
+$nextGroup = strpos($src, "\$router->group('/extra-fields'", $start);
+if ($nextGroup === false) {
+    $fail('anchor after /references (/extra-fields) not found');
+}
+
+$block = substr($src, $start, $nextGroup - $start);
+
+if (!str_contains($block, "searchCustomers")) {
+    $fail('/references must still expose GET customers search');
+}
+
+if (
+    !preg_match(
+        "/\}\s*,\s*\[[\s\S]*PermissionMiddleware\(\s*\\\$modx\s*,\s*'view_document'\s*\)/",
+        $block
+    )
+) {
+    $fail('/references must require view_document via PermissionMiddleware');
+}
+
+fwrite(STDOUT, "OK ReferencesRouteAclTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Группа `/api/mgr/references` была только за outer `AuthMiddleware(mgr)`. `GET /references/customers` отдавал email, phone, `orders_count`, `total_spent` любому залогиненному менеджеру.

На группу повешен `PermissionMiddleware(view_document)` — тот же floor, что у `/api/mgr/customers` на beta (#378).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #415

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0
phpcs --standard=PSR12 tests/ReferencesRouteAclTest.php  # exit 0
# red-green: снятие PermissionMiddleware с /references → ReferencesRouteAclTest exit 1; после отката exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `fix/issue-415-references-permission`
- MODX: n/a (static smoke)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок — Vue не меняли
- [ ] Обновлён CHANGELOG.md — не для этого PR

## Дополнительные заметки

- Hardening (отложено): ужесточить только `GET /references/customers` до `msorder_list`, остальным reference-роутам — отдельный ACL; сейчас паритет с REST `/customers` на beta.
- Vue combo на 403 часто ставит `[]` без toast — UX, не обход ACL; отдельный follow-up.
- Пересечение с #400 (более дробный ACL customers) — при merge сверить floor.