### PR TITLE
fix(api): запретить подделку privacy_accepted_at через customer/add

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -41,6 +41,7 @@ class CustomerProfileController
         'orders_count',
         'total_spent',
         'last_order_at',
+        'privacy_accepted_at',
         'privacy_ip',
     ];
 

--- a/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
+++ b/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Regression #413: customer/add must not write GDPR consent timestamp.
+ *
+ * Run: php tests/ProfileQuickUpdateForbiddenTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$src = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CustomerProfileController.php');
+if ($src === false || $src === '') {
+    $fail('unable to read CustomerProfileController.php');
+}
+
+if (
+    !preg_match(
+        '/private const PROFILE_QUICK_UPDATE_FORBIDDEN\s*=\s*\[(.*?)\];/s',
+        $src,
+        $match
+    )
+) {
+    $fail('PROFILE_QUICK_UPDATE_FORBIDDEN constant not found');
+}
+
+$forbiddenBlock = $match[1];
+if (!preg_match_all("/'([^']+)'/", $forbiddenBlock, $keys)) {
+    $fail('no forbidden field keys parsed');
+}
+
+$forbidden = $keys[1];
+foreach (['privacy_accepted_at', 'privacy_ip', 'password', 'token', 'email_verified_at'] as $key) {
+    if (!in_array($key, $forbidden, true)) {
+        $fail("PROFILE_QUICK_UPDATE_FORBIDDEN must include {$key}");
+    }
+}
+
+if (!str_contains($src, 'in_array($key, self::PROFILE_QUICK_UPDATE_FORBIDDEN, true)')) {
+    $fail('updateField must enforce PROFILE_QUICK_UPDATE_FORBIDDEN');
+}
+
+fwrite(STDOUT, "OK ProfileQuickUpdateForbiddenTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

`POST /api/v1/customer/add` писал любое поле из `fieldMeta`, кроме denylist. В списке был `privacy_ip`, но не `privacy_accepted_at` — авторизованный покупатель мог проставить GDPR-метку согласия без register/consent flow.

`privacy_accepted_at` добавлен в `PROFILE_QUICK_UPDATE_FORBIDDEN`. Легитимный consent по-прежнему только в `RegisterService` (серверный timestamp + IP).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #413

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0
phpcs --standard=PSR12 tests/ProfileQuickUpdateForbiddenTest.php  # exit 0
# red-green: убрать privacy_accepted_at из константы → test exit 1; откат → exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `fix/issue-413-privacy-accepted-at-forbidden`
- MODX: n/a (static smoke)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы — не требуется
- [ ] PHPStan — не в CI
- [ ] ESLint — Vue не меняли
- [ ] CHANGELOG — не для этого PR

## Дополнительные заметки

- Allowlist вместо denylist (и OE-поля на `msCustomer` из #261) — отдельный hardening, не scope #413.
- `PUT /customer/profile` и так пишет только name/email/phone.