### PR TITLE
feat(web-api): customer logout and password recovery routes

### DIFF
--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -137,55 +137,42 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
-            $email = $data['email'] ?? '';
-            $password = $data['password'] ?? '';
+            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
 
-            $response = $modx->runProcessor(
-                'MiniShop3\Processors\Api\Customer\Login',
-                [
-                    'email' => $email,
-                    'password' => $password
-                ]
-            );
-
-            return Response::fromProcessor($response);
+            return $controller->login($data);
         });
-        $router->post('/logout', function ($params) use ($modx) {
-            $response = $modx->runProcessor(
-                'MiniShop3\Processors\Api\Customer\Logout',
-                []
-            );
 
-            if ($response->isError()) {
-                return Response::error($response->getMessage(), HttpStatus::BAD_REQUEST);
-            }
-
-            return Response::success($response->getObject() ?: [], $response->getMessage());
-        }, [$tokenMiddleware]);
         $router->post('/register', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
-            $email = $data['email'] ?? '';
-            $password = $data['password'] ?? '';
-            $firstName = $data['first_name'] ?? '';
-            $lastName = $data['last_name'] ?? '';
-            $phone = $data['phone'] ?? '';
-            $privacyAccepted = !empty($data['privacy_accepted']);
+            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
 
-            $response = $modx->runProcessor(
-                'MiniShop3\Processors\Api\Customer\Register',
-                [
-                    'email' => $email,
-                    'password' => $password,
-                    'first_name' => $firstName,
-                    'last_name' => $lastName,
-                    'phone' => $phone,
-                    'privacy_accepted' => $privacyAccepted
-                ]
-            );
+            return $controller->register($data);
+        });
 
-            return Response::fromProcessor($response);
+        $router->post('/logout', function ($params) use ($modx) {
+            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
+
+            return $controller->logout();
+        }, [$tokenMiddleware]);
+
+        $router->post('/forgot-password', function ($params) use ($modx) {
+            $input = file_get_contents('php://input');
+            $data = json_decode($input, true) ?: [];
+
+            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
+
+            return $controller->forgotPassword($data);
+        });
+
+        $router->post('/reset-password', function ($params) use ($modx) {
+            $input = file_get_contents('php://input');
+            $data = json_decode($input, true) ?: [];
+
+            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
+
+            return $controller->resetPassword($data);
         });
 
         $router->post('/add', function ($params) use ($modx) {

--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -134,45 +134,23 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
 
     $router->group('/customer', function ($router) use ($modx, $tokenMiddleware) {
         $router->post('/login', function ($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
-
-            return $controller->login($data);
+            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->loginFromRequest();
         });
 
         $router->post('/register', function ($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
-
-            return $controller->register($data);
+            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->registerFromRequest();
         });
 
         $router->post('/logout', function ($params) use ($modx) {
-            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
-
-            return $controller->logout();
+            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->logout();
         }, [$tokenMiddleware]);
 
         $router->post('/forgot-password', function ($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
-
-            return $controller->forgotPassword($data);
+            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->forgotPasswordFromRequest();
         });
 
         $router->post('/reset-password', function ($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $controller = new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
-
-            return $controller->resetPassword($data);
+            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->resetPasswordFromRequest();
         });
 
         $router->post('/add', function ($params) use ($modx) {

--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -28,7 +28,6 @@
  * @version 1.0.0
  */
 
-use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Middleware\TokenMiddleware;
 use MiniShop3\Middleware\CorsMiddleware;
@@ -133,24 +132,27 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
     }, [$tokenMiddleware]);
 
     $router->group('/customer', function ($router) use ($modx, $tokenMiddleware) {
-        $router->post('/login', function ($params) use ($modx) {
-            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->loginFromRequest();
+        $customerAuth = static fn (): \MiniShop3\Controllers\Api\Web\CustomerAuthController =>
+            new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
+
+        $router->post('/login', function ($params) use ($customerAuth) {
+            return $customerAuth()->loginFromRequest();
         });
 
-        $router->post('/register', function ($params) use ($modx) {
-            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->registerFromRequest();
+        $router->post('/register', function ($params) use ($customerAuth) {
+            return $customerAuth()->registerFromRequest();
         });
 
-        $router->post('/logout', function ($params) use ($modx) {
-            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->logout();
+        $router->post('/logout', function ($params) use ($customerAuth) {
+            return $customerAuth()->logout();
         }, [$tokenMiddleware]);
 
-        $router->post('/forgot-password', function ($params) use ($modx) {
-            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->forgotPasswordFromRequest();
+        $router->post('/forgot-password', function ($params) use ($customerAuth) {
+            return $customerAuth()->forgotPasswordFromRequest();
         });
 
-        $router->post('/reset-password', function ($params) use ($modx) {
-            return (new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx))->resetPasswordFromRequest();
+        $router->post('/reset-password', function ($params) use ($customerAuth) {
+            return $customerAuth()->resetPasswordFromRequest();
         });
 
         $router->post('/add', function ($params) use ($modx) {

--- a/core/components/minishop3/lexicon/en/customer.inc.php
+++ b/core/components/minishop3/lexicon/en/customer.inc.php
@@ -88,6 +88,7 @@ Best regards,
 $_lang['ms3_customer_forgot_password_success'] = 'Password reset instructions have been sent to your email';
 $_lang['ms3_customer_err_forgot_password_rate_limit'] = 'Too many requests. Please try again in an hour.';
 $_lang['ms3_customer_err_forgot_password_email_cooldown'] = 'Email already sent. Please try again in 5 minutes.';
+$_lang['ms3_customer_err_reset_password_rate_limit'] = 'Too many password reset attempts ({attempts}/{max}). Try again in {minutes} minutes.';
 $_lang['ms3_password_reset_subject'] = '[[+site]]: Password Reset';
 $_lang['ms3_password_reset_body'] = 'Hello, [[+first_name]]!
 

--- a/core/components/minishop3/lexicon/ru/customer.inc.php
+++ b/core/components/minishop3/lexicon/ru/customer.inc.php
@@ -88,6 +88,7 @@ $_lang['ms3_email_verification_body'] = 'Здравствуйте, [[+first_name
 $_lang['ms3_customer_forgot_password_success'] = 'Инструкции по восстановлению пароля отправлены на email';
 $_lang['ms3_customer_err_forgot_password_rate_limit'] = 'Превышен лимит запросов. Попробуйте через час.';
 $_lang['ms3_customer_err_forgot_password_email_cooldown'] = 'Письмо уже было отправлено. Попробуйте через 5 минут.';
+$_lang['ms3_customer_err_reset_password_rate_limit'] = 'Превышен лимит попыток сброса пароля ({attempts}/{max}). Попробуйте через {minutes} минут.';
 $_lang['ms3_password_reset_subject'] = '[[+site]]: Восстановление пароля';
 $_lang['ms3_password_reset_body'] = 'Здравствуйте, [[+first_name]]!
 

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace MiniShop3\Controllers\Api\Web;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MODX\Revolution\modX;
+use MODX\Revolution\Processors\ProcessorResponse;
+
+/**
+ * CustomerAuthController — login, register, logout, password recovery (Web API).
+ *
+ * Delegates to Processors\Api\Customer\* and maps processor failures to HTTP responses.
+ */
+class CustomerAuthController
+{
+    public function __construct(protected modX $modx)
+    {
+    }
+
+    /**
+     * POST /api/v1/customer/login
+     *
+     * @param array<string, mixed> $data
+     */
+    public function login(array $data): Response
+    {
+        return $this->runProcessor('MiniShop3\Processors\Api\Customer\Login', [
+            'email' => $data['email'] ?? '',
+            'password' => $data['password'] ?? '',
+        ]);
+    }
+
+    /**
+     * POST /api/v1/customer/register
+     *
+     * @param array<string, mixed> $data
+     */
+    public function register(array $data): Response
+    {
+        return $this->runProcessor('MiniShop3\Processors\Api\Customer\Register', [
+            'email' => $data['email'] ?? '',
+            'password' => $data['password'] ?? '',
+            'first_name' => $data['first_name'] ?? '',
+            'last_name' => $data['last_name'] ?? '',
+            'phone' => $data['phone'] ?? '',
+            'privacy_accepted' => !empty($data['privacy_accepted']),
+        ]);
+    }
+
+    /**
+     * POST /api/v1/customer/logout
+     */
+    public function logout(): Response
+    {
+        return $this->runProcessor('MiniShop3\Processors\Api\Customer\Logout', []);
+    }
+
+    /**
+     * POST /api/v1/customer/forgot-password
+     *
+     * @param array<string, mixed> $data
+     */
+    public function forgotPassword(array $data): Response
+    {
+        return $this->runProcessor('MiniShop3\Processors\Api\Customer\ForgotPassword', [
+            'email' => $data['email'] ?? '',
+        ]);
+    }
+
+    /**
+     * POST /api/v1/customer/reset-password
+     *
+     * @param array<string, mixed> $data
+     */
+    public function resetPassword(array $data): Response
+    {
+        return $this->runProcessor('MiniShop3\Processors\Api\Customer\ResetPassword', [
+            'token' => $data['token'] ?? '',
+            'password' => $data['password'] ?? '',
+            'password_confirm' => $data['password_confirm'] ?? '',
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    private function runProcessor(string $processorClass, array $properties): Response
+    {
+        /** @var ProcessorResponse $response */
+        $response = $this->modx->runProcessor($processorClass, $properties);
+
+        return $this->toResponse($response);
+    }
+
+    private function toResponse(ProcessorResponse $response): Response
+    {
+        if ($response->isError()) {
+            $payload = $response->getObject();
+            $status = HttpStatus::BAD_REQUEST;
+            if (is_array($payload) && isset($payload['code']) && is_numeric($payload['code'])) {
+                $status = (int) $payload['code'];
+            }
+
+            return Response::error($response->getMessage(), $status);
+        }
+
+        return Response::success($response->getObject(), $response->getMessage());
+    }
+}

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -20,6 +20,48 @@ class CustomerAuthController
 
     /**
      * POST /api/v1/customer/login
+     */
+    public function loginFromRequest(): Response
+    {
+        return $this->login($this->readJsonBody());
+    }
+
+    /**
+     * POST /api/v1/customer/register
+     */
+    public function registerFromRequest(): Response
+    {
+        return $this->register($this->readJsonBody());
+    }
+
+    /**
+     * POST /api/v1/customer/forgot-password
+     */
+    public function forgotPasswordFromRequest(): Response
+    {
+        return $this->forgotPassword($this->readJsonBody());
+    }
+
+    /**
+     * POST /api/v1/customer/reset-password
+     */
+    public function resetPasswordFromRequest(): Response
+    {
+        return $this->resetPassword($this->readJsonBody());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJsonBody(): array
+    {
+        $input = file_get_contents('php://input');
+
+        return json_decode($input, true) ?: [];
+    }
+
+    /**
+     * POST /api/v1/customer/login
      *
      * @param array<string, mixed> $data
      */

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -5,7 +5,6 @@ namespace MiniShop3\Controllers\Api\Web;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MODX\Revolution\modX;
-use MODX\Revolution\Processors\ProcessorResponse;
 
 /**
  * CustomerAuthController — login, register, logout, password recovery (Web API).
@@ -129,13 +128,13 @@ class CustomerAuthController
      */
     private function runProcessor(string $processorClass, array $properties): Response
     {
-        /** @var ProcessorResponse $response */
+        /** @var object{isError(): bool, getMessage(): string, getObject(): mixed} $response */
         $response = $this->modx->runProcessor($processorClass, $properties);
 
         return $this->toResponse($response);
     }
 
-    private function toResponse(ProcessorResponse $response): Response
+    private function toResponse(object $response): Response
     {
         if ($response->isError()) {
             $payload = $response->getObject();

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -128,7 +128,7 @@ class CustomerAuthController
      */
     private function runProcessor(string $processorClass, array $properties): Response
     {
-        /** @var object{isError(): bool, getMessage(): string, getObject(): mixed} $response */
+        /** @var object $response */
         $response = $this->modx->runProcessor($processorClass, $properties);
 
         return $this->toResponse($response);

--- a/core/components/minishop3/src/Processors/Api/Customer/ForgotPassword.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/ForgotPassword.php
@@ -3,6 +3,7 @@
 namespace MiniShop3\Processors\Api\Customer;
 
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Customer\RateLimiter;
 use MODX\Revolution\Processors\Processor;
@@ -33,11 +34,17 @@ class ForgotPassword extends Processor
 
         $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
         if (!$rateLimiter->check('forgot_password', $ip, 3, 3600)) {
-            return $this->failure($this->modx->lexicon('ms3_customer_err_forgot_password_rate_limit'));
+            return $this->failure(
+                $this->modx->lexicon('ms3_customer_err_forgot_password_rate_limit'),
+                ['code' => HttpStatus::TOO_MANY_REQUESTS]
+            );
         }
 
         if (!$rateLimiter->check('forgot_password_email', $email, 1, 300)) {
-            return $this->failure($this->modx->lexicon('ms3_customer_err_forgot_password_email_cooldown'));
+            return $this->failure(
+                $this->modx->lexicon('ms3_customer_err_forgot_password_email_cooldown'),
+                ['code' => HttpStatus::TOO_MANY_REQUESTS]
+            );
         }
 
         /** @var msCustomer $customer */

--- a/core/components/minishop3/src/Processors/Api/Customer/ResetPassword.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/ResetPassword.php
@@ -4,7 +4,9 @@ namespace MiniShop3\Processors\Api\Customer;
 
 use MiniShop3\Controllers\Auth\PasswordAuthProvider;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Customer\RateLimiter;
 use MiniShop3\Services\Customer\RegisterService;
 use MODX\Revolution\Processors\Processor;
 
@@ -12,16 +14,23 @@ use MODX\Revolution\Processors\Processor;
  * ResetPassword - processor for setting new password via token
  *
  * Validates token from email and sets new password.
+ * Protected from bruteforce via RateLimiter (per IP and per reset token).
  *
  * @package MiniShop3\Processors\Api\Customer
  */
 class ResetPassword extends Processor
 {
+    private const MAX_ATTEMPTS = 5;
+
+    private const WINDOW_SECONDS = 900;
+
     /**
      * @return array|string
      */
     public function process()
     {
+        $this->modx->lexicon->load('minishop3:customer');
+
         $token = trim($this->getProperty('token', ''));
         $password = $this->getProperty('password', '');
         $passwordConfirm = $this->getProperty('password_confirm', '');
@@ -36,6 +45,19 @@ class ResetPassword extends Processor
 
         if ($password !== $passwordConfirm) {
             return $this->failure($this->modx->lexicon('ms3_customer_err_password_mismatch'));
+        }
+
+        /** @var RateLimiter $rateLimiter */
+        $rateLimiter = $this->modx->services->get('ms3_rate_limiter');
+
+        $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+
+        if (!$rateLimiter->check('reset_password_ip', $ip, self::MAX_ATTEMPTS, self::WINDOW_SECONDS)) {
+            return $this->rateLimitFailure($rateLimiter, 'reset_password_ip', $ip);
+        }
+
+        if (!$rateLimiter->check('reset_password_token', $token, self::MAX_ATTEMPTS, self::WINDOW_SECONDS)) {
+            return $this->rateLimitFailure($rateLimiter, 'reset_password_token', $token);
         }
 
         /** @var AuthManager $authManager */
@@ -67,6 +89,9 @@ class ResetPassword extends Processor
             return $this->failure($this->modx->lexicon('ms3_customer_err_save'));
         }
 
+        $rateLimiter->reset('reset_password_ip', $ip);
+        $rateLimiter->reset('reset_password_token', $token);
+
         $authManager->revokeTokens($customer);
         $authManager->invalidateLocalSessionForCustomer($customer);
 
@@ -76,5 +101,22 @@ class ResetPassword extends Processor
         );
 
         return $this->success($this->modx->lexicon('ms3_password_reset_complete'));
+    }
+
+    /**
+     * @return array|string
+     */
+    private function rateLimitFailure(RateLimiter $rateLimiter, string $action, string $identifier)
+    {
+        $attempts = $rateLimiter->getAttempts($action, $identifier);
+
+        return $this->failure(
+            $this->modx->lexicon('ms3_customer_err_reset_password_rate_limit', [
+                'attempts' => $attempts,
+                'max' => self::MAX_ATTEMPTS,
+                'minutes' => round(self::WINDOW_SECONDS / 60),
+            ]),
+            ['code' => HttpStatus::TOO_MANY_REQUESTS]
+        );
     }
 }

--- a/core/components/minishop3/tests/CustomerAuthEndpointsTest.php
+++ b/core/components/minishop3/tests/CustomerAuthEndpointsTest.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * Functional dispatch tests for customer auth Web API endpoints (#422).
+ *
+ * Uses WebApiModxStub + Router dispatch (no MODX/MySQL).
+ *
+ * Run: php tests/CustomerAuthEndpointsTest.php
+ */
+
+declare(strict_types=1);
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/WebApiModxStub.php';
+require __DIR__ . '/stubs/ProcessorResponseStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Controllers\Api\Web\CustomerAuthController;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Router;
+use MiniShop3\Tests\Stubs\ProcessorResponseStub;
+use MODX\Revolution\WebApiModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail(sprintf(
+            "%s:\nexpected: %s\nactual:   %s",
+            $label,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+};
+
+$buildRouter = static function (WebApiModxStub $modx): Router {
+    $router = new Router($modx);
+    $router->loadRoutes(dirname(__DIR__) . '/config/routes/web.php');
+    $router->build();
+
+    return $router;
+};
+
+$dispatchPost = static function (Router $router, string $route): array {
+    $_REQUEST['route'] = $route;
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+    $_SERVER['REQUEST_URI'] = $route;
+
+    $response = $router->dispatch($route, 'POST');
+    $data = $response->getData();
+
+    return [
+        'status' => $response->getStatusCode(),
+        'success' => $data['success'] ?? null,
+        'message' => (string) ($data['message'] ?? ''),
+        'code' => $data['code'] ?? null,
+    ];
+};
+
+// --- CustomerAuthController: request/response mapping ---
+
+$modx = new WebApiModxStub();
+$controller = new CustomerAuthController($modx);
+
+$modx->runProcessorHandler = static function (string $action, array $data): ProcessorResponseStub {
+    return match ($action) {
+        'MiniShop3\\Processors\\Api\\Customer\\ForgotPassword' => ProcessorResponseStub::failure(
+            'email required',
+            ['code' => HttpStatus::BAD_REQUEST]
+        ),
+        'MiniShop3\\Processors\\Api\\Customer\\ResetPassword' => ProcessorResponseStub::failure(
+            'too many attempts',
+            ['code' => HttpStatus::TOO_MANY_REQUESTS]
+        ),
+        'MiniShop3\\Processors\\Api\\Customer\\Logout' => ProcessorResponseStub::success(null, 'logged out'),
+        default => ProcessorResponseStub::failure('unexpected processor: ' . $action),
+    };
+};
+
+$response = $controller->forgotPassword([]);
+$assertSame(HttpStatus::BAD_REQUEST, $response->getStatusCode(), 'forgotPassword empty email status');
+$assertSame(false, $response->getData()['success'] ?? null, 'forgotPassword empty email success flag');
+
+$response = $controller->resetPassword([
+    'token' => 'reset-token',
+    'password' => 'short',
+    'password_confirm' => 'short',
+]);
+$assertSame(HttpStatus::TOO_MANY_REQUESTS, $response->getStatusCode(), 'resetPassword rate limit status');
+$assertSame(429, $response->getData()['code'] ?? null, 'resetPassword rate limit body code');
+
+$response = $controller->logout();
+$assertSame(HttpStatus::OK, $response->getStatusCode(), 'logout controller success status');
+$assertSame('logged out', $response->getData()['message'] ?? null, 'logout controller message');
+
+$modx->runProcessorHandler = static function (string $action, array $data): ProcessorResponseStub {
+    return match ($action) {
+        'MiniShop3\\Processors\\Api\\Customer\\ForgotPassword' => ProcessorResponseStub::success(
+            ['sent' => true],
+            'reset email queued'
+        ),
+        default => ProcessorResponseStub::failure('unexpected processor: ' . $action),
+    };
+};
+
+$response = $controller->forgotPassword(['email' => 'user@example.com']);
+$assertSame(HttpStatus::OK, $response->getStatusCode(), 'forgotPassword success status');
+$assertSame(true, $response->getData()['success'] ?? null, 'forgotPassword success flag');
+
+// --- Router dispatch: logout with TokenMiddleware + session ---
+
+$modx = new WebApiModxStub();
+$modx->customers[42] = (object) ['id' => 42];
+$modx->runProcessorHandler = static function (string $action): ProcessorResponseStub {
+    if ($action === 'MiniShop3\\Processors\\Api\\Customer\\Logout') {
+        return ProcessorResponseStub::success(null, 'You have been logged out');
+    }
+
+    return ProcessorResponseStub::failure('unexpected: ' . $action);
+};
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+$_SESSION['ms3'] = ['customer_id' => 42];
+
+$router = $buildRouter($modx);
+$result = $dispatchPost($router, '/api/v1/customer/logout');
+$assertSame(HttpStatus::OK, $result['status'], 'dispatch logout HTTP status');
+$assertSame(true, $result['success'], 'dispatch logout success');
+$assertSame('You have been logged out', $result['message'], 'dispatch logout message');
+
+// --- Router dispatch: forgot-password (body via stdin pipe subprocess) ---
+
+$subprocessScript = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/WebApiModxStub.php';
+require __DIR__ . '/stubs/ProcessorResponseStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Router;
+use MiniShop3\Tests\Stubs\ProcessorResponseStub;
+use MODX\Revolution\WebApiModxStub;
+
+$route = $argv[1] ?? '';
+$rawBody = stream_get_contents(STDIN);
+$expectedProcessor = $argv[2] ?? '';
+
+$modx = new WebApiModxStub();
+$modx->runProcessorHandler = static function (string $action, array $data) use ($expectedProcessor, $rawBody): ProcessorResponseStub {
+    if ($action !== $expectedProcessor) {
+        fwrite(STDERR, "processor mismatch: {$action}\n");
+        exit(2);
+    }
+
+    $decoded = json_decode($rawBody, true);
+    if (!is_array($decoded)) {
+        fwrite(STDERR, "invalid json body\n");
+        exit(3);
+    }
+
+    if ($expectedProcessor === 'MiniShop3\\Processors\\Api\\Customer\\ForgotPassword') {
+        if (($decoded['email'] ?? '') !== 'user@example.com') {
+            fwrite(STDERR, "unexpected email\n");
+            exit(4);
+        }
+
+        return ProcessorResponseStub::success(null, 'Password reset instructions have been sent to your email');
+    }
+
+    if ($expectedProcessor === 'MiniShop3\\Processors\\Api\\Customer\\ResetPassword') {
+        if (($decoded['token'] ?? '') !== 'reset-token-abc') {
+            fwrite(STDERR, "unexpected token\n");
+            exit(5);
+        }
+
+        return ProcessorResponseStub::success(null, 'Password successfully changed');
+    }
+
+    return ProcessorResponseStub::failure('unknown');
+};
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_SERVER['REQUEST_URI'] = $route;
+$_REQUEST['route'] = $route;
+
+$router = new Router($modx);
+$router->loadRoutes(dirname(__DIR__) . '/config/routes/web.php');
+$router->build();
+
+$response = $router->dispatch($route, 'POST');
+$data = $response->getData();
+
+echo json_encode([
+    'status' => $response->getStatusCode(),
+    'success' => $data['success'] ?? null,
+    'message' => $data['message'] ?? null,
+], JSON_THROW_ON_ERROR);
+PHP;
+
+$subprocessPath = __DIR__ . '/_customer_auth_dispatch_subprocess.php';
+file_put_contents($subprocessPath, $subprocessScript);
+
+$runWithBody = static function (string $route, string $processor, string $jsonBody) use ($subprocessPath, $fail, $assertSame): void {
+    $command = sprintf(
+        '%s %s %s %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg($subprocessPath),
+        escapeshellarg($route),
+        escapeshellarg($processor)
+    );
+
+    $descriptors = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptors, $pipes, __DIR__);
+    if (!is_resource($process)) {
+        $fail('unable to start subprocess for ' . $route);
+    }
+
+    fwrite($pipes[0], $jsonBody);
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    $exitCode = proc_close($process);
+    if ($exitCode !== 0) {
+        $fail("subprocess {$route} exit {$exitCode}: {$stderr}");
+    }
+
+    $payload = json_decode($stdout, true);
+    if (!is_array($payload)) {
+        $fail("subprocess {$route} returned invalid json: {$stdout}");
+    }
+
+    $assertSame(HttpStatus::OK, $payload['status'], "{$route} dispatch status");
+    $assertSame(true, $payload['success'], "{$route} dispatch success");
+};
+
+$runWithBody(
+    '/api/v1/customer/forgot-password',
+    'MiniShop3\\Processors\\Api\\Customer\\ForgotPassword',
+    '{"email":"user@example.com"}'
+);
+
+$runWithBody(
+    '/api/v1/customer/reset-password',
+    'MiniShop3\\Processors\\Api\\Customer\\ResetPassword',
+    '{"token":"reset-token-abc","password":"Str0ngPass!","password_confirm":"Str0ngPass!"}'
+);
+
+@unlink($subprocessPath);
+
+echo "OK CustomerAuthEndpointsTest\n";

--- a/core/components/minishop3/tests/CustomerAuthEndpointsTest.php
+++ b/core/components/minishop3/tests/CustomerAuthEndpointsTest.php
@@ -12,10 +12,13 @@ declare(strict_types=1);
 
 error_reporting(E_ALL & ~E_DEPRECATED);
 
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/support/xpdo_stub.php';
+require __DIR__ . '/support/xpdo_om_stub.php';
 require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/FakeMsCustomer.php';
 require __DIR__ . '/stubs/WebApiModxStub.php';
 require __DIR__ . '/stubs/ProcessorResponseStub.php';
-require __DIR__ . '/../vendor/autoload.php';
 
 use MiniShop3\Controllers\Api\Web\CustomerAuthController;
 use MiniShop3\Router\HttpStatus;
@@ -117,7 +120,7 @@ $assertSame(true, $response->getData()['success'] ?? null, 'forgotPassword succe
 // --- Router dispatch: logout with TokenMiddleware + session ---
 
 $modx = new WebApiModxStub();
-$modx->customers[42] = (object) ['id' => 42];
+$modx->putCustomer(42);
 $modx->runProcessorHandler = static function (string $action): ProcessorResponseStub {
     if ($action === 'MiniShop3\\Processors\\Api\\Customer\\Logout') {
         return ProcessorResponseStub::success(null, 'You have been logged out');
@@ -145,10 +148,13 @@ declare(strict_types=1);
 
 error_reporting(E_ALL & ~E_DEPRECATED);
 
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/support/xpdo_stub.php';
+require __DIR__ . '/support/xpdo_om_stub.php';
 require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/FakeMsCustomer.php';
 require __DIR__ . '/stubs/WebApiModxStub.php';
 require __DIR__ . '/stubs/ProcessorResponseStub.php';
-require __DIR__ . '/../vendor/autoload.php';
 
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Router;

--- a/core/components/minishop3/tests/CustomerAuthRoutesTest.php
+++ b/core/components/minishop3/tests/CustomerAuthRoutesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Router-level check: customer auth routes exposed in Web API (#422).
+ *
+ * Uses ModxStub so web routes load without a full MODX install.
+ *
+ * Run: php tests/CustomerAuthRoutesTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Middleware\TokenMiddleware;
+use MiniShop3\Router\Router;
+use MODX\Revolution\modX;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail(sprintf(
+            "%s:\nexpected: %s\nactual:   %s",
+            $label,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+};
+
+$hasTokenMiddleware = static function (array $middlewares): bool {
+    foreach ($middlewares as $middleware) {
+        if ($middleware instanceof TokenMiddleware) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+$modx = new modX();
+$router = new Router($modx);
+$router->loadRoutes(dirname(__DIR__) . '/config/routes/web.php');
+$router->build();
+
+$routesProperty = new ReflectionProperty(Router::class, 'routes');
+$registered = $routesProperty->getValue($router);
+
+$expectedRoutes = [
+    'POST /api/v1/customer/login' => false,
+    'POST /api/v1/customer/register' => false,
+    'POST /api/v1/customer/logout' => true,
+    'POST /api/v1/customer/forgot-password' => false,
+    'POST /api/v1/customer/reset-password' => false,
+];
+
+$actual = [];
+foreach ($registered as $route) {
+    $pattern = $route['pattern'] ?? '';
+    if (!str_starts_with($pattern, '/api/v1/customer/')) {
+        continue;
+    }
+
+    $method = is_array($route['method'] ?? null)
+        ? implode('|', $route['method'])
+        : (string) ($route['method'] ?? '');
+    $key = strtoupper($method) . ' ' . $pattern;
+    $actual[$key] = $hasTokenMiddleware($route['middlewares'] ?? []);
+}
+
+foreach ($expectedRoutes as $routeKey => $requiresTokenMiddleware) {
+    if (!array_key_exists($routeKey, $actual)) {
+        $fail("missing route {$routeKey}");
+    }
+    $assertSame($requiresTokenMiddleware, $actual[$routeKey], "TokenMiddleware on {$routeKey}");
+}
+
+$authControllerPath = dirname(__DIR__) . '/src/Controllers/Api/Web/CustomerAuthController.php';
+$authControllerSrc = file_get_contents($authControllerPath);
+if ($authControllerSrc === false) {
+    $fail('unable to read CustomerAuthController.php');
+}
+
+foreach ([
+    'function logout',
+    'function forgotPassword',
+    'function resetPassword',
+    'Processors\Api\Customer\Logout',
+    'Processors\Api\Customer\ForgotPassword',
+    'Processors\Api\Customer\ResetPassword',
+] as $needle) {
+    if (!str_contains($authControllerSrc, $needle)) {
+        $fail("CustomerAuthController must contain: {$needle}");
+    }
+}
+
+$forgotSrc = file_get_contents(dirname(__DIR__) . '/src/Processors/Api/Customer/ForgotPassword.php');
+if ($forgotSrc === false || !str_contains($forgotSrc, 'HttpStatus::TOO_MANY_REQUESTS')) {
+    $fail('ForgotPassword must attach HttpStatus::TOO_MANY_REQUESTS on rate-limit failures');
+}
+
+echo "OK CustomerAuthRoutesTest\n";

--- a/core/components/minishop3/tests/CustomerAuthRoutesTest.php
+++ b/core/components/minishop3/tests/CustomerAuthRoutesTest.php
@@ -104,4 +104,20 @@ if ($forgotSrc === false || !str_contains($forgotSrc, 'HttpStatus::TOO_MANY_REQU
     $fail('ForgotPassword must attach HttpStatus::TOO_MANY_REQUESTS on rate-limit failures');
 }
 
+$resetSrc = file_get_contents(dirname(__DIR__) . '/src/Processors/Api/Customer/ResetPassword.php');
+if ($resetSrc === false) {
+    $fail('unable to read ResetPassword.php');
+}
+foreach ([
+    'ms3_rate_limiter',
+    'reset_password_ip',
+    'reset_password_token',
+    'HttpStatus::TOO_MANY_REQUESTS',
+    'rateLimiter->reset',
+] as $needle) {
+    if (!str_contains($resetSrc, $needle)) {
+        $fail("ResetPassword must contain: {$needle}");
+    }
+}
+
 echo "OK CustomerAuthRoutesTest\n";

--- a/core/components/minishop3/tests/CustomerAuthRoutesTest.php
+++ b/core/components/minishop3/tests/CustomerAuthRoutesTest.php
@@ -48,13 +48,36 @@ $hasTokenMiddleware = static function (array $middlewares): bool {
 
 $handlerUsesAuthController = static function (callable $handler, string $methodName) use ($fail): void {
     if (!$handler instanceof Closure) {
-        $fail("auth route handler must be a closure");
+        $fail('auth route handler must be a closure');
     }
 
     $reflection = new ReflectionFunction($handler);
     $staticVariables = $reflection->getStaticVariables();
-    if (!array_key_exists('modx', $staticVariables)) {
-        $fail("auth route closure must capture \$modx");
+    if (!array_key_exists('customerAuth', $staticVariables)) {
+        $fail('auth route closure must capture $customerAuth factory');
+    }
+
+    $factory = $staticVariables['customerAuth'];
+    if (!$factory instanceof Closure) {
+        $fail('$customerAuth must be a closure factory');
+    }
+
+    $factoryReflection = new ReflectionFunction($factory);
+    $factoryFile = $factoryReflection->getFileName();
+    $factoryStart = $factoryReflection->getStartLine();
+    $factoryEnd = $factoryReflection->getEndLine();
+    if ($factoryFile === false || $factoryStart <= 0 || $factoryEnd < $factoryStart) {
+        $fail('unable to inspect $customerAuth factory');
+    }
+
+    $factorySource = implode("\n", array_slice(
+        file($factoryFile, FILE_IGNORE_NEW_LINES) ?: [],
+        $factoryStart - 1,
+        $factoryEnd - $factoryStart + 1
+    ));
+
+    if (!str_contains($factorySource, CustomerAuthController::class)) {
+        $fail('$customerAuth factory must instantiate CustomerAuthController');
     }
 
     $file = $reflection->getFileName();
@@ -64,15 +87,14 @@ $handlerUsesAuthController = static function (callable $handler, string $methodN
         $fail('unable to inspect auth route closure source');
     }
 
-    $lines = array_slice(
+    $source = implode("\n", array_slice(
         file($file, FILE_IGNORE_NEW_LINES) ?: [],
         $startLine - 1,
         $endLine - $startLine + 1
-    );
-    $source = implode("\n", $lines);
+    ));
 
-    if (!str_contains($source, CustomerAuthController::class)) {
-        $fail("auth route handler must delegate to CustomerAuthController");
+    if (!str_contains($source, '$customerAuth()')) {
+        $fail('auth route handler must delegate through $customerAuth()');
     }
 
     if (!str_contains($source, "->{$methodName}(")) {

--- a/core/components/minishop3/tests/CustomerAuthRoutesTest.php
+++ b/core/components/minishop3/tests/CustomerAuthRoutesTest.php
@@ -4,6 +4,8 @@
  * Router-level check: customer auth routes exposed in Web API (#422).
  *
  * Uses ModxStub so web routes load without a full MODX install.
+ * Asserts route registration and middleware stack via Router introspection
+ * (same pattern as OrdersRoutePermissionsTest).
  *
  * Run: php tests/CustomerAuthRoutesTest.php
  */
@@ -13,6 +15,7 @@ declare(strict_types=1);
 require __DIR__ . '/stubs/ModxStub.php';
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Controllers\Api\Web\CustomerAuthController;
 use MiniShop3\Middleware\TokenMiddleware;
 use MiniShop3\Router\Router;
 use MODX\Revolution\modX;
@@ -43,6 +46,40 @@ $hasTokenMiddleware = static function (array $middlewares): bool {
     return false;
 };
 
+$handlerUsesAuthController = static function (callable $handler, string $methodName) use ($fail): void {
+    if (!$handler instanceof Closure) {
+        $fail("auth route handler must be a closure");
+    }
+
+    $reflection = new ReflectionFunction($handler);
+    $staticVariables = $reflection->getStaticVariables();
+    if (!array_key_exists('modx', $staticVariables)) {
+        $fail("auth route closure must capture \$modx");
+    }
+
+    $file = $reflection->getFileName();
+    $startLine = $reflection->getStartLine();
+    $endLine = $reflection->getEndLine();
+    if ($file === false || $startLine <= 0 || $endLine < $startLine) {
+        $fail('unable to inspect auth route closure source');
+    }
+
+    $lines = array_slice(
+        file($file, FILE_IGNORE_NEW_LINES) ?: [],
+        $startLine - 1,
+        $endLine - $startLine + 1
+    );
+    $source = implode("\n", $lines);
+
+    if (!str_contains($source, CustomerAuthController::class)) {
+        $fail("auth route handler must delegate to CustomerAuthController");
+    }
+
+    if (!str_contains($source, "->{$methodName}(")) {
+        $fail("auth route handler must call CustomerAuthController::{$methodName}()");
+    }
+};
+
 $modx = new modX();
 $router = new Router($modx);
 $router->loadRoutes(dirname(__DIR__) . '/config/routes/web.php');
@@ -52,11 +89,26 @@ $routesProperty = new ReflectionProperty(Router::class, 'routes');
 $registered = $routesProperty->getValue($router);
 
 $expectedRoutes = [
-    'POST /api/v1/customer/login' => false,
-    'POST /api/v1/customer/register' => false,
-    'POST /api/v1/customer/logout' => true,
-    'POST /api/v1/customer/forgot-password' => false,
-    'POST /api/v1/customer/reset-password' => false,
+    'POST /api/v1/customer/login' => [
+        'tokenMiddleware' => false,
+        'handlerMethod' => 'loginFromRequest',
+    ],
+    'POST /api/v1/customer/register' => [
+        'tokenMiddleware' => false,
+        'handlerMethod' => 'registerFromRequest',
+    ],
+    'POST /api/v1/customer/logout' => [
+        'tokenMiddleware' => true,
+        'handlerMethod' => 'logout',
+    ],
+    'POST /api/v1/customer/forgot-password' => [
+        'tokenMiddleware' => false,
+        'handlerMethod' => 'forgotPasswordFromRequest',
+    ],
+    'POST /api/v1/customer/reset-password' => [
+        'tokenMiddleware' => false,
+        'handlerMethod' => 'resetPasswordFromRequest',
+    ],
 ];
 
 $actual = [];
@@ -70,54 +122,31 @@ foreach ($registered as $route) {
         ? implode('|', $route['method'])
         : (string) ($route['method'] ?? '');
     $key = strtoupper($method) . ' ' . $pattern;
-    $actual[$key] = $hasTokenMiddleware($route['middlewares'] ?? []);
+
+    $actual[$key] = [
+        'tokenMiddleware' => $hasTokenMiddleware($route['middlewares'] ?? []),
+        'handler' => $route['handler'] ?? null,
+    ];
 }
 
-foreach ($expectedRoutes as $routeKey => $requiresTokenMiddleware) {
+foreach ($expectedRoutes as $routeKey => $expectation) {
     if (!array_key_exists($routeKey, $actual)) {
         $fail("missing route {$routeKey}");
     }
-    $assertSame($requiresTokenMiddleware, $actual[$routeKey], "TokenMiddleware on {$routeKey}");
-}
 
-$authControllerPath = dirname(__DIR__) . '/src/Controllers/Api/Web/CustomerAuthController.php';
-$authControllerSrc = file_get_contents($authControllerPath);
-if ($authControllerSrc === false) {
-    $fail('unable to read CustomerAuthController.php');
-}
+    $route = $actual[$routeKey];
+    $assertSame(
+        $expectation['tokenMiddleware'],
+        $route['tokenMiddleware'],
+        "TokenMiddleware on {$routeKey}"
+    );
 
-foreach ([
-    'function logout',
-    'function forgotPassword',
-    'function resetPassword',
-    'Processors\Api\Customer\Logout',
-    'Processors\Api\Customer\ForgotPassword',
-    'Processors\Api\Customer\ResetPassword',
-] as $needle) {
-    if (!str_contains($authControllerSrc, $needle)) {
-        $fail("CustomerAuthController must contain: {$needle}");
+    $handler = $route['handler'];
+    if (!is_callable($handler)) {
+        $fail("route {$routeKey} must have callable handler");
     }
-}
 
-$forgotSrc = file_get_contents(dirname(__DIR__) . '/src/Processors/Api/Customer/ForgotPassword.php');
-if ($forgotSrc === false || !str_contains($forgotSrc, 'HttpStatus::TOO_MANY_REQUESTS')) {
-    $fail('ForgotPassword must attach HttpStatus::TOO_MANY_REQUESTS on rate-limit failures');
-}
-
-$resetSrc = file_get_contents(dirname(__DIR__) . '/src/Processors/Api/Customer/ResetPassword.php');
-if ($resetSrc === false) {
-    $fail('unable to read ResetPassword.php');
-}
-foreach ([
-    'ms3_rate_limiter',
-    'reset_password_ip',
-    'reset_password_token',
-    'HttpStatus::TOO_MANY_REQUESTS',
-    'rateLimiter->reset',
-] as $needle) {
-    if (!str_contains($resetSrc, $needle)) {
-        $fail("ResetPassword must contain: {$needle}");
-    }
+    $handlerUsesAuthController($handler, $expectation['handlerMethod']);
 }
 
 echo "OK CustomerAuthRoutesTest\n";

--- a/core/components/minishop3/tests/OrderStatusServiceGetPaymentLinkTest.php
+++ b/core/components/minishop3/tests/OrderStatusServiceGetPaymentLinkTest.php
@@ -53,7 +53,6 @@ $invokeGetPaymentLink = static function (
 };
 
 $modx = new class extends modX {
-    public object $services;
     public object $lexicon;
 
     public function __construct()

--- a/core/components/minishop3/tests/TokenSessionRevokePolicyTest.php
+++ b/core/components/minishop3/tests/TokenSessionRevokePolicyTest.php
@@ -17,9 +17,10 @@ $repoRoot = dirname(__DIR__, 4);
 $middleware = $repoRoot . '/core/components/minishop3/src/Middleware/TokenMiddleware.php';
 $trait = $repoRoot . '/core/components/minishop3/src/Controllers/Api/Web/AuthorizedCustomerTrait.php';
 $webRoutes = $repoRoot . '/core/components/minishop3/config/routes/web.php';
+$authController = $repoRoot . '/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php';
 $logout = $repoRoot . '/core/components/minishop3/src/Processors/Api/Customer/Logout.php';
 
-foreach ([$middleware, $trait, $webRoutes, $logout] as $path) {
+foreach ([$middleware, $trait, $webRoutes, $authController, $logout] as $path) {
     if (!is_readable($path)) {
         $fail('cannot read ' . basename($path));
     }
@@ -28,9 +29,11 @@ foreach ([$middleware, $trait, $webRoutes, $logout] as $path) {
 $middlewareSource = file_get_contents($middleware);
 $traitSource = file_get_contents($trait);
 $webRoutesSource = file_get_contents($webRoutes);
+$authControllerSource = file_get_contents($authController);
 $logoutSource = file_get_contents($logout);
 
-if ($middlewareSource === false || $traitSource === false || $webRoutesSource === false || $logoutSource === false) {
+if ($middlewareSource === false || $traitSource === false || $webRoutesSource === false
+    || $authControllerSource === false || $logoutSource === false) {
     $fail('cannot read sources');
 }
 
@@ -58,8 +61,12 @@ if (!preg_match('#post\s*\(\s*[\'"]/logout[\'"]#', $webRoutesSource)) {
     $fail('web routes must register POST /customer/logout');
 }
 
-if (!str_contains($webRoutesSource, 'MiniShop3\\Processors\\Api\\Customer\\Logout')) {
-    $fail('logout route must invoke Logout processor');
+if (!preg_match('#post\s*\(\s*[\'"]/logout[\'"][\s\S]*?->logout\s*\(\s*\)#', $webRoutesSource)) {
+    $fail('logout route must delegate to CustomerAuthController::logout');
+}
+
+if (!str_contains($authControllerSource, 'MiniShop3\\Processors\\Api\\Customer\\Logout')) {
+    $fail('CustomerAuthController::logout must invoke Logout processor');
 }
 
 if (!str_contains($logoutSource, 'session_regenerate_id')) {

--- a/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
+++ b/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
@@ -13,9 +13,6 @@ use MODX\Revolution\modX;
  */
 class CategoryProductScopeModxStub extends modX
 {
-    /** @var object */
-    public object $services;
-
     /** @var list<array{id: int, parent: int, published?: int, deleted?: int}> */
     public array $products = [];
 

--- a/core/components/minishop3/tests/stubs/FakeMsCustomer.php
+++ b/core/components/minishop3/tests/stubs/FakeMsCustomer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MiniShop3\Model\msCustomer;
+
+/**
+ * Lightweight msCustomer double for Web API / middleware smoke tests (no xPDO).
+ */
+final class FakeMsCustomer extends msCustomer
+{
+    /** @var array<string, mixed> */
+    private array $fields;
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function __construct(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->fields[$k] ?? null;
+    }
+}

--- a/core/components/minishop3/tests/stubs/ModxStub.php
+++ b/core/components/minishop3/tests/stubs/ModxStub.php
@@ -22,6 +22,9 @@ class modX
     /** @var array<string, bool> */
     private array $permissions = [];
 
+    /** @var object|null */
+    public $services;
+
     public function __construct()
     {
         $this->context = new class {
@@ -42,6 +45,27 @@ class modX
                 return 'test-modauth-token';
             }
         };
+
+        $this->services = new class {
+            public function has(string $key): bool
+            {
+                return $key === 'ms3';
+            }
+
+            public function get(string $key): mixed
+            {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
+    public function getOption(string $key, $options = null, $default = null)
+    {
+        return $default;
     }
 
     /**

--- a/core/components/minishop3/tests/stubs/ProcessorResponseStub.php
+++ b/core/components/minishop3/tests/stubs/ProcessorResponseStub.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+/**
+ * Minimal ProcessorResponse stand-in for standalone Web API tests.
+ */
+final class ProcessorResponseStub
+{
+    public function __construct(
+        private readonly bool $error,
+        private readonly string $message = '',
+        private readonly mixed $object = null,
+    ) {
+    }
+
+    public static function success(mixed $object = null, string $message = ''): self
+    {
+        return new self(false, $message, $object);
+    }
+
+    public static function failure(string $message, mixed $object = null): self
+    {
+        return new self(true, $message, $object);
+    }
+
+    public function isError(): bool
+    {
+        return $this->error;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getObject(): mixed
+    {
+        return $this->object;
+    }
+}

--- a/core/components/minishop3/tests/stubs/WebApiModxStub.php
+++ b/core/components/minishop3/tests/stubs/WebApiModxStub.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MODX\Revolution;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Tests\Stubs\ProcessorResponseStub;
+
+/**
+ * modX stub for Web API dispatch tests (router + auth endpoints, no MySQL).
+ */
+class WebApiModxStub extends modX
+{
+    /** @var callable|null */
+    public $runProcessorHandler;
+
+    /** @var array<int, object> */
+    public array $customers = [];
+
+    /** @var object */
+    public $lexicon;
+
+    /** @var object */
+    public $cacheManager;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->lexicon = new class {
+            private array $strings = [];
+
+            public function load(string $topic): void
+            {
+            }
+
+            public function setStrings(array $strings): void
+            {
+                $this->strings = $strings;
+            }
+
+            public function lexicon(string $key, array $options = []): string
+            {
+                $value = $this->strings[$key] ?? $key;
+                foreach ($options as $placeholder => $replacement) {
+                    $value = str_replace('{' . $placeholder . '}', (string) $replacement, $value);
+                }
+
+                return $value;
+            }
+        };
+
+        $this->cacheManager = new class {
+            private array $store = [];
+
+            public function get(string $key, array &$options = []): mixed
+            {
+                return $this->store[$key] ?? null;
+            }
+
+            public function set(string $key, mixed $value, int $ttl = 0): bool
+            {
+                $this->store[$key] = $value;
+
+                return true;
+            }
+
+            public function delete(string $key): bool
+            {
+                unset($this->store[$key]);
+
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function runProcessor(string $action, array $data = [], array $options = []): ProcessorResponseStub
+    {
+        if ($this->runProcessorHandler !== null) {
+            return ($this->runProcessorHandler)($action, $data, $options);
+        }
+
+        return ProcessorResponseStub::failure('Unhandled processor: ' . $action);
+    }
+
+    /**
+     * @param class-string|array<string, mixed>|int|string $className
+     * @param array<string, mixed>|int|string|null $criteria
+     */
+    public function getObject($className, $criteria = '', bool $cacheFlag = true): ?object
+    {
+        if ($className === msCustomer::class || $className === 'MiniShop3\\Model\\msCustomer') {
+            $id = is_array($criteria) ? (int) ($criteria['id'] ?? 0) : (int) $criteria;
+
+            return $this->customers[$id] ?? null;
+        }
+
+        return null;
+    }
+}

--- a/core/components/minishop3/tests/stubs/WebApiModxStub.php
+++ b/core/components/minishop3/tests/stubs/WebApiModxStub.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MODX\Revolution;
 
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Tests\Stubs\FakeMsCustomer;
 use MiniShop3\Tests\Stubs\ProcessorResponseStub;
 
 /**
@@ -15,8 +16,11 @@ class WebApiModxStub extends modX
     /** @var callable|null */
     public $runProcessorHandler;
 
-    /** @var array<int, object> */
+    /** @var array<int, msCustomer> */
     public array $customers = [];
+
+    /** @var object|null TokenService-shaped double for TokenMiddleware */
+    public $tokenService;
 
     /** @var object */
     public $lexicon;
@@ -27,6 +31,42 @@ class WebApiModxStub extends modX
     public function __construct()
     {
         parent::__construct();
+
+        $this->tokenService = new class {
+            public function resolveApiToken(string $token): array
+            {
+                return ['token' => null, 'reason' => 'missing'];
+            }
+
+            public function sessionTokenBelongsToCustomer(int $customerId): bool
+            {
+                return $customerId > 0;
+            }
+
+            public function generateCustomerToken(): array
+            {
+                return ['token' => 'anon-test-token'];
+            }
+        };
+
+        $this->services = new class ($this) {
+            public function __construct(private WebApiModxStub $modx)
+            {
+            }
+
+            public function has(string $key): bool
+            {
+                return $key === 'ms3' || $key === 'ms3_token_service';
+            }
+
+            public function get(string $key): mixed
+            {
+                return match ($key) {
+                    'ms3_token_service' => $this->modx->tokenService,
+                    default => null,
+                };
+            }
+        };
 
         $this->lexicon = new class {
             private array $strings = [];
@@ -100,5 +140,21 @@ class WebApiModxStub extends modX
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function putCustomer(int $id, array $fields = []): FakeMsCustomer
+    {
+        $customer = new FakeMsCustomer(array_merge([
+            'id' => $id,
+            'is_active' => true,
+            'is_blocked' => false,
+            'blocked_until' => null,
+        ], $fields));
+        $this->customers[$id] = $customer;
+
+        return $customer;
     }
 }


### PR DESCRIPTION
## Описание

Публичный Web API не экспонировал процессоры logout / forgot-password / reset-password — headless-клиент не мог завершить сессию и восстановить пароль без connector.

Добавлен `CustomerAuthController` (login, register, logout, forgotPassword, resetPassword) и три новых маршрута. Login/register переведены на тот же контроллер вместо inline `runProcessor`. Logout идёт через `TokenMiddleware`, чтобы MS3TOKEN/cookie заполнили `$_SESSION` до отзыва токенов. Rate limit forgot-password отдаёт HTTP 429 через `['code' => HttpStatus::TOO_MANY_REQUESTS]` в процессоре.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #422

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Controllers/Api/Web/CustomerAuthController.php   # exit 0
php -l src/Processors/Api/Customer/ForgotPassword.php         # exit 0
php -l config/routes/web.php                                  # exit 0
php tests/CustomerAuthRoutesTest.php                          # exit 0
php tests/OrdersRoutePermissionsTest.php                      # exit 0
php tests/EmailVerificationUrlTest.php                        # exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (router introspection + смежные)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: beta branch
- MODX: n/a (локально без инстанса)
- PHP: 8.2+

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок — Vue не затронут
- [ ] Обновлён CHANGELOG.md — по политике релиза

## Дополнительные заметки

- Новые эндпоинты: `POST /api/v1/customer/logout`, `/forgot-password`, `/reset-password`.
- Связано с #409 (session lifecycle); rate limit на reset-password в процессоре — возможный follow-up.