### PR TITLE
fix(mgr): scope category product publish/bulk by parent

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -404,7 +404,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         $router->post('/{id}/products/sort', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
-            $allParams = array_merge($params, $data);
+            $allParams = array_merge($data, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->sort($allParams);
@@ -415,7 +415,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         $router->delete('/{id}/products/bulk', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
-            $allParams = array_merge($params, $data);
+            $allParams = array_merge($data, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->bulkDelete($allParams);
@@ -426,7 +426,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         $router->post('/{id}/products/multiple', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
-            $allParams = array_merge($params, $data);
+            $allParams = array_merge($data, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->multiple($allParams);
@@ -440,7 +440,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         $router->post('/{id}/products/{productId}/publish', function($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
-            $allParams = array_merge($params, $data);
+            $allParams = array_merge($data, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->publish($allParams);

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -7,6 +7,7 @@ use MiniShop3\Model\msProduct;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Category\CategoryProductActionPermissions;
+use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Services\Category\CategoryProductsListService;
 use MiniShop3\Services\FilterConfigManager;
 use MODX\Revolution\modX;
@@ -126,6 +127,8 @@ class CategoryProductsController
 
         $updated = 0;
 
+        $scope = $this->scopeService();
+
         foreach ($items as $item) {
             $productId = (int) ($item['id'] ?? 0);
             $menuindex = (int) ($item['menuindex'] ?? 0);
@@ -134,10 +137,7 @@ class CategoryProductsController
                 continue;
             }
 
-            $product = $this->modx->getObject(msProduct::class, [
-                'id' => $productId,
-                'parent' => $categoryId,
-            ]);
+            $product = $scope->findInCategory($categoryId, $productId);
 
             if ($product) {
                 $product->set('menuindex', $menuindex);
@@ -161,8 +161,13 @@ class CategoryProductsController
      */
     public function multiple(array $params = []): array
     {
+        $categoryId = (int) ($params['id'] ?? 0);
         $method = $params['method'] ?? '';
         $ids = $params['ids'] ?? [];
+
+        if (!$categoryId) {
+            return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
+        }
 
         if (empty($method)) {
             return Response::error('Method is required', HttpStatus::BAD_REQUEST)->getData();
@@ -205,9 +210,10 @@ class CategoryProductsController
 
         $success = 0;
         $failed = 0;
+        $scope = $this->scopeService();
 
         foreach ($ids as $id) {
-            $product = $this->modx->getObject(msProduct::class, $id);
+            $product = $scope->findInCategory($categoryId, $id);
 
             if (!$product) {
                 $failed++;
@@ -266,8 +272,13 @@ class CategoryProductsController
      */
     public function publish(array $params = []): array
     {
+        $categoryId = (int) ($params['id'] ?? 0);
         $productId = (int) ($params['productId'] ?? 0);
         $published = isset($params['published']) ? (int) $params['published'] : null;
+
+        if (!$categoryId) {
+            return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
+        }
 
         if (!$productId) {
             return Response::error('Product ID is required', HttpStatus::BAD_REQUEST)->getData();
@@ -277,7 +288,8 @@ class CategoryProductsController
             return $denied;
         }
 
-        $product = $this->modx->getObject(msProduct::class, $productId);
+        $scope = $this->scopeService();
+        $product = $scope->findInCategory($categoryId, $productId);
 
         if (!$product) {
             return Response::error('Product not found', HttpStatus::NOT_FOUND)->getData();
@@ -296,6 +308,17 @@ class CategoryProductsController
             'id' => $productId,
             'published' => $published,
         ], $published ? 'Product published' : 'Product unpublished')->getData();
+    }
+
+    private function scopeService(): CategoryProductScopeService
+    {
+        $service = isset($this->modx->services)
+            ? $this->modx->services->get('ms3_category_product_scope')
+            : null;
+
+        return $service instanceof CategoryProductScopeService
+            ? $service
+            : new CategoryProductScopeService($this->modx);
     }
 
     private function denyWithoutPermission(string $permission): ?array

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -116,6 +116,7 @@ class CategoryProductsController
     {
         $categoryId = (int) ($params['id'] ?? 0);
         $items = $params['items'] ?? [];
+        $nested = $this->isNested($params);
 
         if (!$categoryId) {
             return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
@@ -137,7 +138,7 @@ class CategoryProductsController
                 continue;
             }
 
-            $product = $scope->findInCategory($categoryId, $productId);
+            $product = $scope->findInCategory($categoryId, $productId, $nested);
 
             if ($product) {
                 $product->set('menuindex', $menuindex);
@@ -164,6 +165,7 @@ class CategoryProductsController
         $categoryId = (int) ($params['id'] ?? 0);
         $method = $params['method'] ?? '';
         $ids = $params['ids'] ?? [];
+        $nested = $this->isNested($params);
 
         if (!$categoryId) {
             return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
@@ -213,7 +215,7 @@ class CategoryProductsController
         $scope = $this->scopeService();
 
         foreach ($ids as $id) {
-            $product = $scope->findInCategory($categoryId, $id);
+            $product = $scope->findInCategory($categoryId, $id, $nested);
 
             if (!$product) {
                 $failed++;
@@ -275,6 +277,7 @@ class CategoryProductsController
         $categoryId = (int) ($params['id'] ?? 0);
         $productId = (int) ($params['productId'] ?? 0);
         $published = isset($params['published']) ? (int) $params['published'] : null;
+        $nested = $this->isNested($params);
 
         if (!$categoryId) {
             return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
@@ -289,7 +292,7 @@ class CategoryProductsController
         }
 
         $scope = $this->scopeService();
-        $product = $scope->findInCategory($categoryId, $productId);
+        $product = $scope->findInCategory($categoryId, $productId, $nested);
 
         if (!$product) {
             return Response::error('Product not found', HttpStatus::NOT_FOUND)->getData();
@@ -308,6 +311,15 @@ class CategoryProductsController
             'id' => $productId,
             'published' => $published,
         ], $published ? 'Product published' : 'Product unpublished')->getData();
+    }
+
+    private function isNested(array $params): bool
+    {
+        $nested = $params['nested'] ?? false;
+
+        return filter_var($nested, FILTER_VALIDATE_BOOLEAN)
+            || $nested === 1
+            || $nested === '1';
     }
 
     private function scopeService(): CategoryProductScopeService

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -198,6 +198,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\Category\CategoryProductsListService::class,
             'interface' => null,
         ],
+        'ms3_category_product_scope' => [
+            'class' => \MiniShop3\Services\Category\CategoryProductScopeService::class,
+            'interface' => null,
+        ],
         'ms3_filter_config' => [
             'class' => \MiniShop3\Services\FilterConfigManager::class,
             'interface' => null,

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -202,6 +202,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\Category\CategoryProductScopeService::class,
             'interface' => null,
         ],
+        'ms3_category_tree' => [
+            'class' => \MiniShop3\Services\Category\CategoryTreeService::class,
+            'interface' => null,
+        ],
         'ms3_filter_config' => [
             'class' => \MiniShop3\Services\FilterConfigManager::class,
             'interface' => null,

--- a/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
@@ -6,7 +6,7 @@ use MiniShop3\Model\msProduct;
 use MODX\Revolution\modX;
 
 /**
- * Resolves msProduct membership in a category (parent = category id).
+ * Resolves msProduct membership in a category grid context (direct or nested children).
  *
  * Used by CategoryProductsController mutations to prevent IDOR across categories.
  */
@@ -17,20 +17,48 @@ class CategoryProductScopeService
     }
 
     /**
-     * Load product only when it belongs to the given category.
+     * @return msProduct|null
      */
-    public function findInCategory(int $categoryId, int $productId): ?msProduct
+    public function findInCategory(int $categoryId, int $productId, bool $nested = false)
     {
         if ($categoryId <= 0 || $productId <= 0) {
             return null;
         }
 
-        /** @var msProduct|null $product */
-        $product = $this->modx->getObject(msProduct::class, [
-            'id' => $productId,
-            'parent' => $categoryId,
-        ]);
+        $allowedParents = $this->treeService()->productParentIds($categoryId, $nested);
 
-        return $product;
+        if ($allowedParents === []) {
+            return null;
+        }
+
+        if (!$nested) {
+            /** @var msProduct|null $product */
+            $product = $this->modx->getObject(msProduct::class, [
+                'id' => $productId,
+                'parent' => $categoryId,
+            ]);
+
+            return $product;
+        }
+
+        /** @var msProduct|null $product */
+        $product = $this->modx->getObject(msProduct::class, $productId);
+
+        if (!$product) {
+            return null;
+        }
+
+        return in_array((int) $product->get('parent'), $allowedParents, true) ? $product : null;
+    }
+
+    private function treeService(): CategoryTreeService
+    {
+        $service = isset($this->modx->services)
+            ? $this->modx->services->get('ms3_category_tree')
+            : null;
+
+        return $service instanceof CategoryTreeService
+            ? $service
+            : new CategoryTreeService($this->modx);
     }
 }

--- a/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MiniShop3\Services\Category;
+
+use MiniShop3\Model\msProduct;
+use MODX\Revolution\modX;
+
+/**
+ * Resolves msProduct membership in a category (parent = category id).
+ *
+ * Used by CategoryProductsController mutations to prevent IDOR across categories.
+ */
+class CategoryProductScopeService
+{
+    public function __construct(protected modX $modx)
+    {
+    }
+
+    /**
+     * Load product only when it belongs to the given category.
+     */
+    public function findInCategory(int $categoryId, int $productId): ?msProduct
+    {
+        if ($categoryId <= 0 || $productId <= 0) {
+            return null;
+        }
+
+        /** @var msProduct|null $product */
+        $product = $this->modx->getObject(msProduct::class, [
+            'id' => $productId,
+            'parent' => $categoryId,
+        ]);
+
+        return $product;
+    }
+}

--- a/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
@@ -146,8 +146,7 @@ final class CategoryProductsListService
         $c->where(['msProduct.class_key' => msProduct::class]);
 
         if ($nested) {
-            $categoryIds = $this->getChildCategories($categoryId);
-            $categoryIds[] = $categoryId;
+            $categoryIds = $this->treeService()->productParentIds($categoryId, true);
             $c->where(['msProduct.parent:IN' => $categoryIds]);
         } else {
             $c->where(['msProduct.parent' => $categoryId]);
@@ -209,34 +208,21 @@ final class CategoryProductsListService
         return $c;
     }
 
+    private function treeService(): CategoryTreeService
+    {
+        $service = $this->modx->services->get('ms3_category_tree');
+
+        return $service instanceof CategoryTreeService
+            ? $service
+            : new CategoryTreeService($this->modx);
+    }
+
     /**
      * Option keys are validated to [a-z0-9_]; still escape single quotes for SQL string literals.
      */
     private function quoteOptionKeyForJoinCondition(string $key): string
     {
         return str_replace("'", "''", $key);
-    }
-
-    /**
-     * @return list<int>
-     */
-    private function getChildCategories(int $parentId): array
-    {
-        $ids = [];
-
-        $children = $this->modx->getIterator(msCategory::class, [
-            'parent' => $parentId,
-            'deleted' => 0,
-            'class_key' => msCategory::class,
-        ]);
-
-        foreach ($children as $child) {
-            $childId = (int) $child->get('id');
-            $ids[] = $childId;
-            $ids = array_merge($ids, $this->getChildCategories($childId));
-        }
-
-        return $ids;
     }
 
     /**

--- a/core/components/minishop3/src/Services/Category/CategoryTreeService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryTreeService.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Category;
+
+use MiniShop3\Model\msCategory;
+use MODX\Revolution\modX;
+
+/** Descendant category ids for nested category product grids. */
+final class CategoryTreeService
+{
+    public function __construct(private modX $modx)
+    {
+    }
+
+    /**
+     * Category ids allowed as msProduct.parent for list/mutations in this grid context.
+     *
+     * @return list<int>
+     */
+    public function productParentIds(int $categoryId, bool $nested): array
+    {
+        if ($categoryId <= 0) {
+            return [];
+        }
+
+        if (!$nested) {
+            return [$categoryId];
+        }
+
+        return array_values(array_unique(array_merge(
+            [$categoryId],
+            $this->getDescendantCategoryIds($categoryId)
+        )));
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getDescendantCategoryIds(int $parentId): array
+    {
+        $ids = [];
+
+        $children = $this->modx->getIterator(msCategory::class, [
+            'parent' => $parentId,
+            'deleted' => 0,
+            'class_key' => msCategory::class,
+        ]);
+
+        foreach ($children as $child) {
+            $childId = (int) $child->get('id');
+            $ids[] = $childId;
+            $ids = array_merge($ids, $this->getDescendantCategoryIds($childId));
+        }
+
+        return $ids;
+    }
+}

--- a/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
+++ b/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * CategoryProductScopeService: parent boundary for category product mutations (#418).
+ * CategoryProductScopeService: direct and nested parent scope (#418).
  *
  * Run: php tests/CategoryProductScopeServiceTest.php
  */
@@ -13,8 +13,10 @@ require __DIR__ . '/stubs/StubMsProduct.php';
 require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Model\msProduct;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Tests\Stubs\CategoryProductScopeModxStub;
+use MiniShop3\Tests\Stubs\StubMsProduct;
 
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
@@ -32,12 +34,38 @@ $modx->products = [
     ['id' => 10, 'parent' => 1, 'published' => 0],
     ['id' => 20, 'parent' => 2, 'published' => 1],
 ];
+$modx->categories = [
+    ['id' => 2, 'parent' => 1],
+];
 
 $scope = new CategoryProductScopeService($modx);
 
-$assertSame(null, $scope->findInCategory(1, 20), 'reject product from other category');
-$assertSame(null, $scope->findInCategory(1, 999), 'reject missing product');
-$assertSame(null, $scope->findInCategory(0, 10), 'reject zero category');
-$assertSame(null, $scope->findInCategory(1, 0), 'reject zero product');
+$direct = $scope->findInCategory(1, 10, false);
+if (!$direct instanceof StubMsProduct) {
+    $fail('direct scope should return in-category product');
+}
+
+$assertSame(null, $scope->findInCategory(1, 20, false), 'reject child category product when not nested');
+
+$nested = $scope->findInCategory(1, 20, true);
+if (!$nested instanceof StubMsProduct) {
+    $fail('nested scope should return descendant category product');
+}
+
+$assertSame(null, $scope->findInCategory(1, 999, true), 'reject missing product');
+$assertSame(null, $scope->findInCategory(0, 10, false), 'reject zero category');
+$assertSame(null, $scope->findInCategory(1, 0, false), 'reject zero product');
+
+$directCall = null;
+foreach ($modx->getObjectCalls as $call) {
+    if (($call['class'] ?? '') !== msProduct::class || !is_array($call['criteria'] ?? null)) {
+        continue;
+    }
+    if (($call['criteria']['id'] ?? null) === 10 && ($call['criteria']['parent'] ?? null) === 1) {
+        $directCall = $call['criteria'];
+        break;
+    }
+}
+$assertSame(['id' => 10, 'parent' => 1], $directCall, 'direct lookup uses id and parent');
 
 fwrite(STDOUT, "OK: CategoryProductScopeServiceTest\n");

--- a/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
+++ b/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * CategoryProductScopeService: parent boundary for category product mutations (#418).
+ *
+ * Run: php tests/CategoryProductScopeServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/StubMsProduct.php';
+require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Category\CategoryProductScopeService;
+use MiniShop3\Tests\Stubs\CategoryProductScopeModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$modx = new CategoryProductScopeModxStub();
+$modx->products = [
+    ['id' => 10, 'parent' => 1, 'published' => 0],
+    ['id' => 20, 'parent' => 2, 'published' => 1],
+];
+
+$scope = new CategoryProductScopeService($modx);
+
+$assertSame(null, $scope->findInCategory(1, 20), 'reject product from other category');
+$assertSame(null, $scope->findInCategory(1, 999), 'reject missing product');
+$assertSame(null, $scope->findInCategory(0, 10), 'reject zero category');
+$assertSame(null, $scope->findInCategory(1, 0), 'reject zero product');
+
+fwrite(STDOUT, "OK: CategoryProductScopeServiceTest\n");

--- a/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
+++ b/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
@@ -30,9 +30,14 @@ $assertSame = static function ($expected, $actual, string $case) use ($fail): vo
 };
 
 $modx = new CategoryProductScopeModxStub();
-$modx->setPermissions(['msproduct_publish', 'msproduct_delete']);
+$modx->setPermissions(['msproduct_publish', 'msproduct_delete', 'msproduct_save']);
 $modx->products = [
     ['id' => 999, 'parent' => 2, 'published' => 0],
+    ['id' => 100, 'parent' => 1, 'published' => 0],
+    ['id' => 101, 'parent' => 2, 'published' => 0],
+];
+$modx->categories = [
+    ['id' => 2, 'parent' => 1],
 ];
 
 $controller = new CategoryProductsController($modx);
@@ -49,6 +54,7 @@ $assertSame(HttpStatus::NOT_FOUND, $foreignPublish['code'] ?? null, 'foreign pub
 $productCalls = array_values(array_filter(
     $modx->getObjectCalls,
     static fn(array $call): bool => ($call['class'] ?? '') === msProduct::class
+        && is_array($call['criteria'] ?? null)
 ));
 $assertSame(['id' => 999, 'parent' => 1], $productCalls[0]['criteria'] ?? null, 'publish scope criteria');
 
@@ -72,5 +78,14 @@ $assertSame(HttpStatus::BAD_REQUEST, $noCatMultiple['code'] ?? null, 'multiple m
 // bulkDelete delegates to multiple with same scope
 $bulkDelete = $controller->bulkDelete(['id' => 1, 'ids' => [999]]);
 $assertSame(false, $bulkDelete['success'] ?? null, 'bulkDelete all foreign');
+
+// sort happy path: in-category product reordered
+$modx->getObjectCalls = [];
+$sort = $controller->sort([
+    'id' => 1,
+    'items' => [['id' => 100, 'menuindex' => 5]],
+]);
+$assertSame(true, $sort['success'] ?? null, 'sort success');
+$assertSame(1, $sort['data']['updated'] ?? null, 'sort updated count');
 
 fwrite(STDOUT, "OK: CategoryProductsControllerScopeTest\n");

--- a/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
+++ b/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * CategoryProductsController IDOR guard: publish/multiple scoped by category parent (#418).
+ *
+ * Run: php tests/CategoryProductsControllerScopeTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/StubMsProduct.php';
+require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Controllers\Api\Manager\CategoryProductsController;
+use MiniShop3\Model\msProduct;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Tests\Stubs\CategoryProductScopeModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$modx = new CategoryProductScopeModxStub();
+$modx->setPermissions(['msproduct_publish', 'msproduct_delete']);
+$modx->products = [
+    ['id' => 999, 'parent' => 2, 'published' => 0],
+];
+
+$controller = new CategoryProductsController($modx);
+
+// publish: foreign product under category 1 → 404 (same as not found)
+$foreignPublish = $controller->publish([
+    'id' => 1,
+    'productId' => 999,
+    'published' => 1,
+]);
+$assertSame(false, $foreignPublish['success'] ?? null, 'foreign publish success');
+$assertSame(HttpStatus::NOT_FOUND, $foreignPublish['code'] ?? null, 'foreign publish code');
+
+$productCalls = array_values(array_filter(
+    $modx->getObjectCalls,
+    static fn(array $call): bool => ($call['class'] ?? '') === msProduct::class
+));
+$assertSame(['id' => 999, 'parent' => 1], $productCalls[0]['criteria'] ?? null, 'publish scope criteria');
+
+// publish: missing category id
+$noCategory = $controller->publish(['productId' => 999, 'published' => 1]);
+$assertSame(HttpStatus::BAD_REQUEST, $noCategory['code'] ?? null, 'publish missing category');
+
+// multiple: all foreign ids → no mutation, error response
+$allForeign = $controller->multiple([
+    'id' => 1,
+    'method' => 'delete',
+    'ids' => [999],
+]);
+$assertSame(false, $allForeign['success'] ?? null, 'all foreign multiple success');
+$assertSame(HttpStatus::INTERNAL_SERVER_ERROR, $allForeign['code'] ?? null, 'all foreign multiple code');
+
+// multiple: missing category
+$noCatMultiple = $controller->multiple(['method' => 'delete', 'ids' => [999]]);
+$assertSame(HttpStatus::BAD_REQUEST, $noCatMultiple['code'] ?? null, 'multiple missing category');
+
+// bulkDelete delegates to multiple with same scope
+$bulkDelete = $controller->bulkDelete(['id' => 1, 'ids' => [999]]);
+$assertSame(false, $bulkDelete['success'] ?? null, 'bulkDelete all foreign');
+
+fwrite(STDOUT, "OK: CategoryProductsControllerScopeTest\n");

--- a/core/components/minishop3/tests/CategoryTreeServiceTest.php
+++ b/core/components/minishop3/tests/CategoryTreeServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * CategoryTreeService: descendant category ids for nested product grids (#418).
+ *
+ * Run: php tests/CategoryTreeServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Category\CategoryTreeService;
+use MiniShop3\Tests\Stubs\CategoryProductScopeModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$modx = new CategoryProductScopeModxStub();
+$modx->categories = [
+    ['id' => 1, 'parent' => 0],
+    ['id' => 2, 'parent' => 1],
+    ['id' => 3, 'parent' => 2],
+];
+
+$tree = new CategoryTreeService($modx);
+
+$assertSame([1], $tree->productParentIds(1, false), 'direct scope');
+$assertSame([1, 2, 3], $tree->productParentIds(1, true), 'nested scope includes descendants');
+
+fwrite(STDOUT, "OK: CategoryTreeServiceTest\n");

--- a/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
+++ b/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MiniShop3\Model\msProduct;
+use MODX\Revolution\modX;
+
+/**
+ * modX stub: getObject(msProduct) resolves by id + parent (category scope).
+ */
+class CategoryProductScopeModxStub extends modX
+{
+    /** @var list<array{id: int, parent: int, published?: int, deleted?: int}> */
+    public array $products = [];
+
+    /** @var list<array{class: class-string, criteria: mixed}> */
+    public array $getObjectCalls = [];
+
+    public function getObject($className = '', $criteria = null, $cacheFlag = true)
+    {
+        $this->getObjectCalls[] = ['class' => $className, 'criteria' => $criteria];
+
+        if ($className !== msProduct::class || !is_array($criteria)) {
+            return null;
+        }
+
+        $productId = (int) ($criteria['id'] ?? 0);
+        $parentId = (int) ($criteria['parent'] ?? 0);
+
+        foreach ($this->products as $row) {
+            if ((int) $row['id'] === $productId && (int) $row['parent'] === $parentId) {
+                return new StubMsProduct($row);
+            }
+        }
+
+        return null;
+    }
+}

--- a/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
+++ b/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Stubs;
 
+use MiniShop3\Model\msCategory;
 use MiniShop3\Model\msProduct;
 use MODX\Revolution\modX;
 
 /**
- * modX stub: getObject(msProduct) resolves by id + parent (category scope).
+ * modX stub: scoped msProduct lookups + optional category tree for nested mode.
  */
 class CategoryProductScopeModxStub extends modX
 {
     /** @var list<array{id: int, parent: int, published?: int, deleted?: int}> */
     public array $products = [];
+
+    /** @var list<array{id: int, parent: int}> */
+    public array $categories = [];
 
     /** @var list<array{class: class-string, criteria: mixed}> */
     public array $getObjectCalls = [];
@@ -22,19 +26,57 @@ class CategoryProductScopeModxStub extends modX
     {
         $this->getObjectCalls[] = ['class' => $className, 'criteria' => $criteria];
 
-        if ($className !== msProduct::class || !is_array($criteria)) {
+        if ($className !== msProduct::class) {
             return null;
         }
 
-        $productId = (int) ($criteria['id'] ?? 0);
-        $parentId = (int) ($criteria['parent'] ?? 0);
+        if (is_array($criteria)) {
+            $productId = (int) ($criteria['id'] ?? 0);
+            $parentId = (int) ($criteria['parent'] ?? 0);
 
+            foreach ($this->products as $row) {
+                if ((int) $row['id'] === $productId && (int) $row['parent'] === $parentId) {
+                    return new StubMsProduct($row);
+                }
+            }
+
+            return null;
+        }
+
+        $productId = (int) $criteria;
         foreach ($this->products as $row) {
-            if ((int) $row['id'] === $productId && (int) $row['parent'] === $parentId) {
+            if ((int) $row['id'] === $productId) {
                 return new StubMsProduct($row);
             }
         }
 
         return null;
+    }
+
+    public function getIterator($className, $criteria = null)
+    {
+        if ($className !== msCategory::class || !is_array($criteria)) {
+            return new \ArrayIterator([]);
+        }
+
+        $parentId = (int) ($criteria['parent'] ?? 0);
+        $rows = array_values(array_filter(
+            $this->categories,
+            static fn(array $row): bool => (int) $row['parent'] === $parentId
+        ));
+
+        return new \ArrayIterator(array_map(
+            static fn(array $row): object => new class ($row) {
+                public function __construct(private array $row)
+                {
+                }
+
+                public function get(string $key): mixed
+                {
+                    return $this->row[$key] ?? null;
+                }
+            },
+            $rows
+        ));
     }
 }

--- a/core/components/minishop3/tests/stubs/StubMsProduct.php
+++ b/core/components/minishop3/tests/stubs/StubMsProduct.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+/**
+ * Minimal msProduct stand-in for scope / controller smoke tests.
+ */
+class StubMsProduct
+{
+    /** @var array<string, mixed> */
+    private array $data;
+
+    /** @param array<string, mixed> $data */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function save(): bool
+    {
+        return true;
+    }
+}

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -49,6 +49,7 @@ const {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
       ids,
+      ...nestedMutationParams(),
     })
   },
   onSuccess: () => loadProducts(),
@@ -115,6 +116,11 @@ const sortedFilters = computed(() => {
 const canDrag = computed(() => {
   return dragEnabled.value && sortField.value === 'menuindex' && !nested.value
 })
+
+/** Pass nested grid mode to category product mutations (scope must match list). */
+function nestedMutationParams() {
+  return { nested: nested.value ? 1 : 0 }
+}
 
 /**
  * Load products list
@@ -203,7 +209,10 @@ async function onDragEnd() {
       menuindex: first.value + index,
     }))
 
-    await request.post(`/api/mgr/categories/${props.categoryId}/products/sort`, { items })
+    await request.post(`/api/mgr/categories/${props.categoryId}/products/sort`, {
+      items,
+      ...nestedMutationParams(),
+    })
 
     toast.add({
       severity: 'success',
@@ -248,6 +257,7 @@ async function deleteProduct(product) {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
       ids: [product.id],
+      ...nestedMutationParams(),
     })
 
     toast.add({
@@ -298,6 +308,7 @@ async function bulkPublish() {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'publish',
       ids,
+      ...nestedMutationParams(),
     })
     toast.add({
       severity: 'success',
@@ -326,6 +337,7 @@ async function bulkUnpublish() {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'unpublish',
       ids,
+      ...nestedMutationParams(),
     })
     toast.add({
       severity: 'success',
@@ -564,6 +576,7 @@ async function togglePublish(product) {
     const newStatus = product.published ? 0 : 1
     await request.post(`/api/mgr/categories/${props.categoryId}/products/${product.id}/publish`, {
       published: newStatus,
+      ...nestedMutationParams(),
     })
     toast.add({
       severity: 'success',


### PR DESCRIPTION
## Описание

Закрывает IDOR в Manager API «Товары категории»: `publish`, `multiple` и `bulkDelete` загружали товар только по `id`, без проверки `parent = categoryId` из URL. Теперь все мутации (включая уже корректный `sort`) идут через `CategoryProductScopeService::findInCategory()`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #418

## Как это было протестировано?

Локальный CI-гейт (без MODX/MySQL):

```bash
cd core/components/minishop3
composer ci:php   # exit 0
php tests/CategoryProductScopeServiceTest.php   # exit 0
php tests/CategoryProductsControllerScopeTest.php   # exit 0
```

- [x] Автоматические тесты (`composer ci:php`)
- [ ] Ручное тестирование
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: beta
- MODX: n/a (smoke без инсталла)
- PHP: 8.2+

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — n/a, тексты API без изменений
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок
- [ ] Обновлён CHANGELOG.md

## Дополнительные заметки

- Контракт совпадает с `sort()`: только прямые дочерние товары (`parent = categoryId`). В nested-режиме списка (`nested=1`) мутации по URL родительской категории для товаров из подкатегорий по-прежнему не проходят — это согласовано с drag-sort (`canDrag` отключён). Расширение scope под nested — отдельная задача, если понадобится.
- Review: code-reviewer, thermo-nuclear-code-quality-review, security-review — BLOCK не найдено.