### PR TITLE
refactor(vueManager): parallelize option field values load in OrderView

### DIFF
--- a/vueManager/src/components/OrderView.vue
+++ b/vueManager/src/components/OrderView.vue
@@ -541,6 +541,8 @@ async function initOptionsFromProduct(options) {
 
   // Convert to table format with type detection
   const tableData = []
+  const fieldRowsToLoad = []
+
   for (const [key, value] of Object.entries(parsed)) {
     const isProductField = productOptionFields.value.some(f => f.name === key)
     const row = {
@@ -552,13 +554,14 @@ async function initOptionsFromProduct(options) {
       loadingValues: false,
     }
 
-    // If it's a product field, load its values
     if (isProductField) {
-      await loadFieldValuesForRow(row)
+      fieldRowsToLoad.push(row)
     }
 
     tableData.push(row)
   }
+
+  await Promise.all(fieldRowsToLoad.map(row => loadFieldValuesForRow(row)))
 
   optionsTableData.value = tableData
 


### PR DESCRIPTION
## Описание

В `initOptionsFromProduct` загрузка значений product option fields выполнялась последовательно: N полей давали N последовательных запросов к `/api/mgr/references/product-field-values`. Теперь строки сначала собираются в `fieldRowsToLoad`, затем значения подгружаются параллельно через `Promise.all`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #359

## Как это было протестировано?

Локальный гейт:

```bash
cd vueManager && npx eslint src/components/OrderView.vue
# exit 0
```

- [x] Ручное тестирование — не выполнялось (требуется MODX + заказ с product option fields)
- [x] Автоматические тесты (`npm run lint:ci` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-359-promise-all-field-values`
- MODX: n/a
- PHP: n/a

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет) — PHP не затронут
- [x] ESLint проходит без ошибок (`npx eslint src/components/OrderView.vue`)
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике проекта, только при релизе

## Дополнительные заметки

- `loadFieldValuesForRow` по-прежнему обрабатывает ошибки внутри; один неудачный запрос не прерывает остальные.
- `optionsTableData` присваивается после завершения всех загрузок — порядок строк в таблице сохранён.
- Одиночные вызовы `loadFieldValuesForRow` в `onOptionTypeChange` / `onFieldKeyChange` не менялись (не batch-сценарий).