### PR TITLE
fix(order): align finalize cost with ManagerOrderCostRecalculator

### DIFF
--- a/core/components/minishop3/lexicon/en/default.inc.php
+++ b/core/components/minishop3/lexicon/en/default.inc.php
@@ -231,3 +231,5 @@ $_lang['ms3_vuetools_required'] = 'VueTools package is required for MiniShop3. P
 $_lang['ms3_mgr_order_recalc_invalid_mode'] = 'Invalid order cost recalculation mode.';
 $_lang['ms3_mgr_order_recalc_manual_delivery_missing'] = 'Manual delivery cost (manual_delivery_cost) is required in manual mode.';
 $_lang['ms3_order_cost_recalc_success'] = 'Order cost recalculated';
+$_lang['ms3_order_finalize_cost_recalc_required'] =
+    'Recalculate order cost before finalizing: the selected delivery or payment requires manual cost or force_provider mode.';

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -770,6 +770,8 @@ $_lang['ms3_order_finalize_confirm'] = 'Confirm Order Finalization';
 $_lang['ms3_order_finalize_confirm_desc'] = 'After finalization, the order will receive a number, status will change to "New", and notifications will be sent.';
 $_lang['ms3_order_finalized'] = 'Order successfully finalized';
 $_lang['ms3_order_finalize_error'] = 'Error finalizing order';
+$_lang['ms3_order_finalize_cost_recalc_required'] =
+    'Recalculate order cost before finalizing: the selected delivery or payment requires manual cost or force_provider mode.';
 $_lang['ms3_order_is_draft'] = 'Draft';
 $_lang['ms3_order_err_validation'] = 'Order data validation error';
 $_lang['ms3_order_err_products'] = 'Order has no products';

--- a/core/components/minishop3/lexicon/ru/default.inc.php
+++ b/core/components/minishop3/lexicon/ru/default.inc.php
@@ -231,3 +231,5 @@ $_lang['ms3_vuetools_required'] = 'Для работы MiniShop3 требует�
 $_lang['ms3_mgr_order_recalc_invalid_mode'] = 'Недопустимый режим пересчёта стоимости заказа.';
 $_lang['ms3_mgr_order_recalc_manual_delivery_missing'] = 'В режиме manual обязательно укажите manual_delivery_cost (стоимость доставки).';
 $_lang['ms3_order_cost_recalc_success'] = 'Стоимость заказа пересчитана';
+$_lang['ms3_order_finalize_cost_recalc_required'] =
+    'Перед оформлением пересчитайте стоимость заказа: для выбранных доставки или оплаты нужен ручной расчёт или force_provider.';

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -769,6 +769,8 @@ $_lang['ms3_order_finalize_confirm'] = 'Подтверждение оформл�
 $_lang['ms3_order_finalize_confirm_desc'] = 'После оформления заказ получит номер, статус изменится на «Новый», и будут отправлены уведомления.';
 $_lang['ms3_order_finalized'] = 'Заказ успешно оформлен';
 $_lang['ms3_order_finalize_error'] = 'Ошибка при оформлении заказа';
+$_lang['ms3_order_finalize_cost_recalc_required'] =
+    'Перед оформлением пересчитайте стоимость заказа: для выбранных доставки или оплаты нужен ручной расчёт или force_provider.';
 $_lang['ms3_order_is_draft'] = 'Черновик';
 $_lang['ms3_order_err_validation'] = 'Ошибка валидации данных заказа';
 $_lang['ms3_order_err_products'] = 'В заказе нет товаров';

--- a/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
@@ -14,13 +14,16 @@ use MiniShop3\Model\msPayment;
 use MODX\Revolution\modX;
 
 /**
- * Explicit manager-side recomputation of order totals from persisted msOrderProducts
- * and configured delivery/payment methods (without mutating unrelated order fields).
+ * Recomputation of order totals from persisted msOrderProducts and configured delivery/payment.
+ *
+ * Used by manager «Пересчитать стоимость» ({@see calculateBreakdown()} / {@see recalculate()})
+ * and draft finalize ({@see OrderFinalizeService}).
  *
  * External delivery/payment provider classes are not invoked in {@see self::MODE_AUTO};
  * callers should use manual delivery cost or {@see self::MODE_FORCE_PROVIDER}.
  *
  * Payment commission is reflected only in aggregated {@see msOrder cost}, not stored in a column.
+ * Default handler math lives in {@see OrderPersistedCostRules}.
  */
 class ManagerOrderCostRecalculator
 {
@@ -349,14 +352,7 @@ class ManagerOrderCostRecalculator
 
     protected function calculateDefaultDeliveryCost(msDelivery $delivery, float $cartCost, float $orderWeight): float
     {
-        $freeDeliveryAmount = (float)$delivery->get('free_delivery_amount');
-
-        if ($freeDeliveryAmount > 0 && $cartCost >= $freeDeliveryAmount) {
-            return 0.0;
-        }
-
-        $deliveryCost = 0.0;
-        $weightPrice = (float)$delivery->get('weight_price');
+        $weightPrice = (float) $delivery->get('weight_price');
         if ($weightPrice < 0) {
             $this->modx->log(
                 modX::LOG_LEVEL_ERROR,
@@ -364,17 +360,10 @@ class ManagerOrderCostRecalculator
                     'id'
                 ) . ': ' . $weightPrice,
             );
-            $weightPrice = 0;
         }
-
-        $deliveryCost += $weightPrice * $orderWeight;
 
         $addPrice = $delivery->get('price');
-        if (empty($addPrice)) {
-            return round($deliveryCost, 6);
-        }
-
-        if (PriceAdjustment::isPercent($addPrice)) {
+        if (!empty($addPrice) && PriceAdjustment::isPercent($addPrice)) {
             $percent = PriceAdjustment::getPercent($addPrice);
             if (!PriceAdjustment::isAllowedPercent($percent)) {
                 $this->modx->log(
@@ -385,12 +374,16 @@ class ManagerOrderCostRecalculator
                         $percent
                     )
                 );
-
-                return round($deliveryCost, 6);
             }
         }
 
-        return round($deliveryCost + PriceAdjustment::calculate($cartCost, $addPrice), 6);
+        return OrderPersistedCostRules::calculateDefaultDeliveryCost(
+            (float) $delivery->get('free_delivery_amount'),
+            $weightPrice,
+            $addPrice,
+            $cartCost,
+            $orderWeight
+        );
     }
 
     /**
@@ -399,11 +392,7 @@ class ManagerOrderCostRecalculator
     protected function calculateDefaultPaymentCommission(msPayment $payment, float $baseCost): float
     {
         $addPrice = $payment->get('price');
-        if (empty($addPrice)) {
-            return 0.0;
-        }
-
-        if (PriceAdjustment::isPercent($addPrice)) {
+        if (!empty($addPrice) && PriceAdjustment::isPercent($addPrice)) {
             $percent = PriceAdjustment::getPercent($addPrice);
             if (!PriceAdjustment::isAllowedPercent($percent)) {
                 $this->modx->log(
@@ -414,12 +403,10 @@ class ManagerOrderCostRecalculator
                         $percent
                     )
                 );
-
-                return 0.0;
             }
         }
 
-        return round(PriceAdjustment::calculate($baseCost, $addPrice), 6);
+        return OrderPersistedCostRules::calculateDefaultPaymentCommission($addPrice, $baseCost);
     }
 
     protected function isSimpleDelivery(msDelivery $delivery): bool

--- a/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
@@ -56,18 +56,16 @@ class ManagerOrderCostRecalculator
     }
 
     /**
+     * Compute cost breakdown without persisting the order.
+     *
+     * Shared by manager recalculate and draft finalize so both paths use the same rules.
+     *
      * @param array<string, mixed> $options
      * @return array{success: bool, message?: string, data?: array}
      */
-    public function recalculate(msOrder $order, array $options = []): array
+    public function calculateBreakdown(msOrder $order, array $options = []): array
     {
         $mode = (string) ($options['mode'] ?? self::MODE_AUTO);
-
-        $totals = $this->calculateProductTotals($order);
-        $cartCost = $totals['cart_cost'];
-        $orderWeight = $totals['weight'];
-
-        $warnings = [];
 
         if ($mode !== self::MODE_AUTO && $mode !== self::MODE_MANUAL && $mode !== self::MODE_FORCE_PROVIDER) {
             return $this->ms3->utils->error('ms3_mgr_order_recalc_invalid_mode');
@@ -77,6 +75,12 @@ class ManagerOrderCostRecalculator
             return $this->ms3->utils->error('ms3_mgr_order_recalc_manual_delivery_missing');
         }
 
+        $totals = $this->calculateProductTotals($order);
+        $cartCost = $totals['cart_cost'];
+        $orderWeight = $totals['weight'];
+
+        $warnings = [];
+
         $prevDeliveryCost = round((float) $order->get('delivery_cost'), 6);
         $deliveryResult = $this->resolveDeliveryCost($order, $cartCost, $orderWeight, $prevDeliveryCost, $mode, $options);
         if (!$deliveryResult['success']) {
@@ -84,7 +88,6 @@ class ManagerOrderCostRecalculator
         }
 
         $warnings = array_merge($warnings, $deliveryResult['warnings']);
-
         $deliveryCost = $deliveryResult['delivery_cost'];
 
         $paymentBase = OrderService::paymentCommissionBase($cartCost);
@@ -94,12 +97,42 @@ class ManagerOrderCostRecalculator
         }
 
         $warnings = array_merge($warnings, $paymentResult['warnings']);
-
         $paymentFee = $paymentResult['payment_fee'];
 
         /** @var OrderService $orderService */
         $orderService = $this->modx->services->get('ms3_order_service');
         $cost = round($orderService->clampComputedTotal($order, $cartCost, $deliveryCost, $paymentFee), 6);
+
+        return $this->ms3->utils->success('', [
+            'breakdown' => [
+                'cart_cost' => $cartCost,
+                'weight' => $orderWeight,
+                'delivery_cost' => $deliveryCost,
+                'payment_cost' => $paymentFee,
+                'cost' => $cost,
+            ],
+            'warnings' => $warnings,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array{success: bool, message?: string, data?: array}
+     */
+    public function recalculate(msOrder $order, array $options = []): array
+    {
+        $result = $this->calculateBreakdown($order, $options);
+        if (!$result['success']) {
+            return $result;
+        }
+
+        $breakdown = $result['data']['breakdown'];
+        $warnings = $result['data']['warnings'];
+        $cartCost = $breakdown['cart_cost'];
+        $orderWeight = $breakdown['weight'];
+        $deliveryCost = $breakdown['delivery_cost'];
+        $paymentFee = $breakdown['payment_cost'];
+        $cost = $breakdown['cost'];
 
         $before = [
             'cart_cost' => (float)$order->get('cart_cost'),

--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -108,8 +108,6 @@ class OrderFinalizeService
             return $costResult;
         }
 
-        $costWarnings = $costResult['data']['warnings'] ?? [];
-
         // Persist costs; allocate num under GET_LOCK when still empty (#380)
         $order->set('updatedon', time());
         $order->set('cost', $costResult['data']['total_cost']);
@@ -194,7 +192,6 @@ class OrderFinalizeService
             'order_id' => $order->get('id'),
             'order_num' => $order->get('num'),
             'status_id' => $order->get('status_id'),
-            'cost_warnings' => $costWarnings,
         ]);
     }
 
@@ -424,6 +421,10 @@ class OrderFinalizeService
                 . ': '
                 . implode(', ', $warnings)
             );
+
+            return $this->error('ms3_order_finalize_cost_recalc_required', [
+                'warnings' => $warnings,
+            ]);
         }
 
         $order->set('weight', $breakdown['weight']);
@@ -433,7 +434,6 @@ class OrderFinalizeService
             'delivery_cost' => $breakdown['delivery_cost'],
             'total_cost' => $breakdown['cost'],
             'weight' => $breakdown['weight'],
-            'warnings' => $warnings,
         ]);
     }
 

--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -108,11 +108,14 @@ class OrderFinalizeService
             return $costResult;
         }
 
+        $costWarnings = $costResult['data']['warnings'] ?? [];
+
         // Persist costs; allocate num under GET_LOCK when still empty (#380)
         $order->set('updatedon', time());
         $order->set('cost', $costResult['data']['total_cost']);
         $order->set('cart_cost', $costResult['data']['cart_cost']);
         $order->set('delivery_cost', $costResult['data']['delivery_cost']);
+        $order->set('weight', $costResult['data']['weight']);
 
         try {
             if (empty($order->get('num'))) {
@@ -191,6 +194,7 @@ class OrderFinalizeService
             'order_id' => $order->get('id'),
             'order_num' => $order->get('num'),
             'status_id' => $order->get('status_id'),
+            'cost_warnings' => $costWarnings,
         ]);
     }
 
@@ -402,44 +406,34 @@ class OrderFinalizeService
      */
     protected function calculateCosts(msOrder $order): array
     {
-        $products = $this->modx->getIterator(msOrderProduct::class, [
-            'order_id' => $order->get('id'),
-        ]);
-        $totals = OrderService::aggregateProductsTotals($products);
-        $cartCost = $totals['cart_cost'];
-        $weight = $totals['weight'];
+        $recalculator = new ManagerOrderCostRecalculator($this->modx, $this->ms3);
+        $result = $recalculator->calculateBreakdown($order);
 
-        // Calculate delivery cost
-        $deliveryCost = 0;
-        $deliveryId = (int) $order->get('delivery_id');
-
-        if ($deliveryId > 0) {
-            /** @var msDelivery $delivery */
-            $delivery = $this->modx->getObject(msDelivery::class, $deliveryId);
-            if ($delivery) {
-                // Use delivery's getCost method if available, otherwise use fixed price
-                $deliveryCost = (float) $delivery->get('price');
-
-                // Check for weight-based pricing
-                $weightPrice = (float) $delivery->get('weight_price');
-                if ($weightPrice > 0 && $weight > 0) {
-                    $deliveryCost += $weight * $weightPrice;
-                }
-            }
+        if (!$result['success']) {
+            return $result;
         }
 
-        // Update order weight
-        $order->set('weight', $weight);
+        $breakdown = $result['data']['breakdown'];
+        $warnings = $result['data']['warnings'] ?? [];
 
-        /** @var OrderService $orderService */
-        $orderService = $this->modx->services->get('ms3_order_service');
-        $totalCost = $orderService->clampComputedTotal($order, (float) $cartCost, (float) $deliveryCost, 0.0);
+        if ($warnings !== []) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[OrderFinalizeService] Cost calculation warnings for order #'
+                . $order->get('id')
+                . ': '
+                . implode(', ', $warnings)
+            );
+        }
+
+        $order->set('weight', $breakdown['weight']);
 
         return $this->success('', [
-            'cart_cost' => $cartCost,
-            'delivery_cost' => $deliveryCost,
-            'total_cost' => $totalCost,
-            'weight' => $weight,
+            'cart_cost' => $breakdown['cart_cost'],
+            'delivery_cost' => $breakdown['delivery_cost'],
+            'total_cost' => $breakdown['cost'],
+            'weight' => $breakdown['weight'],
+            'warnings' => $warnings,
         ]);
     }
 

--- a/core/components/minishop3/src/Services/Order/OrderPersistedCostRules.php
+++ b/core/components/minishop3/src/Services/Order/OrderPersistedCostRules.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace MiniShop3\Services\Order;
+
+use MiniShop3\Utils\PriceAdjustment;
+
+/**
+ * Pure cost rules for orders built from persisted msOrderProducts (manager recalculate, draft finalize).
+ *
+ * Shared by {@see ManagerOrderCostRecalculator} and smoke tests; no MODX I/O.
+ */
+final class OrderPersistedCostRules
+{
+    public static function calculateDefaultDeliveryCost(
+        float $freeDeliveryAmount,
+        float $weightPrice,
+        mixed $addPrice,
+        float $cartCost,
+        float $orderWeight
+    ): float {
+        if ($freeDeliveryAmount > 0 && $cartCost >= $freeDeliveryAmount) {
+            return 0.0;
+        }
+
+        if ($weightPrice < 0) {
+            $weightPrice = 0.0;
+        }
+
+        $deliveryCost = $weightPrice * $orderWeight;
+
+        if (empty($addPrice)) {
+            return round($deliveryCost, 6);
+        }
+
+        if (PriceAdjustment::isPercent($addPrice)) {
+            $percent = PriceAdjustment::getPercent($addPrice);
+            if (!PriceAdjustment::isAllowedPercent($percent)) {
+                return round($deliveryCost, 6);
+            }
+        }
+
+        return round($deliveryCost + PriceAdjustment::calculate($cartCost, $addPrice), 6);
+    }
+
+    /**
+     * Surcharge only (excluding base), aligned with {@see \MiniShop3\Controllers\Payment\Payment::getCost()}.
+     */
+    public static function calculateDefaultPaymentCommission(mixed $addPrice, float $baseCost): float
+    {
+        if (empty($addPrice)) {
+            return 0.0;
+        }
+
+        if (PriceAdjustment::isPercent($addPrice)) {
+            $percent = PriceAdjustment::getPercent($addPrice);
+            if (!PriceAdjustment::isAllowedPercent($percent)) {
+                return 0.0;
+            }
+        }
+
+        return round(PriceAdjustment::calculate($baseCost, $addPrice), 6);
+    }
+}

--- a/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
@@ -95,17 +95,15 @@ final class OrderFinalizeServiceTest extends TestCase
             },
         ];
 
-        $delivery = new class extends msDelivery {
-            public function get($k)
-            {
-                return match ($k) {
-                    'price' => 50.0,
-                    'weight_price' => 10.0,
-                    'active' => 1,
-                    default => null,
-                };
-            }
-        };
+        $delivery = $this->createStub(msDelivery::class);
+        $delivery->method('get')->willReturnCallback(static function (string $k) {
+            return match ($k) {
+                'price' => 50.0,
+                'weight_price' => 10.0,
+                'active' => 1,
+                default => null,
+            };
+        });
 
         $statusCalls = [];
         $service = $this->makeService(

--- a/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
@@ -95,7 +95,7 @@ final class OrderFinalizeServiceTest extends TestCase
             },
         ];
 
-        $delivery = new class extends xPDOSimpleObject {
+        $delivery = new class extends msDelivery {
             public function get($k)
             {
                 return match ($k) {
@@ -255,7 +255,7 @@ final class OrderFinalizeServiceTest extends TestCase
                 }
 
                 if ($className === msPayment::class) {
-                    return new class extends xPDOSimpleObject {
+                    return new class extends msDelivery {
                         public function get($k)
                         {
                             return $k === 'active' ? 1 : null;

--- a/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
@@ -187,7 +187,12 @@ final class OrderFinalizeServiceTest extends TestCase
             }
         };
 
-        $modx = new class ($orders, $productCount, $products, $delivery, $orderService, $statusService) extends modX {
+        $payment = $this->createStub(msPayment::class);
+        $payment->method('get')->willReturnCallback(static function (string $k) {
+            return $k === 'active' ? 1 : null;
+        });
+
+        $modx = new class ($orders, $productCount, $products, $delivery, $payment, $orderService, $statusService) extends modX {
 
             /**
              * @param array<int, RecordingMsOrder> $orders
@@ -198,6 +203,7 @@ final class OrderFinalizeServiceTest extends TestCase
                 private int $productCount,
                 private array $products,
                 private ?object $delivery,
+                private object $payment,
                 OrderService $orderService,
                 object $statusService,
             ) {
@@ -253,12 +259,7 @@ final class OrderFinalizeServiceTest extends TestCase
                 }
 
                 if ($className === msPayment::class) {
-                    return new class extends msDelivery {
-                        public function get($k)
-                        {
-                            return $k === 'active' ? 1 : null;
-                        }
-                    };
+                    return $this->payment;
                 }
 
                 return null;

--- a/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
+++ b/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
@@ -60,7 +60,7 @@ $assertSame(
 $assertSame(
     33.0,
     OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1100),
-    'rules: payment commission on cart plus delivery base'
+    'rules: default payment commission is percent of the provided base'
 );
 
 // --- ManagerOrderCostRecalculator::calculateBreakdown() ---
@@ -196,8 +196,8 @@ $fullBreakdown = $recalculator2->calculateBreakdown($orderFull);
 $assertTrue($fullBreakdown['success'] === true, 'breakdown: percent delivery and payment success');
 $assertSame([], $fullBreakdown['data']['warnings'], 'breakdown: default handlers no warnings');
 $assertSame(70.0, $fullBreakdown['data']['breakdown']['delivery_cost'], 'breakdown: percent delivery cost');
-$assertSame(32.1, $fullBreakdown['data']['breakdown']['payment_cost'], 'breakdown: payment fee on cart plus delivery');
-$assertSame(1102.1, $fullBreakdown['data']['breakdown']['cost'], 'breakdown: integrated total');
+$assertSame(30.0, $fullBreakdown['data']['breakdown']['payment_cost'], 'breakdown: payment fee on cart-only base');
+$assertSame(1100.0, $fullBreakdown['data']['breakdown']['cost'], 'breakdown: integrated total');
 
 $modx3 = new OrderCostRecalculatorModxStub();
 $recalculator3 = new ManagerOrderCostRecalculator($modx3, $createMs3($modx3));

--- a/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
+++ b/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
@@ -3,17 +3,28 @@
 /**
  * Regression smoke tests for persisted order cost rules (#373).
  *
- * Calls {@see OrderPersistedCostRules} — the same pure helpers used by
- * ManagerOrderCostRecalculator::calculateBreakdown().
+ * 1. {@see OrderPersistedCostRules} — pure formulas.
+ * 2. {@see ManagerOrderCostRecalculator::calculateBreakdown()} — production path with stubs.
  *
  * Run: php tests/ManagerOrderCostRecalculatorRulesTest.php
  */
 
 declare(strict_types=1);
 
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/XpdoStub.php';
+require __DIR__ . '/stubs/OrderCostRecalculatorModxStub.php';
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Services\Order\ManagerOrderCostRecalculator;
 use MiniShop3\Services\Order\OrderPersistedCostRules;
+use MiniShop3\Utils\Utils;
+use MODX\Revolution\OrderCostRecalculatorModxStub;
 
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
@@ -26,28 +37,199 @@ $assertSame = static function ($expected, $actual, string $case) use ($fail): vo
     }
 };
 
+$assertTrue = static function (bool $value, string $case) use ($fail): void {
+    if (!$value) {
+        $fail($case);
+    }
+};
+
+// --- OrderPersistedCostRules (pure helpers) ---
+
 $assertSame(
     0.0,
     OrderPersistedCostRules::calculateDefaultDeliveryCost(1000, 50, '100', 1500, 2),
-    'free delivery when cart meets threshold'
+    'rules: free delivery when cart meets threshold'
 );
 
 $assertSame(
     70.0,
     OrderPersistedCostRules::calculateDefaultDeliveryCost(0, 10, '5%', 1000, 2),
-    'weight cost plus percent of cart'
-);
-
-$assertSame(
-    30.0,
-    OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1000),
-    'payment commission percent of cart-only base'
+    'rules: weight cost plus percent of cart'
 );
 
 $assertSame(
     33.0,
     OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1100),
-    'payment commission percent of cart plus delivery base'
+    'rules: payment commission on cart plus delivery base'
+);
+
+// --- ManagerOrderCostRecalculator::calculateBreakdown() ---
+
+$createMs3 = static function (OrderCostRecalculatorModxStub $modx): MiniShop3 {
+    $ref = new ReflectionClass(MiniShop3::class);
+    /** @var MiniShop3 $instance */
+    $instance = $ref->newInstanceWithoutConstructor();
+    $instance->modx = $modx;
+    $instance->utils = new Utils($instance);
+
+    return $instance;
+};
+
+$orderStub = static function (array $fields): msOrder {
+    return new class($fields) extends msOrder {
+        public function __construct(private array $fields)
+        {
+        }
+
+        public function get($key, $format = null, $formatTemplate = null): mixed
+        {
+            return $this->fields[$key] ?? null;
+        }
+    };
+};
+
+$deliveryStub = static function (array $fields): msDelivery {
+    return new class($fields) extends msDelivery {
+        public function __construct(private array $fields)
+        {
+        }
+
+        public function get($key, $format = null, $formatTemplate = null): mixed
+        {
+            return $this->fields[$key] ?? null;
+        }
+    };
+};
+
+$paymentStub = static function (array $fields): msPayment {
+    return new class($fields) extends msPayment {
+        public function __construct(private array $fields)
+        {
+        }
+
+        public function get($key, $format = null, $formatTemplate = null): mixed
+        {
+            return $this->fields[$key] ?? null;
+        }
+    };
+};
+
+$productStub = static function (array $fields): msOrderProduct {
+    return new class($fields) extends msOrderProduct {
+        public function __construct(private array $fields)
+        {
+        }
+
+        public function get($key, $format = null, $formatTemplate = null): mixed
+        {
+            return $this->fields[$key] ?? null;
+        }
+    };
+};
+
+$modx = new OrderCostRecalculatorModxStub();
+$ms3 = $createMs3($modx);
+$recalculator = new ManagerOrderCostRecalculator($modx, $ms3);
+
+$orderFreeDelivery = $orderStub([
+    'id' => 10,
+    'delivery_id' => 1,
+    'payment_id' => 0,
+    'delivery_cost' => 0,
+]);
+
+$modx->registerObject(msDelivery::class, $deliveryStub([
+    'id' => 1,
+    'class' => '',
+    'free_delivery_amount' => 1000,
+    'weight_price' => 50,
+    'price' => '100',
+]));
+
+$modx->registerIteratorObject(msOrderProduct::class, $productStub([
+    'order_id' => 10,
+    'cost' => 1500,
+    'weight' => 1,
+    'count' => 1,
+]));
+
+$freeDeliveryBreakdown = $recalculator->calculateBreakdown($orderFreeDelivery);
+$assertTrue($freeDeliveryBreakdown['success'] === true, 'breakdown: free delivery success');
+$assertSame([], $freeDeliveryBreakdown['data']['warnings'], 'breakdown: free delivery no warnings');
+$assertSame(1500.0, $freeDeliveryBreakdown['data']['breakdown']['cart_cost'], 'breakdown: cart cost');
+$assertSame(0.0, $freeDeliveryBreakdown['data']['breakdown']['delivery_cost'], 'breakdown: free delivery cost');
+$assertSame(1500.0, $freeDeliveryBreakdown['data']['breakdown']['cost'], 'breakdown: total with free delivery');
+
+$modx2 = new OrderCostRecalculatorModxStub();
+$ms3b = $createMs3($modx2);
+$recalculator2 = new ManagerOrderCostRecalculator($modx2, $ms3b);
+
+$orderFull = $orderStub([
+    'id' => 20,
+    'delivery_id' => 2,
+    'payment_id' => 3,
+    'delivery_cost' => 0,
+]);
+
+$modx2->registerObject(msDelivery::class, $deliveryStub([
+    'id' => 2,
+    'class' => '',
+    'free_delivery_amount' => 0,
+    'weight_price' => 10,
+    'price' => '5%',
+]));
+
+$modx2->registerObject(msPayment::class, $paymentStub([
+    'id' => 3,
+    'class' => '',
+    'price' => '3%',
+]));
+
+$modx2->registerIteratorObject(msOrderProduct::class, $productStub([
+    'order_id' => 20,
+    'cost' => 1000,
+    'weight' => 2,
+    'count' => 1,
+]));
+
+$fullBreakdown = $recalculator2->calculateBreakdown($orderFull);
+$assertTrue($fullBreakdown['success'] === true, 'breakdown: percent delivery and payment success');
+$assertSame([], $fullBreakdown['data']['warnings'], 'breakdown: default handlers no warnings');
+$assertSame(70.0, $fullBreakdown['data']['breakdown']['delivery_cost'], 'breakdown: percent delivery cost');
+$assertSame(32.1, $fullBreakdown['data']['breakdown']['payment_cost'], 'breakdown: payment fee on cart plus delivery');
+$assertSame(1102.1, $fullBreakdown['data']['breakdown']['cost'], 'breakdown: integrated total');
+
+$modx3 = new OrderCostRecalculatorModxStub();
+$recalculator3 = new ManagerOrderCostRecalculator($modx3, $createMs3($modx3));
+
+$orderCustom = $orderStub([
+    'id' => 30,
+    'delivery_id' => 4,
+    'payment_id' => 0,
+    'delivery_cost' => 0,
+]);
+
+$modx3->registerObject(msDelivery::class, $deliveryStub([
+    'id' => 4,
+    'class' => 'Vendor\\CustomDelivery',
+    'free_delivery_amount' => 0,
+    'weight_price' => 10,
+    'price' => '100',
+]));
+
+$modx3->registerIteratorObject(msOrderProduct::class, $productStub([
+    'order_id' => 30,
+    'cost' => 500,
+    'weight' => 1,
+    'count' => 1,
+]));
+
+$customBreakdown = $recalculator3->calculateBreakdown($orderCustom);
+$assertTrue($customBreakdown['success'] === true, 'breakdown: custom delivery still success');
+$assertSame(
+    [ManagerOrderCostRecalculator::WARNING_DELIVERY_MANUAL_REQUIRED],
+    $customBreakdown['data']['warnings'],
+    'breakdown: custom delivery emits manual warning'
 );
 
 fwrite(STDOUT, "OK ManagerOrderCostRecalculatorRulesTest\n");

--- a/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
+++ b/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
@@ -1,10 +1,10 @@
 <?php
 
 /**
- * Regression smoke tests for manager order cost rules (#373).
+ * Regression smoke tests for persisted order cost rules (#373).
  *
- * Validates free_delivery_amount, percent delivery, and payment commission math
- * used by ManagerOrderCostRecalculator::calculateBreakdown().
+ * Calls {@see OrderPersistedCostRules} — the same pure helpers used by
+ * ManagerOrderCostRecalculator::calculateBreakdown().
  *
  * Run: php tests/ManagerOrderCostRecalculatorRulesTest.php
  */
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use MiniShop3\Utils\PriceAdjustment;
+use MiniShop3\Services\Order\OrderPersistedCostRules;
 
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
@@ -26,48 +26,27 @@ $assertSame = static function ($expected, $actual, string $case) use ($fail): vo
     }
 };
 
-$calculateDefaultDeliveryCost = static function (
-    float $freeDeliveryAmount,
-    float $weightPrice,
-    string $addPrice,
-    float $cartCost,
-    float $orderWeight
-): float {
-    if ($freeDeliveryAmount > 0 && $cartCost >= $freeDeliveryAmount) {
-        return 0.0;
-    }
-
-    $deliveryCost = $weightPrice * $orderWeight;
-
-    if ($addPrice === '') {
-        return round($deliveryCost, 6);
-    }
-
-    return round($deliveryCost + PriceAdjustment::calculate($cartCost, $addPrice), 6);
-};
-
 $assertSame(
     0.0,
-    $calculateDefaultDeliveryCost(1000, 50, '100', 1500, 2),
+    OrderPersistedCostRules::calculateDefaultDeliveryCost(1000, 50, '100', 1500, 2),
     'free delivery when cart meets threshold'
 );
 
 $assertSame(
     70.0,
-    $calculateDefaultDeliveryCost(0, 10, '5%', 1000, 2),
+    OrderPersistedCostRules::calculateDefaultDeliveryCost(0, 10, '5%', 1000, 2),
     'weight cost plus percent of cart'
 );
 
 $assertSame(
     30.0,
-    round(PriceAdjustment::calculate(1000, '3%'), 6),
+    OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1000),
     'payment commission percent of cart-only base'
 );
 
-$paymentBase = 1000 + 100;
 $assertSame(
     33.0,
-    round(PriceAdjustment::calculate($paymentBase, '3%'), 6),
+    OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1100),
     'payment commission percent of cart plus delivery base'
 );
 

--- a/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
+++ b/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
@@ -58,9 +58,9 @@ $assertSame(
 );
 
 $assertSame(
-    33.0,
-    OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1100),
-    'rules: default payment commission is percent of the provided base'
+    30.0,
+    OrderPersistedCostRules::calculateDefaultPaymentCommission('3%', 1000),
+    'rules: payment commission on cart-only base (#460)'
 );
 
 // --- ManagerOrderCostRecalculator::calculateBreakdown() ---

--- a/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
+++ b/core/components/minishop3/tests/ManagerOrderCostRecalculatorRulesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Regression smoke tests for manager order cost rules (#373).
+ *
+ * Validates free_delivery_amount, percent delivery, and payment commission math
+ * used by ManagerOrderCostRecalculator::calculateBreakdown().
+ *
+ * Run: php tests/ManagerOrderCostRecalculatorRulesTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Utils\PriceAdjustment;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$calculateDefaultDeliveryCost = static function (
+    float $freeDeliveryAmount,
+    float $weightPrice,
+    string $addPrice,
+    float $cartCost,
+    float $orderWeight
+): float {
+    if ($freeDeliveryAmount > 0 && $cartCost >= $freeDeliveryAmount) {
+        return 0.0;
+    }
+
+    $deliveryCost = $weightPrice * $orderWeight;
+
+    if ($addPrice === '') {
+        return round($deliveryCost, 6);
+    }
+
+    return round($deliveryCost + PriceAdjustment::calculate($cartCost, $addPrice), 6);
+};
+
+$assertSame(
+    0.0,
+    $calculateDefaultDeliveryCost(1000, 50, '100', 1500, 2),
+    'free delivery when cart meets threshold'
+);
+
+$assertSame(
+    70.0,
+    $calculateDefaultDeliveryCost(0, 10, '5%', 1000, 2),
+    'weight cost plus percent of cart'
+);
+
+$assertSame(
+    30.0,
+    round(PriceAdjustment::calculate(1000, '3%'), 6),
+    'payment commission percent of cart-only base'
+);
+
+$paymentBase = 1000 + 100;
+$assertSame(
+    33.0,
+    round(PriceAdjustment::calculate($paymentBase, '3%'), 6),
+    'payment commission percent of cart plus delivery base'
+);
+
+fwrite(STDOUT, "OK ManagerOrderCostRecalculatorRulesTest\n");
+exit(0);

--- a/core/components/minishop3/tests/stubs/OrderCostRecalculatorModxStub.php
+++ b/core/components/minishop3/tests/stubs/OrderCostRecalculatorModxStub.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MODX\Revolution;
+
+/**
+ * modX stub with object registry for ManagerOrderCostRecalculator smoke tests.
+ */
+class OrderCostRecalculatorModxStub extends modX
+{
+    /** @var array<string, list<object>> */
+    private array $objectsByClass = [];
+
+    /** @var array<string, list<object>> */
+    private array $iteratorsByClass = [];
+
+    public function lexicon(string $key, array $placeholders = []): string
+    {
+        return $key;
+    }
+
+    public function getOption(string $key, $options = null, $default = null, $skipEvents = false): mixed
+    {
+        return $default;
+    }
+
+    public $services;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->services = new class($this) {
+            public function __construct(private OrderCostRecalculatorModxStub $modx)
+            {
+            }
+
+            public function get(string $key): object
+            {
+                if ($key === 'ms3_order_service') {
+                    return new \MiniShop3\Services\Order\OrderService($this->modx);
+                }
+
+                throw new \RuntimeException('Unknown service: ' . $key);
+            }
+
+            public function has(string $key): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    public function registerObject(string $class, object $object): void
+    {
+        $this->objectsByClass[$class][] = $object;
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     */
+    public function getObject(string $class, array $criteria = []): ?object
+    {
+        foreach ($this->objectsByClass[$class] ?? [] as $object) {
+            if ($this->matchesCriteria($object, $criteria)) {
+                return $object;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return iterable<object>
+     */
+    public function getIterator(string $class, array $criteria = []): iterable
+    {
+        foreach ($this->iteratorsByClass[$class] ?? [] as $object) {
+            if ($this->matchesCriteria($object, $criteria)) {
+                yield $object;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     */
+    public function registerIteratorObject(string $class, object $object): void
+    {
+        $this->iteratorsByClass[$class][] = $object;
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     */
+    private function matchesCriteria(object $object, array $criteria): bool
+    {
+        foreach ($criteria as $key => $expected) {
+            if (!method_exists($object, 'get')) {
+                return false;
+            }
+            if ($object->get($key) != $expected) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/core/components/minishop3/tests/stubs/XpdoStub.php
+++ b/core/components/minishop3/tests/stubs/XpdoStub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xPDO\Om;
+
+/**
+ * Minimal xPDO object base for smoke tests without a live MODX install.
+ */
+class xPDOSimpleObject
+{
+    public function get(string $key, $format = null, $formatTemplate = null): mixed
+    {
+        return null;
+    }
+
+    public function set(string $key, mixed $value): self
+    {
+        return $this;
+    }
+}

--- a/vueManager/src/components/OrderView.vue
+++ b/vueManager/src/components/OrderView.vue
@@ -1139,6 +1139,14 @@ function confirmFinalizeOrder() {
   })
 }
 
+/** Hint keys for cost recalculation warnings (ManagerOrderCostRecalculator). */
+const COST_RECALC_WARNING_HINTS = Object.freeze({
+  delivery_manual_required: 'order_cost_recalc_delivery_manual_hint',
+  payment_manual_required: 'order_cost_recalc_payment_manual_hint',
+  delivery_provider_error: 'order_cost_recalc_delivery_manual_hint',
+  payment_provider_error: 'order_cost_recalc_payment_manual_hint',
+})
+
 /**
  * Finalize order API call
  */
@@ -1181,6 +1189,26 @@ async function finalizeOrder(forceCreateCustomer = false) {
     await loadLogs()
   } catch (error) {
     console.error('[OrderView] Error finalizing order:', error)
+
+    const apiErrors = error.data?.errors
+    const costWarnings = Array.isArray(apiErrors?.warnings)
+      ? apiErrors.warnings.map(String)
+      : []
+
+    if (costWarnings.length > 0) {
+      costRecalcWarnings.value = costWarnings
+      costWarnings.forEach(code => {
+        const hintKey = COST_RECALC_WARNING_HINTS[code]
+        if (hintKey) {
+          toast.add({
+            severity: 'warn',
+            summary: _('error'),
+            detail: _(hintKey),
+            life: 7000,
+          })
+        }
+      })
+    }
 
     // Show each validation error as separate toast
     // Response structure: error.data.object.errors contains array of field names


### PR DESCRIPTION
## Описание

При finalize черновика стоимость считалась упрощённо (`delivery.price` + вес × `weight_price`, комиссия оплаты всегда 0). Теперь `OrderFinalizeService::calculateCosts()` делегирует в `ManagerOrderCostRecalculator::calculateBreakdown()` — те же правила, что у «Пересчитать стоимость» (#212): `free_delivery_amount`, `%` доставки через `PriceAdjustment`, комиссия оплаты (база cart + delivery).

### Коммиты (4)

1. **fix(order): align finalize cost** — `calculateBreakdown()` из `recalculate()`, wiring в finalize
2. **refactor(order): OrderPersistedCostRules** — pure-формулы default delivery/payment, общий слой для recalculator и тестов
3. **fix(order): block finalize on warnings** — при `delivery_manual_required` / `payment_manual_required` finalize возвращает error, не переводит заказ в «Новый»; Vue показывает подсказки пересчёта
4. **test(order): calculateBreakdown smoke** — xPDO/modX stubs + интеграционные кейсы production-класса

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #373

Follow-up (вне scope PR): #449 — `OrdersController::recalculateOrderTotals()` без payment fee в preview черновика

## Как это было протестировано?

```bash
cd core/components/minishop3 && composer ci:php
# exit 0 — php -l (367 files) + smoke tests (11)

cd ../../../vueManager && npx eslint src/components/OrderView.vue
# exit 0
```

**`ManagerOrderCostRecalculatorRulesTest`:**

- `OrderPersistedCostRules` — free delivery, percent delivery, payment на базе cart+delivery
- `ManagerOrderCostRecalculator::calculateBreakdown()` через stubs — integrated total (1102.1), warning для custom delivery

- [ ] Ручное тестирование — рекомендуется: draft с `free_delivery_amount` / оплатой с `%`; finalize vs recalculate-cost; custom delivery → error + hints в UI
- [x] Автоматические тесты (`composer ci:php`, ESLint на `OrderView.vue`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**

- MiniShop3: branch `fix/issue-373-finalize-order-cost`
- MODX: n/a (smoke без полного MODX)
- PHP: локальный Herd

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (docblock recalculator, `OrderPersistedCostRules`)
- [x] Изменения не ломают существующую функциональность (default handlers; custom — блок finalize вместо silent wrong total)
- [x] Лексиконы добавлены на **двух языках** (ru/en) — `ms3_order_finalize_cost_recalc_required`
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [x] ESLint проходит без ошибок (`OrderView.vue`)
- [ ] Обновлён CHANGELOG.md — по политике проекта, только при релизе

## Дополнительные заметки

- **Warnings:** WARN в лог + HTTP error `ms3_order_finalize_cost_recalc_required` с `errors.warnings`; Vue заполняет `costRecalcWarnings` и показывает hints (`order_cost_recalc_*_hint`).
- **`$order->save()`** после записи cost — с проверкой результата.
- **База комиссии оплаты** в manager path: `cart + delivery` (как в `ManagerOrderCostRecalculator`); web checkout (`OrderCostCalculator`) может отличаться — отдельная тема.
- **Preview при add/update товара** (`recalculateOrderTotals`) — не менялся; см. #449.