### PR TITLE
fix(order): include payment fee in draft order cost preview

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -1353,34 +1353,57 @@ class OrdersController
     }
 
     /**
-     * Recalculate order totals (cart_cost, weight, cost)
+     * Recalculate order totals from persisted line items and delivery/payment config.
+     *
+     * Uses {@see ManagerOrderCostRecalculator::calculateBreakdown()} (MODE_AUTO) so draft
+     * preview matches recalculate-cost / finalize for default handlers. Warnings are logged
+     * but do not block product mutations (unlike finalize).
      *
      * @param msOrder $order Order object
      */
     protected function recalculateOrderTotals(msOrder $order): void
     {
-        $cartCost = 0;
-        $weight = 0;
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+        $recalculator = new ManagerOrderCostRecalculator($this->modx, $ms3);
+        $result = $recalculator->calculateBreakdown($order);
 
-        $products = $this->modx->getIterator(\MiniShop3\Model\msOrderProduct::class, [
-            'order_id' => $order->get('id'),
-        ]);
+        if (empty($result['success'])) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[OrdersController] recalculateOrderTotals failed for order #' . $order->get('id')
+                . ': ' . ($result['message'] ?? 'unknown')
+            );
 
-        foreach ($products as $product) {
-            $cartCost += (float)$product->get('cost');
-            $weight += (float)$product->get('weight') * (int)$product->get('count');
+            return;
         }
 
-        $order->set('cart_cost', $cartCost);
-        $order->set('weight', $weight);
+        $breakdown = $result['data']['breakdown'] ?? null;
+        if (!is_array($breakdown)) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[OrdersController] recalculateOrderTotals missing breakdown for order #' . $order->get('id')
+            );
 
-        // Recalculate total cost (cart + delivery; payment deltas are reflected in cost when persisted elsewhere)
-        /** @var OrderService $orderService */
-        $orderService = $this->modx->services->get('ms3_order_service');
-        $deliveryCost = (float) $order->get('delivery_cost');
-        $order->set('cost', $orderService->clampComputedTotal($order, $cartCost, $deliveryCost, 0.0));
+            return;
+        }
 
-        $order->save();
+        $warnings = $result['data']['warnings'] ?? [];
+
+        if ($warnings !== []) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[OrdersController] recalculateOrderTotals warnings for order #' . $order->get('id')
+                . ': ' . implode(', ', $warnings)
+            );
+        }
+
+        if (!$recalculator->persistBreakdown($order, $breakdown)) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[OrdersController] Failed to save order #' . $order->get('id') . ' after recalculateOrderTotals'
+            );
+        }
     }
 
     /**

--- a/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
@@ -130,6 +130,22 @@ class ManagerOrderCostRecalculator
     }
 
     /**
+     * Persist breakdown totals on the order (shared by recalculate and draft preview paths).
+     *
+     * @param array{cart_cost: float|int, weight: float|int, delivery_cost: float|int, cost: float|int} $breakdown
+     */
+    public function persistBreakdown(msOrder $order, array $breakdown): bool
+    {
+        $order->set('cart_cost', $breakdown['cart_cost']);
+        $order->set('delivery_cost', $breakdown['delivery_cost']);
+        $order->set('weight', $breakdown['weight']);
+        $order->set('cost', $breakdown['cost']);
+        $order->set('updatedon', date('Y-m-d H:i:s'));
+
+        return $order->save();
+    }
+
+    /**
      * @param array<string, mixed> $options
      * @return array{success: bool, message?: string, data?: array}
      */
@@ -140,8 +156,12 @@ class ManagerOrderCostRecalculator
             return $result;
         }
 
-        $breakdown = $result['data']['breakdown'];
-        $warnings = $result['data']['warnings'];
+        $breakdown = $result['data']['breakdown'] ?? null;
+        if (!is_array($breakdown)) {
+            return $this->ms3->utils->error('ms3_err_unknown');
+        }
+
+        $warnings = $result['data']['warnings'] ?? [];
         $cartCost = $breakdown['cart_cost'];
         $orderWeight = $breakdown['weight'];
         $deliveryCost = $breakdown['delivery_cost'];
@@ -155,13 +175,7 @@ class ManagerOrderCostRecalculator
             'weight' => (float)$order->get('weight'),
         ];
 
-        $order->set('cart_cost', $cartCost);
-        $order->set('delivery_cost', $deliveryCost);
-        $order->set('weight', $orderWeight);
-        $order->set('cost', $cost);
-        $order->set('updatedon', date('Y-m-d H:i:s'));
-
-        if (!$order->save()) {
+        if (!$this->persistBreakdown($order, $breakdown)) {
             return $this->ms3->utils->error('ms3_err_unknown');
         }
 


### PR DESCRIPTION
## Описание

При add/update/delete позиций в draft-заказе `OrdersController::recalculateOrderTotals()` больше не считает `cost = cart + delivery` с `payment fee = 0`. Метод делегирует в `ManagerOrderCostRecalculator::calculateBreakdown()` (MODE_AUTO) и сохраняет breakdown через общий `persistBreakdown()`.

Preview `cost` в черновике совпадает с «Пересчитать стоимость» и finalize для default handlers (cart + delivery + payment commission, `free_delivery_amount`, проценты доставки). Warnings логируются, но не блокируют CRUD позиций (в отличие от finalize).

**Зависимость:** PR stacked на #448 (`fix/issue-373-finalize-order-cost`); после merge #448 base можно переключить на `beta`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #449

Relates to #373, #212

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Controllers/Api/Manager/OrdersController.php   # exit 0
php -l src/Services/Order/ManagerOrderCostRecalculator.php # exit 0
composer ci:php                                            # exit 0 (11 smoke tests)
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`, `npm run lint:ci` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: текущая ветка
- MODX: smoke без MODX/MySQL
- PHP: локальный CI-гейт

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не затронут
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике релиза

## Дополнительные заметки

- Вынесен `ManagerOrderCostRecalculator::persistBreakdown()` — общий persist для `recalculate()` и preview path; добавлен guard на отсутствие `breakdown`, `updatedon` при save.
- Out of scope (#449): web checkout base, блокировка операций при warnings (только finalize).
- Регрессия payment fee / free delivery покрыта существующим `ManagerOrderCostRecalculatorRulesTest` (#373); controller path — интеграционный smoke без xPDO stubs для OrdersController.