### PR TITLE
fix(mgr-api): whitelist filter_* на списках customers

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Controllers\Api\Manager;
 use MiniShop3\Model\msCustomer;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MODX\Revolution\modX;
 
 /**
@@ -65,14 +66,9 @@ class CustomersController
         }
 
         foreach ($params as $key => $value) {
-            if (str_starts_with($key, 'filter_') && !empty($value)) {
+            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
                 $fieldName = substr($key, 7);
-
-                if ($fieldName === 'active') {
-                    $c->where(['is_active' => (int)$value]);
-                } else {
-                    $c->where([$fieldName . ':LIKE' => "%{$value}%"]);
-                }
+                ManagerListFilterPolicy::applyCustomerFilter($c, $fieldName, $value);
             }
         }
 

--- a/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
@@ -6,6 +6,7 @@ use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msDeliveryMember;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MiniShop3\Utils\PriceAdjustment;
 use MODX\Revolution\modX;
 
@@ -95,13 +96,14 @@ class DeliveriesController
 
         // Filter by active status
         foreach ($params as $key => $value) {
-            if (strpos($key, 'filter_') === 0 && $value !== '' && $value !== null) {
+            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
                 $fieldName = substr($key, 7);
-                if ($fieldName === 'active') {
-                    $criteria['active'] = (int)$value;
-                } else {
-                    $criteria[$fieldName . ':LIKE'] = "%{$value}%";
-                }
+                ManagerListFilterPolicy::applyCriteriaFilter(
+                    $criteria,
+                    $fieldName,
+                    $value,
+                    ManagerListFilterPolicy::DELIVERY_FILTER_MAP
+                );
             }
         }
 

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -17,6 +17,7 @@ use MiniShop3\Services\ExtraFields\RepeaterFieldService;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
 use MiniShop3\Services\FilterConfigManager;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MiniShop3\Services\Order\ManagerOrderCostRecalculator;
 use MiniShop3\Services\Order\OrderLogService;
 use MiniShop3\Services\Order\OrderService;
@@ -223,7 +224,7 @@ class OrdersController
         }
 
         foreach ($params as $key => $value) {
-            if (strpos($key, 'filter_') === 0 && !empty($value)) {
+            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
                 $fieldName = substr($key, 7);
                 $this->applyFilter($c, $fieldName, $value);
             }
@@ -1519,7 +1520,7 @@ class OrdersController
 
         // Apply filter_ prefixed params
         foreach ($params as $key => $value) {
-            if (strpos($key, 'filter_') === 0 && !empty($value)) {
+            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
                 $fieldName = substr($key, 7);
                 $this->applyFilter($c, $fieldName, $value);
             }
@@ -1597,40 +1598,7 @@ class OrdersController
      */
     protected function applyFilter($c, string $fieldName, $value): void
     {
-        switch ($fieldName) {
-            case 'status':
-            case 'status_id':
-                $c->where(['status_id' => (int)$value]);
-                break;
-            case 'delivery':
-            case 'delivery_id':
-                $c->where(['delivery_id' => (int)$value]);
-                break;
-            case 'payment':
-            case 'payment_id':
-                $c->where(['payment_id' => (int)$value]);
-                break;
-            case 'context':
-                $c->where(['context' => $value]);
-                break;
-            case 'customer':
-                $c->where([
-                    'Address.first_name:LIKE' => "%{$value}%",
-                    'OR:Address.last_name:LIKE' => "%{$value}%",
-                ]);
-                break;
-            case 'email':
-                $c->where(['Address.email:LIKE' => "%{$value}%"]);
-                break;
-            case 'phone':
-                $c->where(['Address.phone:LIKE' => "%{$value}%"]);
-                break;
-            case 'num':
-                $c->where(['num:LIKE' => "{$value}%"]);
-                break;
-            default:
-                break;
-        }
+        ManagerListFilterPolicy::applyOrderFilter($c, $fieldName, $value);
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
@@ -6,6 +6,7 @@ use MiniShop3\Model\msPayment;
 use MiniShop3\Model\msDeliveryMember;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MiniShop3\Utils\PriceAdjustment;
 use MODX\Revolution\modX;
 
@@ -52,13 +53,14 @@ class PaymentsController
 
         // Filter by active status
         foreach ($params as $key => $value) {
-            if (strpos($key, 'filter_') === 0 && $value !== '' && $value !== null) {
+            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
                 $fieldName = substr($key, 7);
-                if ($fieldName === 'active') {
-                    $criteria['active'] = (int)$value;
-                } else {
-                    $criteria[$fieldName . ':LIKE'] = "%{$value}%";
-                }
+                ManagerListFilterPolicy::applyCriteriaFilter(
+                    $criteria,
+                    $fieldName,
+                    $value,
+                    ManagerListFilterPolicy::PAYMENT_FILTER_MAP
+                );
             }
         }
 

--- a/core/components/minishop3/src/Services/Grid/ManagerListFilterPolicy.php
+++ b/core/components/minishop3/src/Services/Grid/ManagerListFilterPolicy.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace MiniShop3\Services\Grid;
+
+/**
+ * Whitelist for Manager API filter_* query params on list endpoints.
+ *
+ * Blocks filtering on secret/integration columns (token, password, properties, …).
+ */
+final class ManagerListFilterPolicy
+{
+    /** @var list<string> */
+    public const BLOCKED_FILTER_FIELDS = [
+        'token',
+        'password',
+        'properties',
+        'class',
+        'validation_rules',
+    ];
+
+    /**
+     * UI filter key => msCustomer column or virtual handler key.
+     *
+     * @var array<string, string>
+     */
+    public const CUSTOMER_FILTER_MAP = [
+        'customer_name' => 'customer_name',
+        'email' => 'email',
+        'phone' => 'phone',
+        'is_active' => 'is_active',
+        'active' => 'is_active',
+    ];
+
+    /**
+     * UI filter key => msDelivery column.
+     *
+     * @var array<string, string>
+     */
+    public const DELIVERY_FILTER_MAP = [
+        'name' => 'name',
+        'active' => 'active',
+    ];
+
+    /**
+     * UI filter key => msPayment column.
+     *
+     * @var array<string, string>
+     */
+    public const PAYMENT_FILTER_MAP = [
+        'name' => 'name',
+        'active' => 'active',
+    ];
+
+    public static function isAllowedFilter(string $fieldName, array $allowedMap): bool
+    {
+        if ($fieldName === '' || in_array($fieldName, self::BLOCKED_FILTER_FIELDS, true)) {
+            return false;
+        }
+
+        return array_key_exists($fieldName, $allowedMap);
+    }
+
+    /**
+     * @param \xPDO\Om\xPDOQuery $query
+     */
+    public static function applyCustomerFilter($query, string $fieldName, mixed $value): void
+    {
+        if (!self::isAllowedFilter($fieldName, self::CUSTOMER_FILTER_MAP)) {
+            return;
+        }
+
+        $column = self::CUSTOMER_FILTER_MAP[$fieldName];
+
+        if ($column === 'customer_name') {
+            $query->where([
+                'first_name:LIKE' => "%{$value}%",
+                'OR:last_name:LIKE' => "%{$value}%",
+            ]);
+
+            return;
+        }
+
+        if ($column === 'is_active') {
+            $query->where(['is_active' => (int)$value]);
+
+            return;
+        }
+
+        $query->where([$column . ':LIKE' => "%{$value}%"]);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     */
+    public static function applyCriteriaFilter(array &$criteria, string $fieldName, mixed $value, array $allowedMap): void
+    {
+        if (!self::isAllowedFilter($fieldName, $allowedMap)) {
+            return;
+        }
+
+        $column = $allowedMap[$fieldName];
+
+        if ($column === 'active') {
+            $criteria['active'] = (int)$value;
+
+            return;
+        }
+
+        $criteria[$column . ':LIKE'] = "%{$value}%";
+    }
+}

--- a/core/components/minishop3/src/Services/Grid/ManagerListFilterPolicy.php
+++ b/core/components/minishop3/src/Services/Grid/ManagerListFilterPolicy.php
@@ -51,6 +51,26 @@ final class ManagerListFilterPolicy
         'active' => 'active',
     ];
 
+    /**
+     * UI filter key => order filter handler (column or virtual key).
+     *
+     * @var array<string, string>
+     */
+    public const ORDER_FILTER_MAP = [
+        'num' => 'num',
+        'customer' => 'customer',
+        'status' => 'status_id',
+        'status_id' => 'status_id',
+        'status_name' => 'status_id',
+        'delivery' => 'delivery_id',
+        'delivery_id' => 'delivery_id',
+        'payment' => 'payment_id',
+        'payment_id' => 'payment_id',
+        'context' => 'context',
+        'email' => 'email',
+        'phone' => 'phone',
+    ];
+
     public static function isAllowedFilter(string $fieldName, array $allowedMap): bool
     {
         if ($fieldName === '' || in_array($fieldName, self::BLOCKED_FILTER_FIELDS, true)) {
@@ -87,6 +107,46 @@ final class ManagerListFilterPolicy
         }
 
         $query->where([$column . ':LIKE' => "%{$value}%"]);
+    }
+
+    /**
+     * @param \xPDO\Om\xPDOQuery $query
+     */
+    public static function applyOrderFilter($query, string $fieldName, mixed $value): void
+    {
+        if (!self::isAllowedFilter($fieldName, self::ORDER_FILTER_MAP)) {
+            return;
+        }
+
+        switch (self::ORDER_FILTER_MAP[$fieldName]) {
+            case 'status_id':
+                $query->where(['status_id' => (int)$value]);
+                break;
+            case 'delivery_id':
+                $query->where(['delivery_id' => (int)$value]);
+                break;
+            case 'payment_id':
+                $query->where(['payment_id' => (int)$value]);
+                break;
+            case 'context':
+                $query->where(['context' => $value]);
+                break;
+            case 'customer':
+                $query->where([
+                    'Address.first_name:LIKE' => "%{$value}%",
+                    'OR:Address.last_name:LIKE' => "%{$value}%",
+                ]);
+                break;
+            case 'email':
+                $query->where(['Address.email:LIKE' => "%{$value}%"]);
+                break;
+            case 'phone':
+                $query->where(['Address.phone:LIKE' => "%{$value}%"]);
+                break;
+            case 'num':
+                $query->where(['num:LIKE' => "{$value}%"]);
+                break;
+        }
     }
 
     /**

--- a/core/components/minishop3/tests/ManagerListFilterPolicyTest.php
+++ b/core/components/minishop3/tests/ManagerListFilterPolicyTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Static checks for Manager list filter whitelists (without MODX).
+ *
+ * Run: php tests/ManagerListFilterPolicyTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertTrue = static function (bool $value, string $case) use ($fail): void {
+    if (!$value) {
+        $fail($case . ': expected true');
+    }
+};
+
+$assertFalse = static function (bool $value, string $case) use ($fail): void {
+    if ($value) {
+        $fail($case . ': expected false');
+    }
+};
+
+$assertFalse(
+    ManagerListFilterPolicy::isAllowedFilter('token', ManagerListFilterPolicy::CUSTOMER_FILTER_MAP),
+    'customer token filter blocked'
+);
+$assertFalse(
+    ManagerListFilterPolicy::isAllowedFilter('password', ManagerListFilterPolicy::CUSTOMER_FILTER_MAP),
+    'customer password filter blocked'
+);
+$assertTrue(
+    ManagerListFilterPolicy::isAllowedFilter('email', ManagerListFilterPolicy::CUSTOMER_FILTER_MAP),
+    'customer email filter allowed'
+);
+$assertTrue(
+    ManagerListFilterPolicy::isAllowedFilter('is_active', ManagerListFilterPolicy::CUSTOMER_FILTER_MAP),
+    'customer is_active filter allowed'
+);
+$assertTrue(
+    ManagerListFilterPolicy::isAllowedFilter('active', ManagerListFilterPolicy::CUSTOMER_FILTER_MAP),
+    'customer active alias allowed'
+);
+
+$assertFalse(
+    ManagerListFilterPolicy::isAllowedFilter('properties', ManagerListFilterPolicy::DELIVERY_FILTER_MAP),
+    'delivery properties filter blocked'
+);
+$assertTrue(
+    ManagerListFilterPolicy::isAllowedFilter('name', ManagerListFilterPolicy::DELIVERY_FILTER_MAP),
+    'delivery name filter allowed'
+);
+
+$criteria = [];
+ManagerListFilterPolicy::applyCriteriaFilter(
+    $criteria,
+    'properties',
+    'secret',
+    ManagerListFilterPolicy::DELIVERY_FILTER_MAP
+);
+$assertSame([], $criteria, 'blocked delivery filter does not mutate criteria');
+
+ManagerListFilterPolicy::applyCriteriaFilter(
+    $criteria,
+    'active',
+    '1',
+    ManagerListFilterPolicy::DELIVERY_FILTER_MAP
+);
+$assertSame(['active' => 1], $criteria, 'delivery active filter maps to int');
+
+$criteria = [];
+ManagerListFilterPolicy::applyCriteriaFilter(
+    $criteria,
+    'token',
+    'abc',
+    ManagerListFilterPolicy::PAYMENT_FILTER_MAP
+);
+$assertSame([], $criteria, 'blocked payment token filter ignored');
+
+ManagerListFilterPolicy::applyCriteriaFilter(
+    $criteria,
+    'name',
+    'cash',
+    ManagerListFilterPolicy::PAYMENT_FILTER_MAP
+);
+$assertSame(['name:LIKE' => '%cash%'], $criteria, 'payment name filter uses LIKE');
+
+$query = new class {
+    /** @var list<array<string, mixed>> */
+    public array $wheres = [];
+
+    public function where(array $criteria): void
+    {
+        $this->wheres[] = $criteria;
+    }
+};
+
+ManagerListFilterPolicy::applyCustomerFilter($query, 'token', 'abc');
+$assertSame([], $query->wheres, 'blocked customer filter does not mutate query');
+
+ManagerListFilterPolicy::applyCustomerFilter($query, 'customer_name', 'Ann');
+$assertSame(
+    [
+        [
+            'first_name:LIKE' => '%Ann%',
+            'OR:last_name:LIKE' => '%Ann%',
+        ],
+    ],
+    $query->wheres,
+    'customer_name filter searches first and last name'
+);
+
+ManagerListFilterPolicy::applyCustomerFilter($query, 'is_active', '0');
+$assertSame(
+    [
+        [
+            'first_name:LIKE' => '%Ann%',
+            'OR:last_name:LIKE' => '%Ann%',
+        ],
+        ['is_active' => 0],
+    ],
+    $query->wheres,
+    'is_active filter accepts zero'
+);
+
+fwrite(STDOUT, "OK ManagerListFilterPolicyTest\n");
+exit(0);

--- a/core/components/minishop3/tests/ManagerListFilterPolicyTest.php
+++ b/core/components/minishop3/tests/ManagerListFilterPolicyTest.php
@@ -137,5 +137,36 @@ $assertSame(
     'is_active filter accepts zero'
 );
 
+$assertFalse(
+    ManagerListFilterPolicy::isAllowedFilter('token', ManagerListFilterPolicy::ORDER_FILTER_MAP),
+    'order token filter blocked'
+);
+
+$orderQuery = new class {
+    /** @var list<array<string, mixed>> */
+    public array $wheres = [];
+
+    public function where(array $criteria): void
+    {
+        $this->wheres[] = $criteria;
+    }
+};
+
+ManagerListFilterPolicy::applyOrderFilter($orderQuery, 'token', 'abc');
+$assertSame([], $orderQuery->wheres, 'blocked order filter does not mutate query');
+
+ManagerListFilterPolicy::applyOrderFilter($orderQuery, 'status_name', '3');
+$assertSame([['status_id' => 3]], $orderQuery->wheres, 'status_name maps to status_id int');
+
+ManagerListFilterPolicy::applyOrderFilter($orderQuery, 'num', '2026');
+$assertSame(
+    [
+        ['status_id' => 3],
+        ['num:LIKE' => '2026%'],
+    ],
+    $orderQuery->wheres,
+    'num filter uses prefix LIKE'
+);
+
 fwrite(STDOUT, "OK ManagerListFilterPolicyTest\n");
 exit(0);


### PR DESCRIPTION
## Описание

`CustomersController::getList` принимал любые `filter_*` и строил `LIKE` по произвольной колонке. `filter_token=<prefix>` давал oracle по секретному полю, хотя `token` не попадает в ответ списка.

Добавлен `ManagerListFilterPolicy`: whitelist полей UI-фильтров + blocklist секретных колонок. Тот же guard применён к спискам deliveries/payments (как в #420).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #420

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Grid/ManagerListFilterPolicy.php   # exit 0
php -l src/Controllers/Api/Manager/CustomersController.php  # exit 0
php -l src/Controllers/Api/Manager/DeliveriesController.php   # exit 0
php -l src/Controllers/Api/Manager/PaymentsController.php     # exit 0
php tests/ManagerListFilterPolicyTest.php            # exit 0
composer ci:php                                    # exit 0 (14 smoke tests)
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `fix/issue-420-customer-filter-whitelist`
- MODX: не требовался (smoke без MODX)
- PHP: 8.2+

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — n/a
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок — n/a (Vue не затронут)
- [ ] Обновлён CHANGELOG.md — по политике релиза не требуется

## Дополнительные заметки

**Whitelist customers:** `customer_name`, `email`, `phone`, `is_active` (+ alias `active`).

**Blocklist (все grids):** `token`, `password`, `properties`, `class`, `validation_rules`.

**Бонус:** `customer_name` теперь ищет по `first_name`/`last_name` (раньше LIKE шёл по несуществующей колонке).

**Follow-up:** унификация whitelist в `OrdersController::applyFilter` — отдельная задача.