### PR TITLE
fix: проверка связи delivery/payment при оформлении заказа

### DIFF
--- a/core/components/minishop3/lexicon/en/order.inc.php
+++ b/core/components/minishop3/lexicon/en/order.inc.php
@@ -22,6 +22,7 @@ $_lang['ms3_order_err_requires'] = 'Required fields are not filled';
 $_lang['ms3_order_err_delivery'] = 'Delivery method is not selected';
 $_lang['ms3_order_err_payment'] = 'Payment method is not selected';
 $_lang['ms3_order_err_payment_not_found'] = 'Payment method not found or inactive';
+$_lang['ms3_order_err_payment_delivery'] = 'Payment method is not available for the selected delivery method';
 $_lang['ms3_order_delivery_id_nf'] = 'Delivery method not found';
 $_lang['ms3_order_payment_id_nf'] = 'Payment method not found';
 

--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -775,6 +775,7 @@ $_lang['ms3_order_err_validation'] = 'Order data validation error';
 $_lang['ms3_order_err_products'] = 'Order has no products';
 $_lang['ms3_order_err_delivery_id'] = 'Delivery method is not selected';
 $_lang['ms3_order_err_payment_id'] = 'Payment method is not selected';
+$_lang['ms3_order_err_payment_delivery'] = 'Payment method is not available for the selected delivery method';
 $_lang['ms3_order_err_customer_id'] = 'Customer is not specified';
 $_lang['ms3_order_err_customer_contact'] = 'Email or phone is required to create a customer';
 $_lang['ms3_order_err_email'] = 'Email is not specified';

--- a/core/components/minishop3/lexicon/ru/order.inc.php
+++ b/core/components/minishop3/lexicon/ru/order.inc.php
@@ -22,6 +22,7 @@ $_lang['ms3_order_err_requires'] = 'Не заполнены обязательн
 $_lang['ms3_order_err_delivery'] = 'Не выбран способ доставки';
 $_lang['ms3_order_err_payment'] = 'Не выбран способ оплаты';
 $_lang['ms3_order_err_payment_not_found'] = 'Способ оплаты не найден или неактивен';
+$_lang['ms3_order_err_payment_delivery'] = 'Способ оплаты недоступен для выбранной доставки';
 $_lang['ms3_order_delivery_id_nf'] = 'Способ доставки не найден';
 $_lang['ms3_order_payment_id_nf'] = 'Способ оплаты не найден';
 

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -774,6 +774,7 @@ $_lang['ms3_order_err_validation'] = 'Ошибка валидации данны
 $_lang['ms3_order_err_products'] = 'В заказе нет товаров';
 $_lang['ms3_order_err_delivery_id'] = 'Не выбран способ доставки';
 $_lang['ms3_order_err_payment_id'] = 'Не выбран способ оплаты';
+$_lang['ms3_order_err_payment_delivery'] = 'Способ оплаты недоступен для выбранной доставки';
 $_lang['ms3_order_err_customer_id'] = 'Не указан покупатель';
 $_lang['ms3_order_err_customer_contact'] = 'Для создания клиента необходимо указать email или телефон';
 $_lang['ms3_order_err_email'] = 'Не указан email';

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -16,6 +16,7 @@ use MiniShop3\Router\Response;
 use MiniShop3\Services\ExtraFields\RepeaterFieldService;
 use MiniShop3\Services\CustomerDuplicateChecker;
 use MiniShop3\Services\CustomerFactory;
+use MiniShop3\Services\Delivery\DeliveryService;
 use MiniShop3\Services\FilterConfigManager;
 use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MiniShop3\Services\Order\ManagerOrderCostRecalculator;
@@ -646,6 +647,14 @@ class OrdersController
         $order->set('cost', $orderService->clampComputedTotal(null, 0.0, $deliveryCost, 0.0));
         $order->set('weight', 0);
 
+        $pairError = $this->validateDeliveryPaymentPair(
+            (int) $order->get('delivery_id'),
+            (int) $order->get('payment_id')
+        );
+        if ($pairError !== null) {
+            return $pairError;
+        }
+
         if (!$order->save()) {
             return Response::error('Failed to create order', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
         }
@@ -848,6 +857,14 @@ class OrdersController
                 $changedOrderFields[$extraFieldKey] = ['old' => $oldValue, 'new' => $newValue];
             }
             $order->set($extraFieldKey, $newValue);
+        }
+
+        $pairError = $this->validateDeliveryPaymentPair(
+            (int) $order->get('delivery_id'),
+            (int) $order->get('payment_id')
+        );
+        if ($pairError !== null) {
+            return $pairError;
         }
 
         $order->set('updatedon', date('Y-m-d H:i:s'));
@@ -1800,5 +1817,26 @@ class OrdersController
         }
 
         return $names;
+    }
+
+    /**
+     * Reject incompatible delivery/payment pairs (msDeliveryMember link required).
+     *
+     * @return array|null Response error payload or null when valid / incomplete pair
+     */
+    protected function validateDeliveryPaymentPair(int $deliveryId, int $paymentId): ?array
+    {
+        if ($deliveryId <= 0 || $paymentId <= 0) {
+            return null;
+        }
+
+        /** @var DeliveryService $deliveryService */
+        $deliveryService = $this->modx->services->get('ms3_delivery_service');
+        $pairError = $deliveryService->getDeliveryPaymentPairError($deliveryId, $paymentId);
+        if ($pairError === null) {
+            return null;
+        }
+
+        return Response::error($pairError, HttpStatus::UNPROCESSABLE_ENTITY)->getData();
     }
 }

--- a/core/components/minishop3/src/Controllers/Order/Order.php
+++ b/core/components/minishop3/src/Controllers/Order/Order.php
@@ -3,10 +3,8 @@
 namespace MiniShop3\Controllers\Order;
 
 use MiniShop3\MiniShop3;
-use MiniShop3\Model\msDeliveryMember;
 use MiniShop3\Model\msOrder;
 use MiniShop3\Model\msOrderLog;
-use MiniShop3\Model\msPayment;
 use MiniShop3\Services\Order\OrderAddressManager;
 use MiniShop3\Services\Order\OrderCostCalculator;
 use MiniShop3\Services\Order\OrderDraftManager;
@@ -489,14 +487,10 @@ class Order
      */
     public function hasPayment(int $delivery, int $payment): bool
     {
-        $q = $this->modx->newQuery(msPayment::class, ['id' => $payment, 'active' => 1]);
-        $q->innerJoin(
-            msDeliveryMember::class,
-            'Member',
-            'Member.payment_id = msPayment.id AND Member.delivery_id = ' . $delivery
-        );
+        /** @var \MiniShop3\Services\Delivery\DeliveryService $deliveryService */
+        $deliveryService = $this->modx->services->get('ms3_delivery_service');
 
-        return (bool)$this->modx->getCount(msPayment::class, $q);
+        return $deliveryService->isPaymentAvailableForDelivery($delivery, $payment);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Delivery/DeliveryService.php
+++ b/core/components/minishop3/src/Services/Delivery/DeliveryService.php
@@ -113,6 +113,43 @@ class DeliveryService
     }
 
     /**
+     * Check whether payment method is linked to delivery and active.
+     */
+    public function isPaymentAvailableForDelivery(int $deliveryId, int $paymentId): bool
+    {
+        if ($deliveryId <= 0 || $paymentId <= 0) {
+            return false;
+        }
+
+        $payment = $this->modx->getObject(msPayment::class, [
+            'id' => $paymentId,
+            'active' => 1,
+        ]);
+        if (!$payment) {
+            return false;
+        }
+
+        return (bool) $this->modx->getCount(msDeliveryMember::class, [
+            'delivery_id' => $deliveryId,
+            'payment_id' => $paymentId,
+        ]);
+    }
+
+    /**
+     * Lexicon key when payment is not linked to delivery, or null if pair is valid/incomplete.
+     */
+    public function getDeliveryPaymentPairError(int $deliveryId, int $paymentId): ?string
+    {
+        if ($deliveryId <= 0 || $paymentId <= 0) {
+            return null;
+        }
+
+        return $this->isPaymentAvailableForDelivery($deliveryId, $paymentId)
+            ? null
+            : 'ms3_order_err_payment_delivery';
+    }
+
+    /**
      * Get first active payment method for delivery
      *
      * Returns ID of first active payment method

--- a/core/components/minishop3/src/Services/Order/OrderFieldManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderFieldManager.php
@@ -251,6 +251,21 @@ class OrderFieldManager
             $response = $this->ms3->utils->invokeEvent('msOnValidateOrderValue', $eventParams);
         }
 
+        if (in_array($key, ['payment_id', 'delivery_id'], true)) {
+            $deliveryId = (int) ($key === 'delivery_id' ? $response['data']['value'] : ($orderData['delivery_id'] ?? 0));
+            $paymentId = (int) ($key === 'payment_id' ? $response['data']['value'] : ($orderData['payment_id'] ?? 0));
+            /** @var \MiniShop3\Services\Delivery\DeliveryService $deliveryService */
+            $deliveryService = $this->modx->services->get('ms3_delivery_service');
+            $pairError = $deliveryService->getDeliveryPaymentPairError($deliveryId, $paymentId);
+            if ($pairError !== null) {
+                return $this->error('', [
+                    'error' => [
+                        $key => $pairError,
+                    ],
+                ]);
+            }
+        }
+
         return $this->success('', ['value' => $response['data']['value']]);
     }
 

--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -229,6 +229,7 @@ class OrderFinalizeService
 
         // Check payment is selected
         $paymentId = (int) $order->get('payment_id');
+        $payment = null;
         if ($paymentId > 0) {
             $payment = $this->modx->getObject(msPayment::class, [
                 'id' => $paymentId,
@@ -241,16 +242,23 @@ class OrderFinalizeService
             $errors[] = 'payment_id';
         }
 
+        // Return early if basic errors found
+        if (!empty($errors)) {
+            return $this->error('ms3_order_err_validation', $errors);
+        }
+
+        /** @var \MiniShop3\Services\Delivery\DeliveryService $deliveryService */
+        $deliveryService = $this->modx->services->get('ms3_delivery_service');
+        $pairError = $deliveryService->getDeliveryPaymentPairError($deliveryId, $paymentId);
+        if ($pairError !== null) {
+            return $this->error($pairError, ['payment_id', 'delivery_id']);
+        }
+
         // Check customer is linked (optional - manager can create orders without customer)
         // $customerId = (int) $order->get('customer_id');
         // if ($customerId === 0) {
         //     $errors[] = 'customer_id';
         // }
-
-        // Return early if basic errors found
-        if (!empty($errors)) {
-            return $this->error('ms3_order_err_validation', $errors);
-        }
 
         // Check required fields for delivery
         $requiredFieldsErrors = $this->validateDeliveryRequiredFields($order);

--- a/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
+++ b/core/components/minishop3/src/Services/Order/OrderSubmitHandler.php
@@ -124,6 +124,16 @@ class OrderSubmitHandler
             return $this->error('ms3_order_err_payment_not_found', ['payment_id' => $orderData['payment_id']]);
         }
 
+        /** @var \MiniShop3\Services\Delivery\DeliveryService $deliveryService */
+        $deliveryService = $this->modx->services->get('ms3_delivery_service');
+        $pairError = $deliveryService->getDeliveryPaymentPairError(
+            (int) $orderData['delivery_id'],
+            (int) $orderData['payment_id']
+        );
+        if ($pairError !== null) {
+            return $this->error($pairError, ['payment_id', 'delivery_id']);
+        }
+
         // Check required fields for delivery
         $requiredResponse = $this->fieldManager->getDeliveryRequiredFields($orderData['delivery_id']);
         if (!$requiredResponse['success']) {

--- a/core/components/minishop3/tests/DeliveryPaymentAvailabilityTest.php
+++ b/core/components/minishop3/tests/DeliveryPaymentAvailabilityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Wiring checks for delivery/payment pair validation (#374).
+ *
+ * Run: php tests/DeliveryPaymentAvailabilityTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertContains = static function (string $needle, string $haystack, string $case) use ($fail): void {
+    if (!str_contains($haystack, $needle)) {
+        $fail($case . ': missing ' . $needle);
+    }
+};
+
+$root = dirname(__DIR__);
+
+$deliveryService = file_get_contents($root . '/src/Services/Delivery/DeliveryService.php');
+if ($deliveryService === false) {
+    $fail('unable to read DeliveryService.php');
+}
+$assertContains('function getDeliveryPaymentPairError', $deliveryService, 'DeliveryService pair error helper');
+
+$files = [
+    'OrderSubmitHandler.php' => $root . '/src/Services/Order/OrderSubmitHandler.php',
+    'OrderFinalizeService.php' => $root . '/src/Services/Order/OrderFinalizeService.php',
+    'OrderFieldManager.php' => $root . '/src/Services/Order/OrderFieldManager.php',
+    'OrdersController.php' => $root . '/src/Controllers/Api/Manager/OrdersController.php',
+];
+
+foreach ($files as $label => $path) {
+    $src = file_get_contents($path);
+    if ($src === false) {
+        $fail('unable to read ' . $label);
+    }
+    $assertContains('getDeliveryPaymentPairError', $src, $label);
+}
+
+$order = file_get_contents($root . '/src/Controllers/Order/Order.php');
+$assertContains("services->get('ms3_delivery_service')", $order, 'Order::hasPayment delegates');
+$assertContains('isPaymentAvailableForDelivery', $order, 'Order::hasPayment uses DeliveryService');
+
+fwrite(STDOUT, "OK DeliveryPaymentAvailabilityTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

`Order::hasPayment()` проверял связь через `msDeliveryMember`, но нигде не вызывался. `OrderSubmitHandler` принимал любой активный `payment_id`, даже если он не привязан к выбранной доставке.

Добавлены `DeliveryService::isPaymentAvailableForDelivery()` и `getDeliveryPaymentPairError()`. Проверка подключена на финальных gate’ах: web submit, `order/add`, manager create/update и finalize. `Order::hasPayment()` делегирует в `DeliveryService`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change
- [ ] Рефакторинг
- [ ] Документация

## Связанные Issues

Closes #374

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Delivery/DeliveryService.php   # exit 0
php -l src/Services/Order/OrderSubmitHandler.php   # exit 0
php -l src/Services/Order/OrderFinalizeService.php # exit 0
php -l src/Services/Order/OrderFieldManager.php    # exit 0
php -l src/Controllers/Api/Manager/OrdersController.php # exit 0
composer ci:php                                    # exit 0 (15 smoke tests)
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: fix/issue-374-has-payment-validation
- MODX: n/a (smoke без MODX)
- PHP: 8.4

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — `ms3_order_err_payment_delivery`
- [ ] PHPStan
- [ ] ESLint — Vue не затронут
- [ ] CHANGELOG — по политике репозитория

## Дополнительные заметки

- Review: code-reviewer HIGH (формат ошибки в OrderFieldManager) исправлен; security-review — BLOCK/HIGH не найдено.
- `Order::hasPayment()` сохранён как публичный API и делегирует в сервис (совместимость с miniShop2).