### PR TITLE
fix(order): единая база для процентной комиссии оплаты (cart-only)

### DIFF
--- a/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
@@ -87,7 +87,7 @@ class ManagerOrderCostRecalculator
 
         $deliveryCost = $deliveryResult['delivery_cost'];
 
-        $paymentBase = round($cartCost + $deliveryCost, 6);
+        $paymentBase = OrderService::paymentCommissionBase($cartCost);
         $paymentResult = $this->resolvePaymentFee($order, $paymentBase, $mode, $options);
         if (!$paymentResult['success']) {
             return $paymentResult;

--- a/core/components/minishop3/src/Services/Order/OrderCostCalculator.php
+++ b/core/components/minishop3/src/Services/Order/OrderCostCalculator.php
@@ -186,13 +186,14 @@ class OrderCostCalculator
             return $this->success('ms3_order_getcost_success', ['cost' => $paymentCost]);
         }
 
-        // Get cart cost for payment calculation
+        // Get cart cost for payment calculation (MS2-compatible base: cart only)
         $cartCostResponse = $this->getCartCost($draft, $token, $ctx);
         $cartCost = $cartCostResponse['success'] ? $cartCostResponse['data']['cost'] : 0;
+        $paymentBase = OrderService::paymentCommissionBase((float) $cartCost);
 
-        // Payment getCost returns total with payment fee, so subtract cart cost
-        $costWithPayment = $msPayment->getCost($draft, $cartCost);
-        $paymentCost = $costWithPayment - $cartCost;
+        // Payment getCost returns total with payment fee, so subtract base
+        $costWithPayment = $msPayment->getCost($draft, $paymentBase);
+        $paymentCost = $costWithPayment - $paymentBase;
 
         $response = $this->ms3->utils->invokeEvent('msOnGetPaymentCost', [
             'calculator' => $this,

--- a/core/components/minishop3/src/Services/Order/OrderService.php
+++ b/core/components/minishop3/src/Services/Order/OrderService.php
@@ -27,6 +27,14 @@ class OrderService
     }
 
     /**
+     * Base amount for payment commission (MS2-compatible: cart cost only, delivery excluded).
+     */
+    public static function paymentCommissionBase(float $cartCost): float
+    {
+        return round($cartCost, 6);
+    }
+
+    /**
      * Clamp computed order total so it never goes negative (defence-in-depth vs misconfigured discounts).
      *
      * @param msOrder|null $order Optional persisted order — used only for log context; null allowed for drafts without ID.

--- a/core/components/minishop3/tests/PaymentCommissionBaseTest.php
+++ b/core/components/minishop3/tests/PaymentCommissionBaseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Guards payment commission base (issue #372): MS2-compatible cart-only base.
+ *
+ * Run: php tests/PaymentCommissionBaseTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Order\OrderService;
+use MiniShop3\Utils\PriceAdjustment;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$cartCost = 1000.0;
+$deliveryCost = 500.0;
+$percent = '3%';
+
+$base = OrderService::paymentCommissionBase($cartCost);
+if ($base !== 1000.0) {
+    $fail('paymentCommissionBase must round cart cost only');
+}
+
+$fee = PriceAdjustment::calculate($base, $percent);
+if (abs($fee - 30.0) > 0.000001) {
+    $fail('3% of cart 1000 must be 30, got ' . $fee);
+}
+
+$wrongFee = PriceAdjustment::calculate($cartCost + $deliveryCost, $percent);
+if (abs($wrongFee - 45.0) > 0.000001) {
+    $fail('sanity: 3% of cart+delivery 1500 must be 45');
+}
+
+if (abs($fee - $wrongFee) < 0.000001) {
+    $fail('cart-only and cart+delivery bases must differ for this repro');
+}
+
+$recalculatorSource = file_get_contents(__DIR__ . '/../src/Services/Order/ManagerOrderCostRecalculator.php');
+if ($recalculatorSource === false) {
+    $fail('cannot read ManagerOrderCostRecalculator.php');
+}
+
+if (!str_contains($recalculatorSource, 'OrderService::paymentCommissionBase($cartCost)')) {
+    $fail('ManagerOrderCostRecalculator must use OrderService::paymentCommissionBase($cartCost)');
+}
+
+if (preg_match('/paymentBase\s*=\s*round\s*\(\s*\$cartCost\s*\+\s*\$deliveryCost/s', $recalculatorSource) === 1) {
+    $fail('ManagerOrderCostRecalculator must not use cart+delivery as payment base');
+}
+
+$calculatorSource = file_get_contents(__DIR__ . '/../src/Services/Order/OrderCostCalculator.php');
+if ($calculatorSource === false) {
+    $fail('cannot read OrderCostCalculator.php');
+}
+
+if (!str_contains($calculatorSource, 'OrderService::paymentCommissionBase')) {
+    $fail('OrderCostCalculator must use OrderService::paymentCommissionBase');
+}
+
+fwrite(STDOUT, "OK PaymentCommissionBaseTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Процентная комиссия оплаты считалась по разным базам: storefront — только от `cart_cost`, пересчёт в менеджере — от `cart_cost + delivery_cost`. При корзине 1000, доставке 500 и `price=3%` на сайте получалось ~30, в mgr ~45.

Добавлен общий контракт `OrderService::paymentCommissionBase()` (как в MS2: только корзина). Storefront и `ManagerOrderCostRecalculator` используют один helper.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #372

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Order/OrderService.php                    # exit 0
php -l src/Services/Order/ManagerOrderCostRecalculator.php    # exit 0
php -l src/Services/Order/OrderCostCalculator.php             # exit 0
php -l tests/PaymentCommissionBaseTest.php                    # exit 0
php tests/PaymentCommissionBaseTest.php                       # exit 0
composer ci:php                                               # exit 0
```

- [x] Ручное тестирование (анализ формул + smoke)
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch fix/issue-372-payment-fee-base
- MODX: не требовался (smoke без MODX)
- PHP: 8.2+

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — n/a
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не затронут
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике репо, release-time

## Дополнительные заметки

Продуктовое решение: **cart-only** (совместимость с MS2 и текущим storefront). Заказы, уже пересчитанные в mgr с базой cart+delivery, при следующем Recalculate cost получат сумму как на сайте.