### PR TITLE
fix(order): блокировка Save во время пересчёта стоимости

### DIFF
--- a/core/components/minishop3/tests/OrderSaveRecalcRaceTest.php
+++ b/core/components/minishop3/tests/OrderSaveRecalcRaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Guards OrderView save/recalculate in-flight lock (issue #379).
+ *
+ * Run: php tests/OrderSaveRecalcRaceTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$repoRoot = dirname(__DIR__, 4);
+$orderView = $repoRoot . '/vueManager/src/components/OrderView.vue';
+$actionsBar = $repoRoot . '/vueManager/src/components/order/OrderFormActionsBar.vue';
+
+foreach ([$orderView => 'OrderView.vue', $actionsBar => 'OrderFormActionsBar.vue'] as $path => $label) {
+    if (!is_readable($path)) {
+        $fail("cannot read {$label}");
+    }
+}
+
+$orderViewSource = file_get_contents($orderView);
+$actionsBarSource = file_get_contents($actionsBar);
+
+if ($orderViewSource === false || $actionsBarSource === false) {
+    $fail('cannot read vue sources');
+}
+
+if (!preg_match('/async function saveOrder\(\)[\s\S]*?if \(recalculatingCost\.value \|\| saving\.value\)/', $orderViewSource)) {
+    $fail('saveOrder must bail out when recalculatingCost or saving is active');
+}
+
+if (!preg_match('/async function recalculateOrderCost[\s\S]*?if \(saving\.value \|\| recalculatingCost\.value\)/', $orderViewSource)) {
+    $fail('recalculateOrderCost must bail out when saving or recalculatingCost is active');
+}
+
+if (!str_contains($actionsBarSource, 'recalculatingCost')) {
+    $fail('OrderFormActionsBar must accept recalculatingCost prop');
+}
+
+if (!str_contains($actionsBarSource, ':disabled="recalculatingCost"')) {
+    $fail('Save button must be disabled while recalculatingCost');
+}
+
+fwrite(STDOUT, "OK OrderSaveRecalcRaceTest\n");
+exit(0);

--- a/vueManager/src/components/OrderView.vue
+++ b/vueManager/src/components/OrderView.vue
@@ -1024,6 +1024,9 @@ async function recalculateOrderCost(opts = {}) {
   if (isCreateMode.value || !orderId.value || orderId.value === 'new') {
     return
   }
+  if (saving.value || recalculatingCost.value) {
+    return
+  }
 
   recalculatingCost.value = true
   costRecalcWarnings.value = []
@@ -1065,6 +1068,10 @@ async function recalculateOrderCost(opts = {}) {
  * Save order
  */
 async function saveOrder() {
+  if (recalculatingCost.value || saving.value) {
+    return
+  }
+
   saving.value = true
 
   try {

--- a/vueManager/src/components/order/OrderAddressTab.vue
+++ b/vueManager/src/components/order/OrderAddressTab.vue
@@ -53,6 +53,7 @@ const {
   createOrder,
   saveOrder,
   goBack,
+  recalculatingCost,
 } = orderCtx
 
 const { _ } = useLexicon()
@@ -242,6 +243,7 @@ const showAddressTabActions = computed(
       v-if="showAddressTabActions"
       :is-create-mode="isCreateMode"
       :saving="saving"
+      :recalculating-cost="recalculatingCost"
       @create="createOrder"
       @save="saveOrder"
       @cancel="goBack"

--- a/vueManager/src/components/order/OrderFormActionsBar.vue
+++ b/vueManager/src/components/order/OrderFormActionsBar.vue
@@ -5,6 +5,8 @@ import Button from 'primevue/button'
 defineProps({
   isCreateMode: { type: Boolean, required: true },
   saving: { type: Boolean, default: false },
+  /** Blocks save while manager cost recalculation is in flight (#379). */
+  recalculatingCost: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['create', 'save', 'cancel'])
@@ -26,6 +28,7 @@ const { _ } = useLexicon()
       :label="_('save')"
       icon="pi pi-check"
       :loading="saving"
+      :disabled="recalculatingCost"
       @click="emit('save')"
     />
     <Button

--- a/vueManager/src/components/order/OrderInfoTab.vue
+++ b/vueManager/src/components/order/OrderInfoTab.vue
@@ -306,6 +306,7 @@ const showOrderInfoActions = computed(
       v-if="showOrderInfoActions"
       :is-create-mode="isCreateMode"
       :saving="saving"
+      :recalculating-cost="recalculatingCost"
       @create="createOrder"
       @save="saveOrder"
       @cancel="goBack"


### PR DESCRIPTION
## Описание

При параллельном Save и Recalculate cost PUT с snapshot старых `cost`/`cart_cost`/`delivery_cost` перезаписывал свежий результат пересчёта (lost update). Recalculate уже блокировался при `saving`, но Save не учитывал `recalculatingCost`.

Добавлены симметричные in-flight guard'ы в `saveOrder` / `recalculateOrderCost` и `:disabled` на кнопку Save, пока идёт пересчёт.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #379

## Как это было протестировано?

```bash
cd core/components/minishop3
php tests/OrderSaveRecalcRaceTest.php   # exit 0
composer ci:php                         # exit 0 (14 smoke tests)

cd ../../vueManager
npx eslint src/components/OrderView.vue \
  src/components/order/OrderFormActionsBar.vue \
  src/components/order/OrderInfoTab.vue \
  src/components/order/OrderAddressTab.vue --max-warnings 0  # exit 0
```

- [x] Ручное тестирование (анализ race + UI disabled)
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch fix/issue-379-order-save-recalc-race
- MODX: не требовался (UI + source smoke)
- PHP: 8.2+

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — n/a
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [x] ESLint проходит без ошибок (затронутые Vue-файлы)
- [ ] Обновлён CHANGELOG.md — по политике репо, release-time

## Дополнительные заметки

Out of scope: etag/updatedon merge на backend (#379 упоминает как альтернативу). Текущий фикс — UI lock + guard'ы, как в AC issue.