### PR TITLE
fix(api): безопасный CORS — без * + credentials по умолчанию

### DIFF
--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -503,7 +503,7 @@ return [
         'area' => 'ms3_api',
     ],
     'ms3_cors_allowed_origins' => [
-        'value' => '*',
+        'value' => '',
         'xtype' => 'textfield',
         'area' => 'ms3_api',
     ],

--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -36,11 +36,11 @@ use MiniShop3\Middleware\ServiceCheckMiddleware;
 
 $tokenMiddleware = new TokenMiddleware($modx);
 $corsMiddleware = new CorsMiddleware([
-    'allowed_origins' => $modx->getOption('ms3_cors_allowed_origins', null, ['*']),
+    'allowed_origins' => $modx->getOption('ms3_cors_allowed_origins', null, ''),
     'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'MS3TOKEN'],
     'allow_credentials' => true,
-    'max_age' => 86400
+    'max_age' => 86400,
 ]);
 $rateLimitMiddleware = new RateLimitMiddleware(
     $modx->getOption('ms3_rate_limit_max_attempts', null, 60),

--- a/core/components/minishop3/lexicon/en/setting.inc.php
+++ b/core/components/minishop3/lexicon/en/setting.inc.php
@@ -253,7 +253,7 @@ $_lang['setting_ms3_import_upload_path_desc'] = 'Relative path from MODX_BASE_PA
 $_lang['setting_ms3_api_debug'] = 'API debug mode';
 $_lang['setting_ms3_api_debug_desc'] = 'Enables extended logging of API requests and responses for debugging. Not recommended in production.';
 $_lang['setting_ms3_cors_allowed_origins'] = 'Allowed CORS origins';
-$_lang['setting_ms3_cors_allowed_origins_desc'] = 'List of domains allowed to make cross-origin requests to API. Use "*" to allow all or specify domains comma-separated.';
+$_lang['setting_ms3_cors_allowed_origins_desc'] = 'Comma-separated origins allowed to call the Web API (e.g. https://shop.example.com). Empty = no cross-origin CORS (same-origin only). Use "*" for any origin without credentials; for headless with cookies list explicit domains.';
 $_lang['setting_ms3_rate_limit_max_attempts'] = 'API rate limit';
 $_lang['setting_ms3_rate_limit_max_attempts_desc'] = 'Maximum number of API requests per time period. Default is 60.';
 $_lang['setting_ms3_rate_limit_decay_seconds'] = 'Rate limit time window (seconds)';

--- a/core/components/minishop3/lexicon/ru/setting.inc.php
+++ b/core/components/minishop3/lexicon/ru/setting.inc.php
@@ -253,7 +253,7 @@ $_lang['setting_ms3_import_upload_path_desc'] = 'Относительный пу
 $_lang['setting_ms3_api_debug'] = 'Режим отладки API';
 $_lang['setting_ms3_api_debug_desc'] = 'Включает расширенное логирование API запросов и ответов для отладки. Не рекомендуется на продакшене.';
 $_lang['setting_ms3_cors_allowed_origins'] = 'Разрешённые CORS origins';
-$_lang['setting_ms3_cors_allowed_origins_desc'] = 'Список доменов, которым разрешены кросс-доменные запросы к API. Используйте "*" для разрешения всех или укажите домены через запятую.';
+$_lang['setting_ms3_cors_allowed_origins_desc'] = 'Origins через запятую для Web API (например https://shop.example.com). Пусто = CORS только same-origin. «*» — любой origin без credentials; для headless с cookies укажите домены явно.';
 $_lang['setting_ms3_rate_limit_max_attempts'] = 'Лимит запросов API';
 $_lang['setting_ms3_rate_limit_max_attempts_desc'] = 'Максимальное количество API запросов за период. По умолчанию 60.';
 $_lang['setting_ms3_rate_limit_decay_seconds'] = 'Период лимита запросов (сек)';

--- a/core/components/minishop3/src/Middleware/CorsMiddleware.php
+++ b/core/components/minishop3/src/Middleware/CorsMiddleware.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Middleware;
 
 use MiniShop3\Router\Middleware\MiddlewareInterface;
 use MiniShop3\Router\Response;
+use MiniShop3\Utils\CorsConfig;
 
 /**
  * Middleware for handling CORS (Cross-Origin Resource Sharing)
@@ -33,42 +34,12 @@ class CorsMiddleware implements MiddlewareInterface
      */
     public function __construct(array $config = [])
     {
-        $this->allowedOrigins = $this->normalizeToArray($config['allowed_origins'] ?? ['*']);
-        $this->allowedMethods = $this->normalizeToArray($config['allowed_methods'] ?? ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']);
-        $this->allowedHeaders = $this->normalizeToArray($config['allowed_headers'] ?? ['Content-Type', 'Authorization', 'X-Requested-With', 'MS3TOKEN']);
-        $this->allowCredentials = (bool)($config['allow_credentials'] ?? true);
-        $this->maxAge = (int)($config['max_age'] ?? 86400); // 24 hours
-    }
-
-    /**
-     * Normalize value to array (handles string, JSON string, or array)
-     *
-     * @param mixed $value
-     * @return array
-     */
-    private function normalizeToArray(mixed $value): array
-    {
-        if (is_array($value)) {
-            return $value;
-        }
-
-        if (is_string($value)) {
-            // Try JSON decode first
-            $decoded = json_decode($value, true);
-            if (is_array($decoded)) {
-                return $decoded;
-            }
-
-            // Comma-separated string
-            if (str_contains($value, ',')) {
-                return array_map('trim', explode(',', $value));
-            }
-
-            // Single value
-            return [$value];
-        }
-
-        return ['*'];
+        $normalized = CorsConfig::normalizeCorsConfig($config);
+        $this->allowedOrigins = $normalized['allowed_origins'];
+        $this->allowedMethods = $normalized['allowed_methods'];
+        $this->allowedHeaders = $normalized['allowed_headers'];
+        $this->allowCredentials = $normalized['allow_credentials'];
+        $this->maxAge = $normalized['max_age'];
     }
 
     /**
@@ -108,13 +79,17 @@ class CorsMiddleware implements MiddlewareInterface
             return false;
         }
 
-        // If all origins are allowed
-        if (in_array('*', $this->allowedOrigins)) {
+        if ($this->allowedOrigins === []) {
+            return false;
+        }
+
+        // If all origins are allowed (credentials must be off — normalized in constructor)
+        if (CorsConfig::hasWildcardOrigin($this->allowedOrigins)) {
             return true;
         }
 
         // Check exact match
-        if (in_array($origin, $this->allowedOrigins)) {
+        if (in_array($origin, $this->allowedOrigins, true)) {
             return true;
         }
 
@@ -139,17 +114,15 @@ class CorsMiddleware implements MiddlewareInterface
      */
     private function setCorsHeaders(string $origin): void
     {
-        // For wildcard origin (*) we cannot use credentials
-        if (in_array('*', $this->allowedOrigins) && !$this->allowCredentials) {
+        if (CorsConfig::hasWildcardOrigin($this->allowedOrigins)) {
             header('Access-Control-Allow-Origin: *');
         } else {
-            // For specific origin we can use credentials
             header('Access-Control-Allow-Origin: ' . $origin);
             header('Vary: Origin');
-        }
 
-        if ($this->allowCredentials) {
-            header('Access-Control-Allow-Credentials: true');
+            if ($this->allowCredentials) {
+                header('Access-Control-Allow-Credentials: true');
+            }
         }
 
         header('Access-Control-Allow-Methods: ' . implode(', ', $this->allowedMethods));

--- a/core/components/minishop3/src/Utils/CorsConfig.php
+++ b/core/components/minishop3/src/Utils/CorsConfig.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace MiniShop3\Utils;
+
+/**
+ * Pure CORS config normalization (no MODX). Issue #335.
+ */
+final class CorsConfig
+{
+    /**
+     * Normalize CORS middleware config. Wildcard origins cannot be combined with credentials.
+     *
+     * @param array<string, mixed> $config
+     * @return array{
+     *     allowed_origins: string[],
+     *     allowed_methods: string[],
+     *     allowed_headers: string[],
+     *     allow_credentials: bool,
+     *     max_age: int
+     * }
+     */
+    public static function normalizeCorsConfig(array $config): array
+    {
+        $allowedOrigins = self::normalizeOriginsList($config['allowed_origins'] ?? '');
+        $allowCredentials = (bool) ($config['allow_credentials'] ?? true);
+
+        if (self::hasWildcardOrigin($allowedOrigins) && $allowCredentials) {
+            $allowCredentials = false;
+        }
+
+        return [
+            'allowed_origins' => $allowedOrigins,
+            'allowed_methods' => self::normalizeStringList(
+                $config['allowed_methods'] ?? ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
+            ),
+            'allowed_headers' => self::normalizeStringList(
+                $config['allowed_headers'] ?? ['Content-Type', 'Authorization', 'X-Requested-With', 'MS3TOKEN']
+            ),
+            'allow_credentials' => $allowCredentials,
+            'max_age' => max(0, (int) ($config['max_age'] ?? 86400)),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function normalizeOriginsList(mixed $value): array
+    {
+        return self::normalizeStringList($value);
+    }
+
+    public static function hasWildcardOrigin(array $origins): bool
+    {
+        return in_array('*', $origins, true);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function normalizeStringList(mixed $value): array
+    {
+        if (is_array($value)) {
+            $items = $value;
+        } elseif (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return [];
+            }
+
+            $decoded = json_decode($trimmed, true);
+            if (is_array($decoded)) {
+                $items = $decoded;
+            } elseif (str_contains($trimmed, ',')) {
+                $items = explode(',', $trimmed);
+            } else {
+                $items = [$trimmed];
+            }
+        } else {
+            return [];
+        }
+
+        $result = [];
+        foreach ($items as $item) {
+            if (!is_string($item) && !is_numeric($item)) {
+                continue;
+            }
+            $item = trim((string) $item);
+            if ($item !== '') {
+                $result[] = $item;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/core/components/minishop3/tests/CorsConfigNormalizeTest.php
+++ b/core/components/minishop3/tests/CorsConfigNormalizeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * CORS config normalization guards (issue #335).
+ *
+ * Run: php tests/CorsConfigNormalizeTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Utils\CorsConfig;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$default = CorsConfig::normalizeCorsConfig([
+    'allowed_origins' => '',
+    'allow_credentials' => true,
+]);
+
+if ($default['allowed_origins'] !== []) {
+    $fail('empty default origins must be []');
+}
+if ($default['allow_credentials'] !== true) {
+    $fail('empty default may keep allow_credentials true');
+}
+
+$wildcardWithCredentials = CorsConfig::normalizeCorsConfig([
+    'allowed_origins' => '*',
+    'allow_credentials' => true,
+]);
+
+if ($wildcardWithCredentials['allowed_origins'] !== ['*']) {
+    $fail('explicit * must remain in origins list');
+}
+if ($wildcardWithCredentials['allow_credentials'] !== false) {
+    $fail('* + allow_credentials must normalize credentials to false');
+}
+
+$allowlist = CorsConfig::normalizeCorsConfig([
+    'allowed_origins' => 'https://shop.example.com, https://app.example.com',
+    'allow_credentials' => true,
+]);
+
+if ($allowlist['allowed_origins'] !== ['https://shop.example.com', 'https://app.example.com']) {
+    $fail('comma-separated allowlist must parse');
+}
+if ($allowlist['allow_credentials'] !== true) {
+    $fail('explicit allowlist must keep allow_credentials true');
+}
+
+$runtimeGuard = CorsConfig::normalizeCorsConfig([
+    'allowed_origins' => ['*'],
+    'allow_credentials' => true,
+]);
+if (CorsConfig::hasWildcardOrigin($runtimeGuard['allowed_origins']) && $runtimeGuard['allow_credentials']) {
+    $fail('runtime must not allow * with credentials after normalize');
+}
+
+$middleware = file_get_contents(dirname(__DIR__) . '/src/Middleware/CorsMiddleware.php');
+if ($middleware === false) {
+    $fail('cannot read CorsMiddleware.php');
+}
+if (!str_contains($middleware, 'CorsConfig::normalizeCorsConfig')) {
+    $fail('CorsMiddleware must use CorsConfig::normalizeCorsConfig');
+}
+if (preg_match('/in_array\s*\(\s*[\'"]\*[\'"]\s*,\s*\$this->allowedOrigins\s*\)[\s\S]*Access-Control-Allow-Origin:\s*[\'"]\s*\.\s*\$origin/s', $middleware) === 1) {
+    $fail('CorsMiddleware must not reflect origin when wildcard is configured');
+}
+
+$webRoutes = file_get_contents(dirname(__DIR__) . '/config/routes/web.php');
+if ($webRoutes === false) {
+    $fail('cannot read web.php');
+}
+if (str_contains($webRoutes, "getOption('ms3_cors_allowed_origins', null, ['*']")) {
+    $fail('web.php must not default ms3_cors_allowed_origins to *');
+}
+
+fwrite(STDOUT, "OK CorsConfigNormalizeTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Дефолт Web API: `allowed_origins: ['*']` + `allow_credentials: true` фактически отражал любой `Origin` с cookies (нарушение CORS и риск для headless).

Добавлен `CorsConfig::normalizeCorsConfig()`: `*` автоматически отключает credentials; пустой allowlist = same-origin only. Дефолт setting и `web.php` — пустая строка вместо `*`. `CorsMiddleware` больше не отражает origin при wildcard.

## Тип изменений

- [x] Исправление бага (non-breaking change для явных allowlist)
- [ ] Breaking change — см. migration note ниже

## Связанные Issues

Closes #335

## Migration note

- **Новые установки:** cross-origin CORS выключен, пока не задан `ms3_cors_allowed_origins`.
- **Headless с cookies:** укажите домены явно (не `*`).
- **Persisted `*` в БД:** CORS остаётся открытым, но без `Allow-Credentials` — для cookie-auth нужен allowlist.

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Utils/CorsConfig.php                    # exit 0
php -l src/Middleware/CorsMiddleware.php           # exit 0
php -l config/routes/web.php                       # exit 0
php tests/CorsConfigNormalizeTest.php              # exit 0
composer ci:php                                    # exit 0 (14 smoke)
```

- [x] Автоматические тесты
- [x] Ручной анализ CORS headers logic

## Чеклист

- [x] Лексиконы ru + en обновлены
- [x] Allowlist доменов работает (parse + credentials true)
- [ ] CHANGELOG — release-time

## Gate A

| AC | Evidence |
|----|----------|
| `*` + credentials невозможны в runtime | `CorsConfigNormalizeTest` + `normalizeCorsConfig()` |
| Безопасный дефолт + лексикон | `settings.php`, `web.php`, ru/en setting.inc.php |
| Allowlist для headless | test comma-separated origins + credentials true |
| Assertion на нормализацию | `CorsConfigNormalizeTest.php` |