### PR TITLE
fix(order): повторная проверка fixed после mutation статуса плагином

### DIFF
--- a/core/components/minishop3/src/Services/Order/OrderStatusService.php
+++ b/core/components/minishop3/src/Services/Order/OrderStatusService.php
@@ -104,13 +104,9 @@ class OrderStatusService
         );
 
         if ($oldStatus) {
-            if ($oldStatus->get('final')) {
-                return $this->modx->lexicon('ms3_err_status_final');
-            }
-            if ($oldStatus->get('fixed')) {
-                if ($status->get('position') <= $oldStatus->get('position')) {
-                    return $this->modx->lexicon('ms3_err_status_fixed');
-                }
+            $transitionError = $this->validateStatusTransition($oldStatus, $status);
+            if ($transitionError !== null) {
+                return $transitionError;
             }
         }
 
@@ -143,6 +139,11 @@ class OrderStatusService
             if ($msOrder->get('status_id') == $statusId) {
                 return $this->modx->lexicon('ms3_err_status_same');
             }
+
+            $transitionError = $this->validateStatusTransition($oldStatus, $status);
+            if ($transitionError !== null) {
+                return $transitionError;
+            }
         }
 
         $msOrder->set('status_id', $statusId);
@@ -171,6 +172,28 @@ class OrderStatusService
         }
 
         return true;
+    }
+
+    /**
+     * Validate transition from old status to new (final/fixed rules).
+     */
+    protected function validateStatusTransition(
+        ?msOrderStatusModel $oldStatus,
+        msOrderStatusModel $newStatus
+    ): ?string {
+        if (!$oldStatus) {
+            return null;
+        }
+
+        if ($oldStatus->get('final')) {
+            return $this->modx->lexicon('ms3_err_status_final');
+        }
+
+        if ($oldStatus->get('fixed') && $newStatus->get('position') <= $oldStatus->get('position')) {
+            return $this->modx->lexicon('ms3_err_status_fixed');
+        }
+
+        return null;
     }
 
     /**

--- a/core/components/minishop3/tests/OrderStatusFixedRevalidateTest.php
+++ b/core/components/minishop3/tests/OrderStatusFixedRevalidateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Guards fixed/final status re-validation after plugin mutation (issue #382).
+ *
+ * Run: php tests/OrderStatusFixedRevalidateTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$source = file_get_contents(dirname(__DIR__) . '/src/Services/Order/OrderStatusService.php');
+if ($source === false) {
+    $fail('cannot read OrderStatusService.php');
+}
+
+if (!str_contains($source, 'function validateStatusTransition')) {
+    $fail('OrderStatusService must define validateStatusTransition');
+}
+
+if (!preg_match('/function validateStatusTransition[\s\S]*ms3_err_status_fixed/s', $source)) {
+    $fail('validateStatusTransition must enforce fixed status position rule');
+}
+
+if (!preg_match(
+    '/\$resolvedStatusId\s*!==\s*\$statusId[\s\S]*validateStatusTransition\s*\(\s*\$oldStatus\s*,\s*\$status\s*\)/s',
+    $source
+)) {
+    $fail('OrderStatusService must re-run validateStatusTransition after plugin status mutation');
+}
+
+fwrite(STDOUT, "OK OrderStatusFixedRevalidateTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

`OrderStatusService::change()` проверял `fixed`/`final` до `msOnBeforeChangeOrderStatus`, но не после merge `returnedValues['status']`. Плагин мог подменить target status на более ранний position и обойти правило.

Вынесена `validateStatusTransition()`; после перечитывания статуса из mutation правила применяются повторно.

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #382

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Order/OrderStatusService.php   # exit 0
php tests/OrderStatusFixedRevalidateTest.php         # exit 0
composer ci:php                                    # exit 0 (14 smoke)
```

## Gate A

| AC | Evidence |
|----|----------|
| После mutation — re-validate fixed/position | `validateStatusTransition()` после `$resolvedStatusId !== $statusId` |
| Ошибка `ms3_err_status_fixed` | тот же helper, что до события |
| Regression guard | `OrderStatusFixedRevalidateTest.php` |