### PR TITLE
fix(email): экранирование & в ссылке на заказ в письме менеджеру

### DIFF
--- a/core/components/minishop3/elements/chunks/ms3_email_new_manager.tpl
+++ b/core/components/minishop3/elements/chunks/ms3_email_new_manager.tpl
@@ -86,7 +86,7 @@
             <td>
                 <table style="width:95%;margin:auto;">
                     <tr>
-                        <td><a href="{$site_url}{'manager_url'|option}?a=mgr/orders&namespace=minishop3&order={$order.id}" target="_blank" style="{$style.a}">{'ms3_email_link_to_order' | lexicon}</a></td>
+                        <td><a href="{$site_url}{'manager_url'|option}?a=mgr/orders&amp;namespace=minishop3&amp;order={$order.id}" target="_blank" style="{$style.a}">{'ms3_email_link_to_order' | lexicon}</a></td>
                     </tr>
                 </table>
             </td>

--- a/core/components/minishop3/tests/EmailChunkHrefAmpersandTest.php
+++ b/core/components/minishop3/tests/EmailChunkHrefAmpersandTest.php
@@ -20,7 +20,10 @@ if ($files === []) {
     $fail('No ms3_email*.tpl chunks found');
 }
 
-$hrefPattern = '/href\s*=\s*("|\')([^"\']*)\1/i';
+// Match double- and single-quoted hrefs separately: a Fenom href="…{'mod'|…}…" contains
+// single quotes inside the double-quoted value, so a shared [^"']* char class would stop early
+// and never see the query-string ampersands.
+$hrefPattern = '/href\s*=\s*(?:"([^"]*)"|\'([^\']*)\')/i';
 $bareAmpersand = '/&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/';
 
 foreach ($files as $file) {
@@ -34,7 +37,7 @@ foreach ($files as $file) {
     }
 
     foreach ($matches as $match) {
-        $href = $match[2];
+        $href = ($match[1] ?? '') . ($match[2] ?? '');
         if (preg_match($bareAmpersand, $href)) {
             $fail(basename($file) . ': unescaped & in href: ' . $href);
         }

--- a/core/components/minishop3/tests/EmailChunkHrefAmpersandTest.php
+++ b/core/components/minishop3/tests/EmailChunkHrefAmpersandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Проверка email-чанков: в href не должно быть неэкранированных & (DOMDocument/htmlParseEntityRef).
+ *
+ * Запуск: php tests/EmailChunkHrefAmpersandTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$chunksDir = __DIR__ . '/../elements/chunks';
+$files = glob($chunksDir . '/ms3_email*.tpl') ?: [];
+
+if ($files === []) {
+    $fail('No ms3_email*.tpl chunks found');
+}
+
+$hrefPattern = '/href\s*=\s*("|\')([^"\']*)\1/i';
+$bareAmpersand = '/&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/';
+
+foreach ($files as $file) {
+    $content = file_get_contents($file);
+    if ($content === false) {
+        $fail('Cannot read ' . basename($file));
+    }
+
+    if (!preg_match_all($hrefPattern, $content, $matches, PREG_SET_ORDER)) {
+        continue;
+    }
+
+    foreach ($matches as $match) {
+        $href = $match[2];
+        if (preg_match($bareAmpersand, $href)) {
+            $fail(basename($file) . ': unescaped & in href: ' . $href);
+        }
+    }
+}
+
+fwrite(STDOUT, "OK EmailChunkHrefAmpersandTest (" . count($files) . " chunks)\n");
+exit(0);


### PR DESCRIPTION
## Описание

В чанке `ms3_email_new_manager` query string в `href` содержал литеральные `&` (`&namespace=…&order=…`). При отправке письма MODX прогоняет HTML через `InlineStyle` → `DOMDocument::loadHTML()`, libxml выдаёт `htmlParseEntityRef: expecting ';'` и засоряет `error.log`.

Исправление: `&` → `&amp;` в атрибуте `href`. Добавлен smoke-тест, сканирующий все `ms3_email*.tpl` на неэкранированные `&` в quoted `href`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #451

## Как это было протестировано?

Локальный CI-гейт (без MODX/MySQL):

```bash
cd core/components/minishop3
composer ci:php   # exit 0, 14 smoke tests (в т.ч. EmailChunkHrefAmpersandTest)
php -l tests/EmailChunkHrefAmpersandTest.php   # exit 0
```

- [ ] Ручное тестирование (оформление заказа + проверка `error.log` без warnings — рекомендуется на стенде)
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch fix/issue-451-email-href-amp
- MODX: n/a (smoke без MODX)
- PHP: 8.x (локально)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| warnings в error.log при каждой отправке | валидный HTML в href, warnings не ожидаются |

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок — Vue не затронут
- [ ] Обновлён CHANGELOG.md — по политике релиза

## Дополнительные заметки

- Проверены все 7 файлов `ms3_email*.tpl` — проблемный href только в `ms3_email_new_manager.tpl`.
- Кастомные чанки, переопределённые в БД MODX, пакет не обновит автоматически.
- Deep-link `?a=mgr/orders&order=` vs `?a=mgr/order&id=` — отдельная тема, не входит в scope #451.