### PR TITLE
fix(vue): unwrap пустого object/data в request.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,6 @@ jobs:
 
       - name: Vitest
         run: npm test
+
+      - name: Smoke tests
+        run: npm run test:smoke

--- a/vueManager/package.json
+++ b/vueManager/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "lint:ci": "eslint . --max-warnings 0",
+    "test:smoke": "node --test tests/*.test.js",
     "format": "prettier --write \"src/**/*.{js,vue,scss,css}\"",
     "format:check": "prettier --check \"src/**/*.{js,vue,scss,css}\"",
     "lint:all": "npm run lint && npm run format:check && npm run lint:scss",

--- a/vueManager/src/request.js
+++ b/vueManager/src/request.js
@@ -1,4 +1,31 @@
 /**
+ * Extract payload from MODX connector JSON envelope.
+ *
+ * Connector responses use `{ success, message, object?, data? }`. Callers expect
+ * the inner payload (e.g. `{ results, total }`), not the envelope with `success`.
+ *
+ * @param {unknown} responseData - Parsed JSON body from connector.php
+ * @returns {unknown} Unwrapped payload, or the original value when not an envelope
+ *
+ * Uses `!= null` so falsy scalars in `object`/`data` (0, false, "") are valid payloads.
+ */
+export function unwrapResponsePayload(responseData) {
+  if (responseData === null || typeof responseData !== 'object' || Array.isArray(responseData)) {
+    return responseData
+  }
+
+  if ('object' in responseData && responseData.object != null) {
+    return responseData.object
+  }
+
+  if ('data' in responseData && responseData.data != null) {
+    return responseData.data
+  }
+
+  return responseData
+}
+
+/**
  * API Request class for working with MiniShop3 API through MODX connector
  *
  * Features:
@@ -126,19 +153,7 @@ class Request {
         )
       }
 
-      if (responseData.object && Object.keys(responseData.object).length > 0) {
-        return responseData.object
-      } else if (
-        responseData.data &&
-        Array.isArray(responseData.data) &&
-        responseData.data.length > 0
-      ) {
-        return responseData.data
-      } else if (responseData.data && !Array.isArray(responseData.data)) {
-        return responseData.data
-      }
-
-      return responseData
+      return unwrapResponsePayload(responseData)
     } catch (error) {
       if (error instanceof RequestError) {
         throw error
@@ -236,13 +251,7 @@ class Request {
         )
       }
 
-      if (responseData.object && Object.keys(responseData.object).length > 0) {
-        return responseData.object
-      } else if (responseData.data) {
-        return responseData.data
-      }
-
-      return responseData
+      return unwrapResponsePayload(responseData)
     } catch (error) {
       if (error instanceof RequestError) {
         throw error

--- a/vueManager/tests/requestUnwrap.test.js
+++ b/vueManager/tests/requestUnwrap.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { unwrapResponsePayload } from '../src/request.js'
+
+test('returns empty object payload instead of envelope', () => {
+  const envelope = { success: true, message: '', object: {} }
+  assert.deepEqual(unwrapResponsePayload(envelope), {})
+})
+
+test('returns list payload with empty results', () => {
+  const envelope = { success: true, message: '', object: { results: [], total: 0 } }
+  assert.deepEqual(unwrapResponsePayload(envelope), { results: [], total: 0 })
+})
+
+test('returns empty data array instead of envelope', () => {
+  const envelope = { success: true, message: '', data: [] }
+  assert.deepEqual(unwrapResponsePayload(envelope), [])
+})
+
+test('returns object array payload', () => {
+  const envelope = { success: true, message: '', object: [] }
+  assert.deepEqual(unwrapResponsePayload(envelope), [])
+})
+
+test('prefers object field over data field', () => {
+  const envelope = { success: true, object: { a: 1 }, data: { b: 2 } }
+  assert.deepEqual(unwrapResponsePayload(envelope), { a: 1 })
+})
+
+test('returns non-array data object', () => {
+  const envelope = { success: true, data: { import_id: 'abc' } }
+  assert.deepEqual(unwrapResponsePayload(envelope), { import_id: 'abc' })
+})
+
+test('falls back to envelope when payload fields are null', () => {
+  const envelope = { success: true, message: 'Deleted', object: null, data: null }
+  assert.equal(unwrapResponsePayload(envelope), envelope)
+})
+
+test('returns envelope when no payload keys', () => {
+  const envelope = { success: true, message: 'ok' }
+  assert.equal(unwrapResponsePayload(envelope), envelope)
+})
+
+test('returns falsy scalar object payload', () => {
+  assert.equal(unwrapResponsePayload({ success: true, object: 0 }), 0)
+  assert.equal(unwrapResponsePayload({ success: true, object: false }), false)
+  assert.equal(unwrapResponsePayload({ success: true, object: '' }), '')
+})
+
+test('passes through non-object values', () => {
+  assert.equal(unwrapResponsePayload(null), null)
+  assert.equal(unwrapResponsePayload('ok'), 'ok')
+})


### PR DESCRIPTION
## Описание

В `request.js` unwrap отбрасывал payload, если `object` был `{}` или `data` — пустым массивом (`Object.keys().length` / `array.length > 0`). Вместо inner payload callers получали connector envelope `{ success, message, … }`. Гриды с проверкой `response.results` попадали в ветку «Invalid response» без error toast.

Добавлена функция `unwrapResponsePayload()`: при наличии ключа `object`/`data` с значением `!= null` возвращается payload (включая `{}`, `[]`, falsy scalar). Используется в `request()` и `upload()`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #388

Refs #370

## Как это было протестировано?

```bash
cd vueManager
npm run test:smoke   # exit 0, 10 tests
npm run lint:ci      # exit 0
```

CI job `vue` дополнен шагом `npm run test:smoke`.

- [ ] Ручное тестирование (грид с пустым списком / processor-style ответ)
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch fix/issue-388-request-unwrap
- MODX: n/a (unit smoke)
- PHP: n/a

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| envelope без `.results`, console.error | payload `{}` / `{ results: [], total: 0 }` |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах (JSDoc контракт unwrap)
- [x] Изменения не ломают существующую функциональность (`response.object || response` совместим)
- [ ] Лексиконы добавлены на **двух языках** — не требуется
- [ ] PHPStan — PHP не затронут
- [x] ESLint проходит без ошибок
- [ ] Обновлён CHANGELOG.md — по политике релиза

## Дополнительные заметки

- Ответы `{ success, message }` без `object`/`data` (delete и т.п.) по-прежнему возвращают envelope — намеренно, чтобы не ломать void-операции.
- Callers с `if (response.results)` при `object: {}` всё ещё покажут пустой грид и console.error; backend должен отдавать `{ results, total }`.
- Dedupe error-handling между `request()` и `upload()` — follow-up.