### PR TITLE
perf(orders): conditional Address JOIN и отдельный stats endpoint

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -772,6 +772,10 @@ $router->group('/api/mgr', function ($router) use ($modx) {
         $router->get('/filters', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->getFilters($params);
         });
+        $router->get('/stats', function ($params) use ($modx) {
+            return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
+                ->getStats(array_merge($_GET, $params));
+        });
         $router->get('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->get($params);
         });

--- a/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/OrdersController.php
@@ -20,6 +20,7 @@ use MiniShop3\Services\Delivery\DeliveryService;
 use MiniShop3\Services\FilterConfigManager;
 use MiniShop3\Services\Grid\ManagerListFilterPolicy;
 use MiniShop3\Services\Order\ManagerOrderCostRecalculator;
+use MiniShop3\Services\Order\ManagerOrderListQueryService;
 use MiniShop3\Services\Order\OrderLogService;
 use MiniShop3\Services\Order\OrderService;
 use MiniShop3\Services\Order\OrderStatusService;
@@ -192,8 +193,10 @@ class OrdersController
 
         $c = $this->modx->newQuery(msOrder::class);
 
-        // Address JOIN is always needed for search and customer info
-        $c->leftJoin(msOrderAddress::class, 'Address', '`Address`.order_id = msOrder.id');
+        $needsAddressJoin = ManagerOrderListQueryService::needsAddressJoin($params, $query, $gridFields, $sort);
+        if ($needsAddressJoin) {
+            $c->leftJoin(msOrderAddress::class, 'Address', '`Address`.order_id = msOrder.id');
+        }
 
         // Dynamic JOINs from relation fields in grid config
         $relationGroups = $gridConfig ? $gridConfig->extractRelationFields($gridFields) : [];
@@ -247,11 +250,13 @@ class OrdersController
         $countQuery->stmt->execute();
         $total = (int)$countQuery->stmt->fetchColumn();
 
-        // Build SELECT: base model fields + address fields + dynamic relation fields
+        // Build SELECT: base model fields + optional address + dynamic relation fields
         $selectParts = [
             $this->modx->getSelectColumns(msOrder::class, 'msOrder'),
-            '`Address`.first_name', '`Address`.last_name', '`Address`.phone', '`Address`.email',
         ];
+        if ($needsAddressJoin) {
+            $selectParts[] = '`Address`.first_name, `Address`.last_name, `Address`.phone, `Address`.email';
+        }
 
         // Add SELECT for relation fields
         foreach ($relationGroups as $group) {
@@ -277,13 +282,28 @@ class OrdersController
             $results[] = $this->formatOrder($row);
         }
 
-        $stats = $this->getOrdersStats($params);
-
-        return Response::success([
+        $payload = [
             'results' => $results,
             'total' => $total,
-            'stats' => $stats
-        ])->getData();
+        ];
+
+        if (ManagerOrderListQueryService::shouldIncludeStats($params)) {
+            $payload['stats'] = $this->getOrdersStats($params);
+        }
+
+        return Response::success($payload)->getData();
+    }
+
+    /**
+     * Aggregated order stats for the manager grid (same filters as getList, no pagination).
+     * GET /api/mgr/orders/stats
+     *
+     * @param array $params Filter parameters (filter_*, show_drafts, …)
+     * @return array Response envelope data
+     */
+    public function getStats(array $params = []): array
+    {
+        return Response::success($this->getOrdersStats($params))->getData();
     }
 
     /**
@@ -1521,7 +1541,7 @@ class OrdersController
     {
         $c = $this->modx->newQuery(msOrder::class);
 
-        if ($this->hasAddressFilter($params)) {
+        if (ManagerOrderListQueryService::hasAddressFilter($params)) {
             $c->leftJoin(msOrderAddress::class, 'Address', '`Address`.order_id = msOrder.id');
         }
 
@@ -1559,14 +1579,7 @@ class OrdersController
 
     protected function hasAddressFilter(array $params): bool
     {
-        foreach (self::ADDRESS_FILTER_KEYS as $fieldName) {
-            $value = $params['filter_' . $fieldName] ?? null;
-            if ($value !== null && $value !== '') {
-                return true;
-            }
-        }
-
-        return false;
+        return ManagerOrderListQueryService::hasAddressFilter($params);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Order/ManagerOrderListQueryService.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderListQueryService.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Order;
+
+/**
+ * Orders manager list query helpers (#353): conditional Address JOIN detection.
+ */
+final class ManagerOrderListQueryService
+{
+    /** filter_* keys that require Address in WHERE. */
+    public const ADDRESS_FILTER_KEYS = [
+        'customer',
+        'email',
+        'phone',
+    ];
+
+    /** Grid/sort field names backed by msOrderAddress columns. */
+    public const ADDRESS_FIELD_KEYS = [
+        'customer',
+        'email',
+        'phone',
+        'first_name',
+        'last_name',
+    ];
+
+    /**
+     * Whether list query must LEFT JOIN msOrderAddress.
+     *
+     * @param array<string, mixed>        $params     Request params (filter_* keys)
+     * @param array<int, array<string,mixed>> $gridFields Grid config rows
+     */
+    public static function needsAddressJoin(
+        array $params,
+        string $query,
+        array $gridFields,
+        string $sort,
+    ): bool {
+        if (self::hasAddressFilter($params)) {
+            return true;
+        }
+
+        if ($query !== '') {
+            return true;
+        }
+
+        if (in_array($sort, self::ADDRESS_FIELD_KEYS, true)) {
+            return true;
+        }
+
+        return self::gridNeedsAddressColumns($gridFields);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function hasAddressFilter(array $params): bool
+    {
+        foreach (self::ADDRESS_FILTER_KEYS as $fieldName) {
+            $value = $params['filter_' . $fieldName] ?? null;
+            if ($value !== null && $value !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $gridFields
+     */
+    public static function gridNeedsAddressColumns(array $gridFields): bool
+    {
+        foreach ($gridFields as $field) {
+            if (($field['visible'] ?? true) === false) {
+                continue;
+            }
+
+            $name = (string) ($field['name'] ?? '');
+            if (in_array($name, self::ADDRESS_FIELD_KEYS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function shouldIncludeStats(array $params): bool
+    {
+        if (!array_key_exists('include_stats', $params)) {
+            return false;
+        }
+
+        $value = $params['include_stats'];
+        if ($value === '' || $value === null) {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/core/components/minishop3/tests/ManagerOrderListQueryServiceTest.php
+++ b/core/components/minishop3/tests/ManagerOrderListQueryServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ManagerOrderListQueryService: conditional Address JOIN (#353).
+ *
+ * Run: php tests/ManagerOrderListQueryServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Order\ManagerOrderListQueryService;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($label . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$minimalGrid = [
+    ['name' => 'id', 'visible' => true],
+    ['name' => 'num', 'visible' => true],
+    ['name' => 'cost', 'visible' => true],
+];
+
+$gridWithCustomer = [
+    ...$minimalGrid,
+    ['name' => 'customer', 'visible' => true],
+];
+
+$gridHiddenCustomer = [
+    ...$minimalGrid,
+    ['name' => 'customer', 'visible' => false],
+];
+
+$assertSame(
+    false,
+    ManagerOrderListQueryService::needsAddressJoin([], '', $minimalGrid, 'id'),
+    'minimal grid without filters'
+);
+
+$assertSame(
+    true,
+    ManagerOrderListQueryService::needsAddressJoin([], '', $gridWithCustomer, 'id'),
+    'visible customer column'
+);
+
+$assertSame(
+    false,
+    ManagerOrderListQueryService::needsAddressJoin([], '', $gridHiddenCustomer, 'id'),
+    'hidden customer column'
+);
+
+$assertSame(
+    true,
+    ManagerOrderListQueryService::needsAddressJoin(['filter_email' => 'a@b.c'], '', $minimalGrid, 'id'),
+    'address filter'
+);
+
+$assertSame(
+    true,
+    ManagerOrderListQueryService::needsAddressJoin([], 'search', $minimalGrid, 'id'),
+    'non-empty query search'
+);
+
+$assertSame(
+    true,
+    ManagerOrderListQueryService::needsAddressJoin([], '', $minimalGrid, 'email'),
+    'sort by address field'
+);
+
+$assertSame(false, ManagerOrderListQueryService::shouldIncludeStats([]), 'include_stats default off');
+$assertSame(false, ManagerOrderListQueryService::shouldIncludeStats(['include_stats' => '0']), 'include_stats 0');
+$assertSame(true, ManagerOrderListQueryService::shouldIncludeStats(['include_stats' => '1']), 'include_stats 1');
+
+fwrite(STDOUT, "OK ManagerOrderListQueryServiceTest\n");
+exit(0);

--- a/core/components/minishop3/tests/OrdersRoutePermissionsTest.php
+++ b/core/components/minishop3/tests/OrdersRoutePermissionsTest.php
@@ -88,6 +88,7 @@ $registered = $routesProperty->getValue($router);
 $expected = [
     'GET /api/mgr/orders' => 'msorder_list',
     'GET /api/mgr/orders/filters' => 'msorder_list',
+    'GET /api/mgr/orders/stats' => 'msorder_list',
     'GET /api/mgr/orders/{id}' => 'msorder_list',
     'GET /api/mgr/orders/{id}/products' => 'msorder_list',
     'GET /api/mgr/orders/{id}/logs' => 'msorder_list',

--- a/vueManager/src/components/OrdersGrid.vue
+++ b/vueManager/src/components/OrdersGrid.vue
@@ -54,7 +54,7 @@ const {
   deleteBulk: async ids => {
     await request.delete('/api/mgr/orders/bulk', { ids })
   },
-  onSuccess: () => loadOrders(),
+  onSuccess: () => refreshGrid(),
   getItemName: item => `#${item.num || item.id}`,
 })
 
@@ -85,48 +85,59 @@ const sortedFilters = computed(() => {
 })
 
 /**
- * Load orders list
+ * Build GET params shared by list and stats endpoints.
+ *
+ * @param {{ includePagination?: boolean }} options
+ */
+function buildOrderListParams({ includePagination = true } = {}) {
+  const params = {
+    show_drafts: showDrafts.value ? 1 : 0,
+  }
+
+  if (includePagination) {
+    params.start = first.value
+    params.limit = rows.value
+    params.sort = sortField.value
+    params.dir = sortOrder.value === 1 ? 'ASC' : 'DESC'
+  }
+
+  Object.keys(filterValues.value).forEach(key => {
+    const value = filterValues.value[key]
+    if (value !== null && value !== undefined && value !== '') {
+      const filterConfig = filters.value[key]
+      if (filterConfig?.type === 'daterange' && Array.isArray(value)) {
+        if (value[0]) {
+          addFilterParam(
+            params,
+            filterConfig.fields?.from || `${key}_from`,
+            formatLocalDateYmd(value[0])
+          )
+        }
+        if (value[1]) {
+          addFilterParam(
+            params,
+            filterConfig.fields?.to || `${key}_to`,
+            formatLocalDateYmd(value[1])
+          )
+        }
+      } else if (filterConfig?.type === 'datepicker' && value) {
+        addFilterParam(params, key, formatLocalDateYmd(value))
+      } else {
+        addFilterParam(params, key, value)
+      }
+    }
+  })
+
+  return params
+}
+
+/**
+ * Load orders list (stats via GET /orders/stats — #353).
  */
 async function loadOrders() {
   try {
     await runGuarded(loading, async (signal, isCurrent) => {
-      const params = {
-        start: first.value,
-        limit: rows.value,
-        sort: sortField.value,
-        dir: sortOrder.value === 1 ? 'ASC' : 'DESC',
-        show_drafts: showDrafts.value ? 1 : 0,
-      }
-
-      // Apply filter values
-      Object.keys(filterValues.value).forEach(key => {
-        const value = filterValues.value[key]
-        if (value !== null && value !== undefined && value !== '') {
-          const filterConfig = filters.value[key]
-          if (filterConfig?.type === 'daterange' && Array.isArray(value)) {
-            if (value[0]) {
-              addFilterParam(
-                params,
-                filterConfig.fields?.from || `${key}_from`,
-                formatLocalDateYmd(value[0])
-              )
-            }
-            if (value[1]) {
-              addFilterParam(
-                params,
-                filterConfig.fields?.to || `${key}_to`,
-                formatLocalDateYmd(value[1])
-              )
-            }
-          } else if (filterConfig?.type === 'datepicker' && value) {
-            addFilterParam(params, key, formatLocalDateYmd(value))
-          } else {
-            addFilterParam(params, key, value)
-          }
-        }
-      })
-
-      const response = await request.get('/api/mgr/orders', params, { signal })
+      const response = await request.get('/api/mgr/orders', buildOrderListParams(), { signal })
 
       if (!isCurrent()) {
         return
@@ -135,9 +146,6 @@ async function loadOrders() {
       if (response && response.results) {
         orders.value = response.results
         totalRecords.value = response.total || 0
-        if (response.stats) {
-          stats.value = response.stats
-        }
       } else {
         console.error('[OrdersGrid] Invalid response:', response)
         orders.value = []
@@ -153,6 +161,24 @@ async function loadOrders() {
       life: 5000,
     })
   }
+}
+
+/**
+ * Load header stats for current filters (parallel to list, no pagination).
+ */
+async function loadOrderStats() {
+  try {
+    const response = await request.get('/api/mgr/orders/stats', buildOrderListParams({ includePagination: false }))
+    if (response && (response.month_total !== undefined || response.month_sum !== undefined)) {
+      stats.value = response
+    }
+  } catch (error) {
+    console.error('[OrdersGrid] Error loading order stats:', error)
+  }
+}
+
+async function refreshGrid() {
+  await Promise.all([loadOrders(), loadOrderStats()])
 }
 
 /**
@@ -203,7 +229,7 @@ async function deleteOrder(order) {
       life: 3000,
     })
 
-    await loadOrders()
+    await refreshGrid()
   } catch (error) {
     console.error('[OrdersGrid] Error deleting order:', error)
     toast.add({
@@ -378,7 +404,7 @@ function initFilterValues() {
  */
 function applyFilters() {
   first.value = 0
-  loadOrders()
+  refreshGrid()
 }
 
 /**
@@ -387,7 +413,7 @@ function applyFilters() {
 function clearFilters() {
   initFilterValues()
   first.value = 0
-  loadOrders()
+  refreshGrid()
 }
 
 /**
@@ -404,7 +430,7 @@ function toggleShowDrafts() {
     /* localStorage unavailable */
   }
   first.value = 0
-  loadOrders()
+  refreshGrid()
 }
 
 /**
@@ -561,7 +587,7 @@ function getCustomerLink(data) {
 
 onMounted(async () => {
   await Promise.all([loadGridConfig(), loadFiltersConfig()])
-  await loadOrders()
+  await refreshGrid()
 })
 </script>
 
@@ -775,7 +801,7 @@ onMounted(async () => {
                   grid-id="orders"
                   @edit="editOrder"
                   @delete="deleteOrder"
-                  @refresh="loadOrders"
+                  @refresh="refreshGrid"
                 />
               </template>
             </Column>


### PR DESCRIPTION
## Описание

Оптимизация manager list заказов (#353):

1. **Conditional Address JOIN** — `ManagerOrderListQueryService::needsAddressJoin()` включает JOIN только при search query, address-фильтрах (`filter_customer|email|phone`), сортировке по address-полям или видимых колонках grid (`customer`, `email`, …).
2. **Stats off hot path** — `getList` больше не вызывает `getOrdersStats()` по умолчанию. Stats доступны через `GET /api/mgr/orders/stats` (те же filter-параметры, без pagination) или legacy `?include_stats=1` на list.
3. **Vue OrdersGrid** — `loadOrders()` + `loadOrderStats()` параллельно через `refreshGrid()`; shape строк списка не меняется.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #353

Refs #338

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0, 14 smoke tests (ManagerOrderListQueryServiceTest, OrdersRoutePermissionsTest +stats route)

cd ../../../vueManager
npm run lint:ci   # exit 0
```

- [ ] Ручное тестирование (грид заказов: stats + список совпадают с прежним UX)
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch fix/issue-353
- MODX: n/a (smoke без MODX runtime для query service)
- PHP: 8.2+

## API контракт stats

| Endpoint | Ответ |
|----------|--------|
| `GET /api/mgr/orders` | `{ results, total }` (+ optional `stats` при `include_stats=1`) |
| `GET /api/mgr/orders/stats` | `{ month_sum, month_total }` (formatted strings, как раньше в list) |

Фильтры: те же `filter_*`, `show_drafts`, direct keys — без `start`/`limit`/`sort`.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Логика query в `Services/Order/ManagerOrderListQueryService`
- [x] Лексиконы — не требуется
- [x] ESLint проходит
- [ ] CHANGELOG — по политике релиза

## Дополнительные заметки

- При видимой колонке `customer` JOIN остаётся (нужны поля для `formatOrder`).
- Storefront / OrderDraft path не затронут.
- Полный распил `OrdersController` (#338) — follow-up; сервис закладывает основу для `ManagerOrderQueryService`.