### PR TITLE
chore(build): clean full vue-dist on prebuild

### DIFF
--- a/vueManager/package.json
+++ b/vueManager/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "rimraf ../assets/components/minishop3/js/mgr/vue-dist/index*.min.js",
+    "prebuild": "rimraf ../assets/components/minishop3/js/mgr/vue-dist ../assets/components/minishop3/css/mgr/vue-dist",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",


### PR DESCRIPTION
## Проблема

`prebuild` чистил только `index*.min.js`, поэтому хэшированные чанки (`DynamicField-*.min.js` и др.) накапливались в `vue-dist/` от сборки к сборке. `emptyOutDir` тут задать нельзя: у основного `vite.config.js` `output.dir` = корень репозитория, и Vite отказывается его чистить (это снесло бы весь репозиторий).

## Решение

```diff
- "prebuild": "rimraf ../assets/components/minishop3/js/mgr/vue-dist/index*.min.js",
+ "prebuild": "rimraf ../assets/components/minishop3/js/mgr/vue-dist ../assets/components/minishop3/css/mgr/vue-dist",
```

Перед каждой сборкой обе `vue-dist`-директории (JS + CSS) удаляются целиком и пересоздаются с нуля. `rimraf` уже в зависимостях, идемпотентен (не падает на отсутствующем пути) → безопасно для CI (Linux) и dev (Windows).

## Проверено

- Пересборка: **136 → 52** JS-файла (удалено 84 мёртвых), `DynamicField`-чанков **18 → 1**.
- Все entry (`product-tabs`, `order`, `orders`, `customers`…) и `primeicons` (CSS + 5 форматов шрифтов) регенерируются корректно.
- `vue-dist` в `.gitignore` — на трекинг влияет только строка в `package.json`; выигрыш идёт в транспортный пакет (меньше мусора).