### PR TITLE
feat(mgr-api): document-level ACL для category products

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -84,7 +84,8 @@ class CategoryProductsController
             return $this->errorResponse('ms3_err_category_products_list_service', HttpStatus::INTERNAL_SERVER_ERROR);
         }
 
-        $page = $listService->getPage(
+        $results = $this->collectVisibleListPage(
+            $listService,
             $categoryId,
             $params,
             $nested,
@@ -95,11 +96,19 @@ class CategoryProductsController
             $sortDir
         );
 
-        $results = $this->filterListResultsByDocumentView($page['results'], $nested);
+        $total = $this->countVisibleListResults(
+            $listService,
+            $categoryId,
+            $params,
+            $nested,
+            $gridFields,
+            (string) $sortBy,
+            $sortDir
+        );
 
         return Response::success([
             'results' => $results,
-            'total' => $page['total'],
+            'total' => $total,
         ])->getData();
     }
 
@@ -260,6 +269,7 @@ class CategoryProductsController
 
         $success = 0;
         $failed = 0;
+        $policyDenied = 0;
         $scope = $this->scopeService();
 
         foreach ($ids as $id) {
@@ -275,7 +285,7 @@ class CategoryProductsController
                 && !CategoryProductDocumentPolicy::isAllowedAll($product, $documentPolicies)
             ) {
                 $this->logDocumentPolicyDenied($product, $documentPolicies);
-                $failed++;
+                $policyDenied++;
                 continue;
             }
 
@@ -299,6 +309,13 @@ class CategoryProductsController
         }
 
         if ($success === 0) {
+            if ($policyDenied > 0) {
+                return Response::error(
+                    'Save permission denied for this document',
+                    HttpStatus::FORBIDDEN
+                )->getData();
+            }
+
             return $this->errorResponse('ms3_err_category_products_no_updates', HttpStatus::INTERNAL_SERVER_ERROR);
         }
 
@@ -434,25 +451,164 @@ class CategoryProductsController
      */
     private function filterListResultsByDocumentView(array $results, bool $nested): array
     {
-        $filtered = [];
+        if ($results === []) {
+            return [];
+        }
 
+        $productIds = array_values(array_filter(array_map(
+            static fn (array $row): int => (int) ($row['id'] ?? 0),
+            $results
+        )));
+
+        if ($productIds === []) {
+            return [];
+        }
+
+        /** @var array<int, msProduct> $productsById */
+        $productsById = [];
+        $collection = $this->modx->getCollection(msProduct::class, ['id:IN' => $productIds]);
+        foreach ($collection as $product) {
+            if ($product instanceof msProduct) {
+                $productsById[(int) $product->get('id')] = $product;
+            }
+        }
+
+        /** @var array<int, msCategory> $parentsById */
+        $parentsById = [];
+        if ($nested) {
+            $parentIds = array_values(array_unique(array_filter(array_map(
+                static fn (array $row): int => (int) ($row['parent'] ?? 0),
+                $results
+            ))));
+            if ($parentIds !== []) {
+                $parentCollection = $this->modx->getCollection(msCategory::class, ['id:IN' => $parentIds]);
+                foreach ($parentCollection as $parent) {
+                    if ($parent instanceof msCategory) {
+                        $parentsById[(int) $parent->get('id')] = $parent;
+                    }
+                }
+            }
+        }
+
+        $filtered = [];
         foreach ($results as $row) {
             $productId = (int) ($row['id'] ?? 0);
-            if ($productId <= 0) {
-                continue;
-            }
-
-            $product = $this->modx->getObject(msProduct::class, $productId);
+            $product = $productsById[$productId] ?? null;
             if (!$product instanceof msProduct) {
                 continue;
             }
 
-            if (CategoryProductDocumentPolicy::canViewInCategoryGrid($this->modx, $product, $nested)) {
+            if (CategoryProductDocumentPolicy::canViewInCategoryGridCached($product, $nested, $parentsById)) {
                 $filtered[] = $row;
             }
         }
 
         return $filtered;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $gridFields
+     * @return list<array<string, mixed>>
+     */
+    private function collectVisibleListPage(
+        CategoryProductsListService $listService,
+        int $categoryId,
+        array $params,
+        bool $nested,
+        array $gridFields,
+        int $start,
+        int $limit,
+        string $sortBy,
+        string $sortDir,
+    ): array {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $visible = [];
+        $scanOffset = 0;
+        $skipped = 0;
+        $batchSize = max($limit * 2, 20);
+
+        while (count($visible) < $limit) {
+            $page = $listService->getPage(
+                $categoryId,
+                $params,
+                $nested,
+                $gridFields,
+                $scanOffset,
+                $batchSize,
+                $sortBy,
+                $sortDir
+            );
+
+            if ($page['results'] === []) {
+                break;
+            }
+
+            $filtered = $this->filterListResultsByDocumentView($page['results'], $nested);
+            foreach ($filtered as $row) {
+                if ($skipped < $start) {
+                    $skipped++;
+                    continue;
+                }
+
+                $visible[] = $row;
+                if (count($visible) >= $limit) {
+                    break 2;
+                }
+            }
+
+            $scanOffset += count($page['results']);
+            if (count($page['results']) < $batchSize) {
+                break;
+            }
+        }
+
+        return $visible;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $gridFields
+     */
+    private function countVisibleListResults(
+        CategoryProductsListService $listService,
+        int $categoryId,
+        array $params,
+        bool $nested,
+        array $gridFields,
+        string $sortBy,
+        string $sortDir,
+    ): int {
+        $visible = 0;
+        $scanOffset = 0;
+        $batchSize = 200;
+
+        while (true) {
+            $page = $listService->getPage(
+                $categoryId,
+                $params,
+                $nested,
+                $gridFields,
+                $scanOffset,
+                $batchSize,
+                $sortBy,
+                $sortDir
+            );
+
+            if ($page['results'] === []) {
+                break;
+            }
+
+            $visible += count($this->filterListResultsByDocumentView($page['results'], $nested));
+            $scanOffset += count($page['results']);
+
+            if (count($page['results']) < $batchSize) {
+                break;
+            }
+        }
+
+        return $visible;
     }
 
     /** @param list<string> $policies */

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -7,6 +7,7 @@ use MiniShop3\Model\msProduct;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Category\CategoryProductActionPermissions;
+use MiniShop3\Services\Category\CategoryProductDocumentPolicy;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Services\Category\CategoryProductsListService;
 use MiniShop3\Services\FilterConfigManager;
@@ -59,14 +60,9 @@ class CategoryProductsController
     public function getList(array $params = []): array
     {
         $categoryId = (int) ($params['id'] ?? 0);
-
-        if (!$categoryId) {
-            return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);
-        }
-
-        $category = $this->modx->getObject(msCategory::class, $categoryId);
-        if (!$category) {
-            return $this->errorResponse('ms3_err_category_nf', HttpStatus::NOT_FOUND);
+        $resolved = $this->requireCategoryWithView($categoryId);
+        if (!$resolved instanceof msCategory) {
+            return $resolved;
         }
 
         $start = (int) ($params['start'] ?? 0);
@@ -99,8 +95,10 @@ class CategoryProductsController
             $sortDir
         );
 
+        $results = $this->filterListResultsByDocumentView($page['results'], $nested);
+
         return Response::success([
-            'results' => $page['results'],
+            'results' => $results,
             'total' => $page['total'],
         ])->getData();
     }
@@ -114,6 +112,12 @@ class CategoryProductsController
      */
     public function getFilters(array $params = []): array
     {
+        $categoryId = (int) ($params['id'] ?? 0);
+        $resolved = $this->requireCategoryWithView($categoryId);
+        if (!$resolved instanceof msCategory) {
+            return $resolved;
+        }
+
         /** @var FilterConfigManager $filterConfigManager */
         $filterConfigManager = $this->modx->services->get('ms3_filter_config');
 
@@ -139,33 +143,51 @@ class CategoryProductsController
         $items = $params['items'] ?? [];
         $nested = $this->isNested($params);
 
-        if (!$categoryId) {
-            return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);
-        }
-
         if (empty($items) || !is_array($items)) {
             return $this->errorResponse('ms3_err_items_required', HttpStatus::BAD_REQUEST);
         }
 
+        $resolved = $this->requireCategoryWithView($categoryId);
+        if (!$resolved instanceof msCategory) {
+            return $resolved;
+        }
+
         $updated = 0;
-        $scopeService = $this->scopeService();
+        $policyDenied = 0;
+
+        $scope = $this->scopeService();
 
         foreach ($items as $item) {
             $productId = (int) ($item['id'] ?? 0);
             $menuindex = (int) ($item['menuindex'] ?? 0);
 
-            if (!$productId || !$scopeService->canReorderInCategory($productId, $categoryId)) {
+            if (!$productId) {
                 continue;
             }
 
-            $product = $this->modx->getObject(msProduct::class, $productId);
+            $product = $scope->findInCategory($categoryId, $productId, $nested);
 
-            if ($product) {
-                $product->set('menuindex', $menuindex);
-                if ($product->save()) {
-                    $updated++;
-                }
+            if (!$product) {
+                continue;
             }
+
+            if (!CategoryProductDocumentPolicy::isAllowedAll($product, CategoryProductDocumentPolicy::sortPolicies())) {
+                $policyDenied++;
+                $this->logDocumentPolicyDenied($product, CategoryProductDocumentPolicy::sortPolicies());
+                continue;
+            }
+
+            $product->set('menuindex', $menuindex);
+            if ($product->save()) {
+                $updated++;
+            }
+        }
+
+        if ($updated === 0 && $policyDenied > 0) {
+            return Response::error(
+                'Save permission denied for this document',
+                HttpStatus::FORBIDDEN
+            )->getData();
         }
 
         return Response::success([
@@ -188,7 +210,7 @@ class CategoryProductsController
         $nested = $this->isNested($params);
 
         if (!$categoryId) {
-            return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
+            return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);
         }
 
         if (empty($method)) {
@@ -234,6 +256,8 @@ class CategoryProductsController
             return $this->errorResponse('ms3_err_product_ids_invalid', HttpStatus::BAD_REQUEST);
         }
 
+        $documentPolicies = CategoryProductActionPermissions::documentPoliciesForMethod($method);
+
         $success = 0;
         $failed = 0;
         $scope = $this->scopeService();
@@ -242,6 +266,15 @@ class CategoryProductsController
             $product = $scope->findInCategory($categoryId, $id, $nested);
 
             if (!$product) {
+                $failed++;
+                continue;
+            }
+
+            if (
+                $documentPolicies !== null
+                && !CategoryProductDocumentPolicy::isAllowedAll($product, $documentPolicies)
+            ) {
+                $this->logDocumentPolicyDenied($product, $documentPolicies);
                 $failed++;
                 continue;
             }
@@ -304,7 +337,7 @@ class CategoryProductsController
         $nested = $this->isNested($params);
 
         if (!$categoryId) {
-            return Response::error('Category ID is required', HttpStatus::BAD_REQUEST)->getData();
+            return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);
         }
 
         if (!$productId) {
@@ -325,6 +358,13 @@ class CategoryProductsController
         // If published param not provided, toggle current state
         if ($published === null) {
             $published = $product->get('published') ? 0 : 1;
+        }
+
+        $policies = CategoryProductDocumentPolicy::policiesForPublish((bool) $published);
+        if ($denied = CategoryProductDocumentPolicy::denialResponseAll($product, $policies)) {
+            $this->logDocumentPolicyDenied($product, $policies);
+
+            return $denied;
         }
 
         if (!$this->applyPublish($product, (bool) $published)) {
@@ -355,6 +395,77 @@ class CategoryProductsController
         return $service instanceof CategoryProductScopeService
             ? $service
             : new CategoryProductScopeService($this->modx);
+    }
+
+    /**
+     * @return msCategory|array msCategory on success, error response array on failure
+     */
+    private function requireCategoryWithView(int $categoryId): msCategory|array
+    {
+        if (!$categoryId) {
+            return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);
+        }
+
+        $category = $this->modx->getObject(msCategory::class, $categoryId);
+        if (!$category) {
+            return $this->errorResponse('ms3_err_category_nf', HttpStatus::NOT_FOUND);
+        }
+
+        if ($denied = CategoryProductDocumentPolicy::denialResponse(
+            $category,
+            CategoryProductDocumentPolicy::categoryViewPolicy()
+        )) {
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[CategoryProductsController] Document view denied for category '
+                . $categoryId
+                . ' (user id ' . (int) ($this->modx->user->get('id') ?? 0) . ')'
+            );
+
+            return $denied;
+        }
+
+        return $category;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $results
+     * @return list<array<string, mixed>>
+     */
+    private function filterListResultsByDocumentView(array $results, bool $nested): array
+    {
+        $filtered = [];
+
+        foreach ($results as $row) {
+            $productId = (int) ($row['id'] ?? 0);
+            if ($productId <= 0) {
+                continue;
+            }
+
+            $product = $this->modx->getObject(msProduct::class, $productId);
+            if (!$product instanceof msProduct) {
+                continue;
+            }
+
+            if (CategoryProductDocumentPolicy::canViewInCategoryGrid($this->modx, $product, $nested)) {
+                $filtered[] = $row;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /** @param list<string> $policies */
+    private function logDocumentPolicyDenied(msProduct $product, array $policies): void
+    {
+        $this->modx->log(
+            modX::LOG_LEVEL_WARN,
+            '[CategoryProductsController] Document policy denied ('
+            . implode(',', $policies)
+            . ') for product '
+            . (int) $product->get('id')
+            . ' (user id ' . (int) ($this->modx->user->get('id') ?? 0) . ')'
+        );
     }
 
     private function denyWithoutPermission(string $permission): ?array

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -61,7 +61,7 @@ class CategoryProductsController
     {
         $categoryId = (int) ($params['id'] ?? 0);
         $resolved = $this->requireCategoryWithView($categoryId);
-        if (!$resolved instanceof msCategory) {
+        if (is_array($resolved)) {
             return $resolved;
         }
 
@@ -114,7 +114,7 @@ class CategoryProductsController
     {
         $categoryId = (int) ($params['id'] ?? 0);
         $resolved = $this->requireCategoryWithView($categoryId);
-        if (!$resolved instanceof msCategory) {
+        if (is_array($resolved)) {
             return $resolved;
         }
 
@@ -148,7 +148,7 @@ class CategoryProductsController
         }
 
         $resolved = $this->requireCategoryWithView($categoryId);
-        if (!$resolved instanceof msCategory) {
+        if (is_array($resolved)) {
             return $resolved;
         }
 
@@ -400,7 +400,7 @@ class CategoryProductsController
     /**
      * @return msCategory|array msCategory on success, error response array on failure
      */
-    private function requireCategoryWithView(int $categoryId): msCategory|array
+    private function requireCategoryWithView(int $categoryId): object|array
     {
         if (!$categoryId) {
             return $this->errorResponse('ms3_err_category_id_required', HttpStatus::BAD_REQUEST);

--- a/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductActionPermissions.php
@@ -4,9 +4,19 @@ namespace MiniShop3\Services\Category;
 
 use MiniShop3\Router\HttpStatus;
 
-/** Maps category product bulk/multiple actions to MODX permissions (#378). */
+/** Maps category product bulk/multiple actions to MODX permissions (#378) and document policies (#445). */
 final class CategoryProductActionPermissions
 {
+    /** @var array<string, array{permission: string, document: list<string>}> */
+    private const ACTIONS = [
+        'publish' => ['permission' => 'msproduct_publish', 'document' => ['publish']],
+        'unpublish' => ['permission' => 'msproduct_publish', 'document' => ['save', 'unpublish']],
+        'delete' => ['permission' => 'msproduct_delete', 'document' => ['delete']],
+        'undelete' => ['permission' => 'msproduct_delete', 'document' => ['save', 'undelete']],
+        'show' => ['permission' => 'msproduct_save', 'document' => ['save']],
+        'hide' => ['permission' => 'msproduct_save', 'document' => ['save']],
+    ];
+
     /**
      * Permissions that may authorize POST …/products/multiple (route gate).
      *
@@ -19,12 +29,17 @@ final class CategoryProductActionPermissions
 
     public static function forMethod(string $method): ?string
     {
-        return match ($method) {
-            'publish', 'unpublish' => 'msproduct_publish',
-            'delete', 'undelete' => 'msproduct_delete',
-            'show', 'hide' => 'msproduct_save',
-            default => null,
-        };
+        return self::ACTIONS[$method]['permission'] ?? null;
+    }
+
+    /**
+     * Resource-level MODX policies required before mutating a product document.
+     *
+     * @return list<string>|null null when method is unknown
+     */
+    public static function documentPoliciesForMethod(string $method): ?array
+    {
+        return self::ACTIONS[$method]['document'] ?? null;
     }
 
     /**

--- a/core/components/minishop3/src/Services/Category/CategoryProductDocumentPolicy.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductDocumentPolicy.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace MiniShop3\Services\Category;
+
+use MiniShop3\Model\msCategory;
+use MiniShop3\Model\msProduct;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MODX\Revolution\modX;
+
+/**
+ * Resource-level MODX ACL (checkPolicy) for category product Manager API (#445).
+ *
+ * Complements global msproduct_* / view_document route permissions (#378).
+ */
+final class CategoryProductDocumentPolicy
+{
+    public const POLICY_VIEW = 'view';
+    public const POLICY_SAVE = 'save';
+    public const POLICY_PUBLISH = 'publish';
+    public const POLICY_DELETE = 'delete';
+    public const POLICY_UNPUBLISH = 'unpublish';
+    public const POLICY_UNDELETE = 'undelete';
+
+    public static function categoryViewPolicy(): string
+    {
+        return self::POLICY_VIEW;
+    }
+
+    /** @return list<string> */
+    public static function sortPolicies(): array
+    {
+        return [self::POLICY_SAVE];
+    }
+
+    /** @return list<string> */
+    public static function policiesForPublish(bool $published): array
+    {
+        return $published
+            ? [self::POLICY_PUBLISH]
+            : [self::POLICY_SAVE, self::POLICY_UNPUBLISH];
+    }
+
+    public static function isAllowed(object $resource, string $policy): bool
+    {
+        return self::evaluate($resource, $policy) === null;
+    }
+
+    /** @param list<string> $policies */
+    public static function isAllowedAll(object $resource, array $policies): bool
+    {
+        return self::evaluateAll($resource, $policies) === null;
+    }
+
+    /**
+     * @return array{status: int, message: string}|null null when allowed
+     */
+    public static function evaluate(object $resource, string $policy): ?array
+    {
+        if (method_exists($resource, 'checkPolicy') && $resource->checkPolicy($policy)) {
+            return null;
+        }
+
+        return [
+            'status' => HttpStatus::FORBIDDEN,
+            'message' => self::messageForPolicy($policy),
+        ];
+    }
+
+    /**
+     * @param list<string> $policies
+     * @return array{status: int, message: string}|null null when allowed
+     */
+    public static function evaluateAll(object $resource, array $policies): ?array
+    {
+        foreach ($policies as $policy) {
+            $denied = self::evaluate($resource, $policy);
+            if ($denied !== null) {
+                return $denied;
+            }
+        }
+
+        return null;
+    }
+
+    public static function denialResponse(object $resource, string $policy): ?array
+    {
+        return self::toErrorResponse(self::evaluate($resource, $policy));
+    }
+
+    /** @param list<string> $policies */
+    public static function denialResponseAll(object $resource, array $policies): ?array
+    {
+        return self::toErrorResponse(self::evaluateAll($resource, $policies));
+    }
+
+    public static function canViewInCategoryGrid(modX $modx, msProduct $product, bool $nested): bool
+    {
+        if (!self::isAllowed($product, self::POLICY_VIEW)) {
+            return false;
+        }
+
+        if (!$nested) {
+            return true;
+        }
+
+        $parentId = (int) $product->get('parent');
+        if ($parentId <= 0) {
+            return false;
+        }
+
+        $parent = $modx->getObject(msCategory::class, $parentId);
+        if (!$parent instanceof msCategory) {
+            return false;
+        }
+
+        return self::isAllowed($parent, self::POLICY_VIEW);
+    }
+
+    public static function toErrorResponse(?array $evaluation): ?array
+    {
+        if ($evaluation === null) {
+            return null;
+        }
+
+        return Response::error(
+            $evaluation['message'],
+            $evaluation['status']
+        )->getData();
+    }
+
+    private static function messageForPolicy(string $policy): string
+    {
+        return match ($policy) {
+            self::POLICY_VIEW => 'View permission denied for this document',
+            self::POLICY_SAVE => 'Save permission denied for this document',
+            self::POLICY_PUBLISH => 'Publish permission denied for this document',
+            self::POLICY_DELETE => 'Delete permission denied for this document',
+            self::POLICY_UNPUBLISH => 'Unpublish permission denied for this document',
+            self::POLICY_UNDELETE => 'Undelete permission denied for this document',
+            default => 'Access denied for this document',
+        };
+    }
+}

--- a/core/components/minishop3/src/Services/Category/CategoryProductDocumentPolicy.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductDocumentPolicy.php
@@ -117,6 +117,35 @@ final class CategoryProductDocumentPolicy
         return self::isAllowed($parent, self::POLICY_VIEW);
     }
 
+    /**
+     * @param array<int, msCategory> $parentsById
+     */
+    public static function canViewInCategoryGridCached(
+        msProduct $product,
+        bool $nested,
+        array $parentsById,
+    ): bool {
+        if (!self::isAllowed($product, self::POLICY_VIEW)) {
+            return false;
+        }
+
+        if (!$nested) {
+            return true;
+        }
+
+        $parentId = (int) $product->get('parent');
+        if ($parentId <= 0) {
+            return false;
+        }
+
+        $parent = $parentsById[$parentId] ?? null;
+        if (!$parent instanceof msCategory) {
+            return false;
+        }
+
+        return self::isAllowed($parent, self::POLICY_VIEW);
+    }
+
     public static function toErrorResponse(?array $evaluation): ?array
     {
         if ($evaluation === null) {

--- a/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
+++ b/core/components/minishop3/tests/CategoryProductActionPermissionsTest.php
@@ -102,4 +102,19 @@ $assertSame('msproduct_publish', $publishDenied['permission'], 'publish denied p
 
 $assertSame(true, CategoryProductActionPermissions::evaluate('show', $allowAll)['allowed'], 'show allowAll');
 
+foreach ([
+    ['publish', ['publish']],
+    ['unpublish', ['save', 'unpublish']],
+    ['delete', ['delete']],
+    ['undelete', ['save', 'undelete']],
+    ['show', ['save']],
+    ['unknown', null],
+] as [$method, $expected]) {
+    $assertSame(
+        $expected,
+        CategoryProductActionPermissions::documentPoliciesForMethod($method),
+        "documentPoliciesForMethod({$method})"
+    );
+}
+
 fwrite(STDOUT, "OK: CategoryProductActionPermissionsTest\n");

--- a/core/components/minishop3/tests/CategoryProductDocumentPolicyTest.php
+++ b/core/components/minishop3/tests/CategoryProductDocumentPolicyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Resource policy map for category product document ACL (#445).
+ *
+ * Run: php tests/CategoryProductDocumentPolicyTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Services\Category\CategoryProductDocumentPolicy;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertSame(
+    [CategoryProductDocumentPolicy::POLICY_PUBLISH],
+    CategoryProductDocumentPolicy::policiesForPublish(true),
+    'policiesForPublish(true)'
+);
+$assertSame(
+    [CategoryProductDocumentPolicy::POLICY_SAVE, CategoryProductDocumentPolicy::POLICY_UNPUBLISH],
+    CategoryProductDocumentPolicy::policiesForPublish(false),
+    'policiesForPublish(false)'
+);
+$assertSame(
+    [CategoryProductDocumentPolicy::POLICY_SAVE],
+    CategoryProductDocumentPolicy::sortPolicies(),
+    'sortPolicies'
+);
+$assertSame(
+    CategoryProductDocumentPolicy::POLICY_VIEW,
+    CategoryProductDocumentPolicy::categoryViewPolicy(),
+    'categoryViewPolicy'
+);
+
+$allowed = new class {
+    public function checkPolicy(string $policy): bool
+    {
+        return $policy === 'view';
+    }
+};
+
+$denied = new class {
+    public function checkPolicy(string $policy): bool
+    {
+        return false;
+    }
+};
+
+$partial = new class {
+    public function checkPolicy(string $policy): bool
+    {
+        return $policy === 'save';
+    }
+};
+
+$assertSame(true, CategoryProductDocumentPolicy::isAllowed($allowed, 'view'), 'isAllowed view');
+$assertSame(false, CategoryProductDocumentPolicy::isAllowed($denied, 'view'), 'isAllowed denied');
+$assertSame(
+    true,
+    CategoryProductDocumentPolicy::isAllowedAll($partial, ['save']),
+    'isAllowedAll single save'
+);
+$assertSame(
+    false,
+    CategoryProductDocumentPolicy::isAllowedAll($partial, ['save', 'unpublish']),
+    'isAllowedAll compound partial failure'
+);
+
+$viewDenied = CategoryProductDocumentPolicy::evaluate($denied, 'view');
+$assertSame(HttpStatus::FORBIDDEN, $viewDenied['status'] ?? null, 'evaluate denied status');
+$assertSame(
+    'View permission denied for this document',
+    $viewDenied['message'] ?? null,
+    'evaluate denied message'
+);
+
+$noPolicyObject = new stdClass();
+$noPolicyDenied = CategoryProductDocumentPolicy::evaluate($noPolicyObject, 'view');
+$assertSame(HttpStatus::FORBIDDEN, $noPolicyDenied['status'] ?? null, 'evaluate without checkPolicy status');
+
+fwrite(STDOUT, "OK: CategoryProductDocumentPolicyTest\n");

--- a/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
+++ b/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/stubs/ModxStub.php';
 require __DIR__ . '/stubs/StubMsProduct.php';
+require __DIR__ . '/stubs/StubMsCategory.php';
 require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
+++ b/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
@@ -42,6 +42,31 @@ class CategoryProductScopeModxStub extends modX
     {
         $this->getObjectCalls[] = ['class' => $className, 'criteria' => $criteria];
 
+        if ($className === msCategory::class) {
+            $categoryId = is_array($criteria)
+                ? (int) ($criteria['id'] ?? 0)
+                : (int) $criteria;
+
+            if ($categoryId <= 0) {
+                return null;
+            }
+
+            foreach ($this->categories as $row) {
+                if ((int) $row['id'] === $categoryId) {
+                    return new StubMsCategory($row);
+                }
+            }
+
+            // Category ids used as product parents / API path params (direct children grid).
+            foreach ($this->products as $product) {
+                if ((int) ($product['parent'] ?? 0) === $categoryId) {
+                    return new StubMsCategory(['id' => $categoryId]);
+                }
+            }
+
+            return null;
+        }
+
         if ($className !== msProduct::class) {
             return null;
         }

--- a/core/components/minishop3/tests/stubs/StubMsCategory.php
+++ b/core/components/minishop3/tests/stubs/StubMsCategory.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace MiniShop3\Tests\Stubs;
 
 /**
- * Minimal msProduct stand-in for scope / controller smoke tests.
+ * Minimal msCategory stand-in for document ACL smoke tests (#445).
  */
-class StubMsProduct
+class StubMsCategory
 {
     /** @var array<string, mixed> */
     private array $data;
@@ -28,16 +28,6 @@ class StubMsProduct
     public function get(string $key): mixed
     {
         return $this->data[$key] ?? null;
-    }
-
-    public function set(string $key, mixed $value): void
-    {
-        $this->data[$key] = $value;
-    }
-
-    public function save(): bool
-    {
-        return true;
     }
 
     public function checkPolicy(string $policy): bool


### PR DESCRIPTION
## Описание

Добавлен resource-level ACL (`checkPolicy`) для Manager API «Товары категории»: поверх глобальных `view_document` / `msproduct_*` (#378) проверяются права MODX на документ категории и каждый товар.

- **Read** (`getList`, `getFilters`): `view` на категорию; в списке — `view` на товар, при `nested=1` также `view` на родительскую категорию товара.
- **Write** (`sort`, `multiple`, `publish`): `save` / `publish` / `delete` (+ составные `save+unpublish`, `save+undelete` как в legacy processors).
- Единый реестр action → permission + document policies в `CategoryProductActionPermissions`.

Closes #445

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #445

Дополнительно: дополняет #378; не заменяет category scope IDOR из #418 / PR #443.

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0
```

- `php -l` — 378 PHP-файлов, exit 0
- Smoke: `CategoryProductDocumentPolicyTest.php`, `CategoryProductActionPermissionsTest.php` и остальные 19 тестов — exit 0

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-445-category-document-acl`
- MODX: не требовался (smoke без MODX)
- PHP: 8.2+

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность (ужесточение ACL)
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — сообщения на англ., как в соседнем `ProductDataService`
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не затронут
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- `getList`: `total` из SQL может быть выше числа видимых строк после document ACL filter на странице (pagination edge case); данные недоступных товаров не отдаются.
- Web API не затронут (scope issue).