### PR TITLE
Web API: публичный Customer DTO и allowlist полей профиля

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -7,6 +7,7 @@ use MiniShop3\Model\msCustomer;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MODX\Revolution\modX;
 
@@ -144,6 +145,7 @@ class CustomerEmailController
                 $this->modx->lexicon('ms3_customer_email_verified'),
                 [
                     'customer_id' => $customer->id,
+                    'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3),
                     'token' => null,
                     'expires_at' => null,
                 ]
@@ -163,6 +165,7 @@ class CustomerEmailController
             $this->modx->lexicon('ms3_customer_email_verified'),
             [
                 'customer_id' => $customer->id,
+                'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3),
                 'token' => $session['token'],
                 'expires_at' => $session['expires_at'],
             ]

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -22,31 +22,6 @@ use Rakit\Validation\Validator;
  */
 class CustomerProfileController
 {
-    /**
-     * Field names never editable via POST /api/v1/customer/add (security & system counters).
-     *
-     * @var list<string>
-     */
-    private const PROFILE_QUICK_UPDATE_FORBIDDEN = [
-        'id',
-        'token',
-        'user_id',
-        'password',
-        'email_verified_at',
-        'is_active',
-        'is_blocked',
-        'failed_login_attempts',
-        'blocked_until',
-        'created_at',
-        'updated_at',
-        'last_login_at',
-        'orders_count',
-        'total_spent',
-        'last_order_at',
-        'privacy_accepted_at',
-        'privacy_ip',
-    ];
-
     /** @var modX */
     protected modX $modx;
 
@@ -92,9 +67,26 @@ class CustomerProfileController
         }
 
         $customerId = (int)$customer->get('id');
-        $validator = new Validator();
-        $validation = $validator->make($data, $this->getProfileFieldRules());
+        $this->ms3->loadMap();
+        $editableKeys = CustomerPublicDto::editableFieldKeys($this->modx, $this->ms3);
+        $data = array_intersect_key($data, array_flip($editableKeys));
 
+        $rules = $this->getProfileFieldRules();
+        foreach (array_keys($rules) as $coreKey) {
+            if (!array_key_exists($coreKey, $data)) {
+                $_SESSION['ms3']['customer_profile_errors'] = [
+                    $coreKey => $this->modx->lexicon('ms3_customer_err_validation'),
+                ];
+
+                return $this->error(
+                    $this->modx->lexicon('ms3_customer_err_validation'),
+                    ['errors' => [$coreKey => $this->modx->lexicon('ms3_customer_err_validation')]]
+                );
+            }
+        }
+
+        $validator = new Validator();
+        $validation = $validator->make($data, $rules);
         $validation->validate();
 
         if ($validation->fails()) {
@@ -107,21 +99,33 @@ class CustomerProfileController
             );
         }
 
-        $newEmail = trim($data['email']);
-
-        if (!$this->isEmailAvailable($customer, $newEmail)) {
-            $_SESSION['ms3']['customer_profile_errors'] = [
-                'email' => $this->modx->lexicon('ms3_customer_err_email_exists')
-            ];
-            return $this->error($this->modx->lexicon('ms3_customer_err_email_exists'));
+        $fieldMeta = $this->modx->getFieldMeta(msCustomer::class);
+        if (!is_array($fieldMeta) || $fieldMeta === []) {
+            return $this->error($this->modx->lexicon('ms3_customer_err_save'));
         }
 
-        $this->resetEmailVerificationIfChanged($customer, $newEmail);
+        foreach ($data as $key => $rawValue) {
+            if ($key === 'email') {
+                $newEmail = trim((string) $rawValue);
+                if (!$this->isEmailAvailable($customer, $newEmail)) {
+                    $_SESSION['ms3']['customer_profile_errors'] = [
+                        'email' => $this->modx->lexicon('ms3_customer_err_email_exists'),
+                    ];
 
-        $customer->set('first_name', trim($data['first_name']));
-        $customer->set('last_name', trim($data['last_name']));
-        $customer->set('email', $newEmail);
-        $customer->set('phone', trim($data['phone']));
+                    return $this->error($this->modx->lexicon('ms3_customer_err_email_exists'));
+                }
+                $this->resetEmailVerificationIfChanged($customer, $newEmail);
+                $customer->set('email', $newEmail);
+                continue;
+            }
+
+            if (isset($rules[$key])) {
+                $customer->set($key, trim((string) $rawValue));
+                continue;
+            }
+
+            $customer->set($key, $this->normalizeQuickProfileValue($rawValue, $fieldMeta[$key]));
+        }
 
         if (!$customer->save()) {
             return $this->error($this->modx->lexicon('ms3_customer_err_save'));
@@ -136,7 +140,7 @@ class CustomerProfileController
 
         return $this->success(
             $this->modx->lexicon('ms3_customer_profile_updated'),
-            ['customer' => CustomerPublicDto::fromCustomer($customer)]
+            ['customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3)]
         );
     }
 
@@ -171,16 +175,13 @@ class CustomerProfileController
         }
 
         $this->ms3->loadMap();
+        $editableKeys = CustomerPublicDto::editableFieldKeys($this->modx, $this->ms3);
+        if (!in_array($key, $editableKeys, true)) {
+            return $this->error($this->modx->lexicon('ms3_customer_err_field_not_allowed'));
+        }
+
         $fieldMeta = $this->modx->getFieldMeta(msCustomer::class);
-        if (!is_array($fieldMeta) || $fieldMeta === []) {
-            return $this->error($this->modx->lexicon('ms3_customer_err_field_not_allowed'));
-        }
-
-        if (in_array($key, self::PROFILE_QUICK_UPDATE_FORBIDDEN, true)) {
-            return $this->error($this->modx->lexicon('ms3_customer_err_field_not_allowed'));
-        }
-
-        if (!isset($fieldMeta[$key])) {
+        if (!is_array($fieldMeta) || !isset($fieldMeta[$key])) {
             return $this->error($this->modx->lexicon('ms3_customer_err_field_not_allowed'));
         }
 
@@ -220,7 +221,7 @@ class CustomerProfileController
             $this->modx->lexicon('ms3_customer_profile_updated'),
             [
                 $key => $customer->get($key),
-                'customer' => CustomerPublicDto::fromCustomer($customer),
+                'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3),
             ]
         );
     }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -71,19 +71,14 @@ class CustomerProfileController
         $editableKeys = CustomerPublicDto::editableFieldKeys($this->modx, $this->ms3);
         $data = array_intersect_key($data, array_flip($editableKeys));
 
-        $rules = $this->getProfileFieldRules();
-        foreach (array_keys($rules) as $coreKey) {
-            if (!array_key_exists($coreKey, $data)) {
-                $_SESSION['ms3']['customer_profile_errors'] = [
-                    $coreKey => $this->modx->lexicon('ms3_customer_err_validation'),
-                ];
-
-                return $this->error(
-                    $this->modx->lexicon('ms3_customer_err_validation'),
-                    ['errors' => [$coreKey => $this->modx->lexicon('ms3_customer_err_validation')]]
-                );
-            }
+        if ($data === []) {
+            return $this->error($this->modx->lexicon('ms3_customer_err_validation'));
         }
+
+        // Partial update: validate only the core profile rules for fields
+        // actually present in $data. Missing core fields are left untouched
+        // rather than rejected (#424 review).
+        $rules = array_intersect_key($this->getProfileFieldRules(), $data);
 
         $validator = new Validator();
         $validation = $validator->make($data, $rules);

--- a/core/components/minishop3/src/Processors/Api/Customer/Login.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Login.php
@@ -2,8 +2,10 @@
 
 namespace MiniShop3\Processors\Api\Customer;
 
+use MiniShop3\MiniShop3;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MiniShop3\Services\Customer\RateLimiter;
 use MODX\Revolution\Processors\Processor;
 
@@ -106,15 +108,11 @@ class Login extends Processor
             $redirectUrl = $this->modx->makeUrl($redirectPageId, '', '', 'full');
         }
 
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+
         return $this->success('', [
-            'customer' => [
-                'id' => $customer->id,
-                'email' => $customer->get('email'),
-                'first_name' => $customer->get('first_name'),
-                'last_name' => $customer->get('last_name'),
-                'phone' => $customer->get('phone'),
-                'email_verified' => !empty($customer->get('email_verified_at')),
-            ],
+            'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $ms3),
             'token' => $session['token'],
             'expires_at' => $session['expires_at'],
             'redirect_url' => $redirectUrl,

--- a/core/components/minishop3/src/Processors/Api/Customer/Register.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/Register.php
@@ -2,8 +2,10 @@
 
 namespace MiniShop3\Processors\Api\Customer;
 
+use MiniShop3\MiniShop3;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MiniShop3\Services\Customer\RateLimiter;
 use MiniShop3\Services\Customer\RegisterService;
@@ -117,15 +119,11 @@ class Register extends Processor
             }
         }
 
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+
         return $this->success($this->modx->lexicon('ms3_customer_register_success'), [
-            'customer' => [
-                'id' => $customer->id,
-                'email' => $customer->get('email'),
-                'first_name' => $customer->get('first_name'),
-                'last_name' => $customer->get('last_name'),
-                'phone' => $customer->get('phone'),
-                'email_verified' => !empty($customer->get('email_verified_at')),
-            ],
+            'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $ms3),
             'token' => $tokenString,
             'expires_at' => $expiresAt,
             'email_verification_required' => $requireEmailVerification,

--- a/core/components/minishop3/src/Processors/Api/Customer/VerifyEmail.php
+++ b/core/components/minishop3/src/Processors/Api/Customer/VerifyEmail.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3\Processors\Api\Customer;
 
+use MiniShop3\MiniShop3;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MiniShop3\Services\Customer\EmailVerificationService;
 use MODX\Revolution\Processors\Processor;
 
@@ -39,12 +41,11 @@ class VerifyEmail extends Processor
             return $this->failure($this->modx->lexicon('ms3_customer_err_email_verification_invalid'));
         }
 
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+
         return $this->success($this->modx->lexicon('ms3_customer_email_verify_success'), [
-            'customer' => [
-                'id' => $customer->id,
-                'email' => $customer->get('email'),
-                'email_verified' => true,
-            ],
+            'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $ms3),
         ]);
     }
 }

--- a/core/components/minishop3/src/Services/Customer/CustomerExtraFieldRegistry.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerExtraFieldRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Customer;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msExtraField;
+use MODX\Revolution\modX;
+
+/**
+ * DB lookup of active msExtraField keys for msCustomer (#424).
+ *
+ * Extracted from CustomerPublicDto so the extra-field query is reusable and
+ * testable without dragging the whole DTO allowlist along.
+ */
+final class CustomerExtraFieldRegistry
+{
+    /**
+     * Active msExtraField keys registered for msCustomer.
+     *
+     * @return list<string>
+     */
+    public static function activeKeys(modX $modx): array
+    {
+        $keys = [];
+        $iterator = $modx->getIterator(msExtraField::class, [
+            'class' => msCustomer::class,
+            'active' => 1,
+        ]);
+
+        foreach ($iterator as $field) {
+            $keys[] = (string) $field->get('key');
+        }
+
+        return $keys;
+    }
+}

--- a/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
@@ -6,7 +6,6 @@ namespace MiniShop3\Services\Customer;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
-use MiniShop3\Model\msExtraField;
 use MODX\Revolution\modX;
 
 /**
@@ -87,13 +86,9 @@ final class CustomerPublicDto
     /**
      * @return array<string, mixed>
      */
-    public static function fromCustomer(msCustomer $customer, ?modX $modx = null, ?MiniShop3 $ms3 = null): array
+    public static function fromCustomer(msCustomer $customer, modX $modx, MiniShop3 $ms3): array
     {
-        $extraKeys = ($modx !== null && $ms3 !== null)
-            ? self::activeCustomerExtraFieldKeys($modx)
-            : [];
-
-        return self::fromArray($customer->toArray(), $extraKeys);
+        return self::fromArray($customer->toArray(), CustomerExtraFieldRegistry::activeKeys($modx));
     }
 
     /**
@@ -149,7 +144,7 @@ final class CustomerPublicDto
             return self::CORE_PROFILE_EDITABLE_FIELDS;
         }
 
-        $extraKeys = self::activeCustomerExtraFieldKeys($modx);
+        $extraKeys = CustomerExtraFieldRegistry::activeKeys($modx);
         $merged = self::mergeEditableFieldKeys($extraKeys);
 
         return array_values(array_filter(
@@ -161,23 +156,5 @@ final class CustomerPublicDto
     public static function isEditableField(string $key, modX $modx, MiniShop3 $ms3): bool
     {
         return in_array($key, self::editableFieldKeys($modx, $ms3), true);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function activeCustomerExtraFieldKeys(modX $modx): array
-    {
-        $keys = [];
-        $iterator = $modx->getIterator(msExtraField::class, [
-            'class' => msCustomer::class,
-            'active' => 1,
-        ]);
-
-        foreach ($iterator as $field) {
-            $keys[] = (string) $field->get('key');
-        }
-
-        return $keys;
     }
 }

--- a/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerPublicDto.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace MiniShop3\Services\Customer;
 
+use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msExtraField;
+use MODX\Revolution\modX;
 
 /**
- * Public customer payload for Web API responses (no secrets / lock internals).
+ * Public customer payload and profile field allowlist for Web API (#424).
  */
 final class CustomerPublicDto
 {
     /**
-     * Fields allowed in public customer JSON (fail-closed for new columns).
+     * Core fields exposed in public customer JSON (fail-closed for new columns).
      *
      * @var list<string>
      */
@@ -34,19 +37,147 @@ final class CustomerPublicDto
     ];
 
     /**
+     * Base profile fields editable via Web API (Rakit rules apply in controller).
+     *
+     * @var list<string>
+     */
+    public const CORE_PROFILE_EDITABLE_FIELDS = [
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+    ];
+
+    /**
+     * Never writable from Web customer profile/add endpoints.
+     *
+     * @var list<string>
+     */
+    public const SYSTEM_NON_EDITABLE_FIELDS = [
+        'id',
+        'token',
+        'user_id',
+        'password',
+        'email_verified_at',
+        'is_active',
+        'is_blocked',
+        'failed_login_attempts',
+        'blocked_until',
+        'created_at',
+        'updated_at',
+        'last_login_at',
+        'orders_count',
+        'total_spent',
+        'last_order_at',
+        'privacy_accepted_at',
+        'privacy_ip',
+    ];
+
+    /**
      * @param array<string, mixed> $customerFields
      * @return array<string, mixed>
      */
-    public static function fromArray(array $customerFields): array
+    public static function fromArray(array $customerFields, array $extraPublicKeys = []): array
     {
-        return array_intersect_key($customerFields, array_flip(self::PUBLIC_FIELDS));
+        $allowed = self::publicFieldKeys($extraPublicKeys);
+
+        return array_intersect_key($customerFields, array_flip($allowed));
     }
 
     /**
      * @return array<string, mixed>
      */
-    public static function fromCustomer(msCustomer $customer): array
+    public static function fromCustomer(msCustomer $customer, ?modX $modx = null, ?MiniShop3 $ms3 = null): array
     {
-        return self::fromArray($customer->toArray());
+        $extraKeys = ($modx !== null && $ms3 !== null)
+            ? self::activeCustomerExtraFieldKeys($modx)
+            : [];
+
+        return self::fromArray($customer->toArray(), $extraKeys);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function publicFieldKeys(array $extraFieldKeys = []): array
+    {
+        $keys = self::PUBLIC_FIELDS;
+
+        foreach ($extraFieldKeys as $key) {
+            $key = (string) $key;
+            if ($key === '' || in_array($key, self::SYSTEM_NON_EDITABLE_FIELDS, true)) {
+                continue;
+            }
+            if (!in_array($key, $keys, true)) {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @param list<string> $extraFieldKeys Active msExtraField keys for msCustomer
+     *
+     * @return list<string>
+     */
+    public static function mergeEditableFieldKeys(array $extraFieldKeys): array
+    {
+        $allowed = self::CORE_PROFILE_EDITABLE_FIELDS;
+
+        foreach ($extraFieldKeys as $key) {
+            $key = (string) $key;
+            if ($key === '' || in_array($key, self::SYSTEM_NON_EDITABLE_FIELDS, true)) {
+                continue;
+            }
+            if (!in_array($key, $allowed, true)) {
+                $allowed[] = $key;
+            }
+        }
+
+        return $allowed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function editableFieldKeys(modX $modx, MiniShop3 $ms3): array
+    {
+        $ms3->loadMap();
+        $fieldMeta = $modx->getFieldMeta(msCustomer::class);
+        if (!is_array($fieldMeta) || $fieldMeta === []) {
+            return self::CORE_PROFILE_EDITABLE_FIELDS;
+        }
+
+        $extraKeys = self::activeCustomerExtraFieldKeys($modx);
+        $merged = self::mergeEditableFieldKeys($extraKeys);
+
+        return array_values(array_filter(
+            $merged,
+            static fn(string $key): bool => isset($fieldMeta[$key])
+        ));
+    }
+
+    public static function isEditableField(string $key, modX $modx, MiniShop3 $ms3): bool
+    {
+        return in_array($key, self::editableFieldKeys($modx, $ms3), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function activeCustomerExtraFieldKeys(modX $modx): array
+    {
+        $keys = [];
+        $iterator = $modx->getIterator(msExtraField::class, [
+            'class' => msCustomer::class,
+            'active' => 1,
+        ]);
+
+        foreach ($iterator as $field) {
+            $keys[] = (string) $field->get('key');
+        }
+
+        return $keys;
     }
 }

--- a/core/components/minishop3/tests/CustomerAuthProcessorsDtoTest.php
+++ b/core/components/minishop3/tests/CustomerAuthProcessorsDtoTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Web auth processors must serialize customer via CustomerPublicDto (#424).
+ *
+ * Run: php tests/CustomerAuthProcessorsDtoTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$processors = [
+    'Login.php',
+    'Register.php',
+    'VerifyEmail.php',
+];
+
+foreach ($processors as $file) {
+    $path = __DIR__ . '/../src/Processors/Api/Customer/' . $file;
+    $src = file_get_contents($path);
+    if ($src === false || $src === '') {
+        $fail("unable to read {$file}");
+    }
+
+    if (!str_contains($src, 'use MiniShop3\\Services\\Customer\\CustomerPublicDto;')) {
+        $fail("{$file} must import CustomerPublicDto");
+    }
+
+    if (!str_contains($src, 'CustomerPublicDto::fromCustomer($customer, $this->modx, $ms3)')) {
+        $fail("{$file} must return customer via CustomerPublicDto::fromCustomer");
+    }
+
+    if (preg_match("/'email_verified'\\s*=>/", $src)) {
+        $fail("{$file} must not expose legacy email_verified boolean");
+    }
+
+    if (preg_match("/'customer'\\s*=>\\s*\\[/", $src)) {
+        $fail("{$file} must not build inline customer array");
+    }
+}
+
+fwrite(STDOUT, "OK CustomerAuthProcessorsDtoTest\n");
+exit(0);

--- a/core/components/minishop3/tests/CustomerAuthProcessorsDtoTest.php
+++ b/core/components/minishop3/tests/CustomerAuthProcessorsDtoTest.php
@@ -1,12 +1,25 @@
 <?php
 
 /**
- * Web auth processors must serialize customer via CustomerPublicDto (#424).
+ * Web auth processors must serialize customer via CustomerPublicDto (#424),
+ * plus a behavior test for the DTO serialization itself.
  *
  * Run: php tests/CustomerAuthProcessorsDtoTest.php
  */
 
 declare(strict_types=1);
+
+require __DIR__ . '/support/xpdo_stub.php';
+require __DIR__ . '/support/xpdo_om_stub.php';
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/StubMsCustomer.php';
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msExtraField;
+use MiniShop3\Services\Customer\CustomerPublicDto;
+use MiniShop3\Tests\Stubs\StubMsCustomer;
+use MODX\Revolution\modX;
 
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
@@ -41,6 +54,128 @@ foreach ($processors as $file) {
     if (preg_match("/'customer'\\s*=>\\s*\\[/", $src)) {
         $fail("{$file} must not build inline customer array");
     }
+}
+
+// Behavior test: fromCustomer() serializes a customer with extra-field allowlist
+// and never leaks secret/system columns (#424 review: replace grep-only checks).
+$extraKeys = ['loyalty_tier', 'company'];
+
+$modx = new class ($extraKeys) extends modX {
+    /** @var list<string> */
+    private array $extraKeys;
+
+    /**
+     * @param list<string> $extraKeys
+     */
+    public function __construct(array $extraKeys)
+    {
+        parent::__construct();
+        $this->extraKeys = $extraKeys;
+    }
+
+    public function getIterator($className, $criteria = null)
+    {
+        if ($className !== msExtraField::class) {
+            return new ArrayIterator([]);
+        }
+
+        $fields = array_map(
+            static fn(string $key): object => new class ($key) {
+                public function __construct(private string $key)
+                {
+                }
+
+                public function get(string $k): mixed
+                {
+                    return $k === 'key' ? $this->key : null;
+                }
+            },
+            $this->extraKeys
+        );
+
+        return new ArrayIterator($fields);
+    }
+};
+
+$ms3 = new class extends MiniShop3 {
+    public function __construct()
+    {
+        // Bypass real constructor: fromCustomer() does not use ms3.
+    }
+};
+
+$customer = new StubMsCustomer([
+    'id' => 42,
+    'user_id' => 7,
+    'first_name' => 'Ada',
+    'last_name' => 'Lovelace',
+    'email' => 'ada@example.com',
+    'phone' => '+10000000000',
+    'password' => '$2y$10$notarealhash',
+    'token' => 'session-or-api-secret',
+    'email_verified_at' => '2026-01-02 03:04:05',
+    'is_active' => true,
+    'is_blocked' => true,
+    'privacy_ip' => '203.0.113.10',
+    'failed_login_attempts' => 3,
+    'blocked_until' => '2026-01-01 00:00:00',
+    'created_at' => '2025-01-01 00:00:00',
+    'updated_at' => '2025-06-01 00:00:00',
+    'last_login_at' => '2025-12-01 00:00:00',
+    'orders_count' => 2,
+    'total_spent' => 99.5,
+    'last_order_at' => '2025-11-01 00:00:00',
+    'privacy_accepted_at' => '2025-01-01 00:00:00',
+    'loyalty_tier' => 'gold',
+    'company' => 'ACME',
+    'future_secret_column' => 'must-not-leak',
+]);
+
+$public = CustomerPublicDto::fromCustomer($customer, $modx, $ms3);
+
+$expected = [
+    'id' => 42,
+    'first_name' => 'Ada',
+    'last_name' => 'Lovelace',
+    'email' => 'ada@example.com',
+    'phone' => '+10000000000',
+    'email_verified_at' => '2026-01-02 03:04:05',
+    'is_active' => true,
+    'created_at' => '2025-01-01 00:00:00',
+    'updated_at' => '2025-06-01 00:00:00',
+    'last_login_at' => '2025-12-01 00:00:00',
+    'orders_count' => 2,
+    'total_spent' => 99.5,
+    'last_order_at' => '2025-11-01 00:00:00',
+    'privacy_accepted_at' => '2025-01-01 00:00:00',
+    'loyalty_tier' => 'gold',
+    'company' => 'ACME',
+];
+
+if ($public !== $expected) {
+    $fail(sprintf(
+        "fromCustomer behavior mismatch:\nexpected: %s\nactual:   %s",
+        json_encode($expected, JSON_UNESCAPED_SLASHES),
+        json_encode($public, JSON_UNESCAPED_SLASHES)
+    ));
+}
+
+foreach (['password', 'token', 'privacy_ip', 'failed_login_attempts', 'blocked_until', 'is_blocked', 'user_id', 'future_secret_column'] as $hidden) {
+    if (array_key_exists($hidden, $public)) {
+        $fail("fromCustomer leaked secret/system field: {$hidden}");
+    }
+}
+
+// Empty extra-field registry → only core public fields, no extras leak.
+$emptyModx = new class extends modX {
+    public function getIterator($className, $criteria = null)
+    {
+        return new ArrayIterator([]);
+    }
+};
+$barePublic = CustomerPublicDto::fromCustomer($customer, $emptyModx, $ms3);
+if (array_key_exists('loyalty_tier', $barePublic) || array_key_exists('company', $barePublic)) {
+    $fail('fromCustomer must not expose extra fields when registry has none registered');
 }
 
 fwrite(STDOUT, "OK CustomerAuthProcessorsDtoTest\n");

--- a/core/components/minishop3/tests/CustomerPublicDtoTest.php
+++ b/core/components/minishop3/tests/CustomerPublicDtoTest.php
@@ -75,6 +75,21 @@ foreach (['password', 'token', 'privacy_ip', 'failed_login_attempts', 'blocked_u
     }
 }
 
+$coreEditable = CustomerPublicDto::CORE_PROFILE_EDITABLE_FIELDS;
+foreach (['first_name', 'last_name', 'email', 'phone'] as $key) {
+    if (!in_array($key, $coreEditable, true)) {
+        $fail("CORE_PROFILE_EDITABLE_FIELDS missing {$key}");
+    }
+}
+
+$withExtra = CustomerPublicDto::fromArray(
+    array_merge($input, ['loyalty_tier' => 'gold']),
+    ['loyalty_tier']
+);
+if (($withExtra['loyalty_tier'] ?? null) !== 'gold') {
+    $fail('registered extra field must be included in public payload');
+}
+
 $controllerSrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CustomerProfileController.php');
 if ($controllerSrc === false) {
     $fail('unable to read CustomerProfileController.php');
@@ -82,8 +97,8 @@ if ($controllerSrc === false) {
 if (str_contains($controllerSrc, '$customer->toArray()')) {
     $fail('CustomerProfileController still serializes full customer via toArray()');
 }
-if (!str_contains($controllerSrc, 'CustomerPublicDto::fromCustomer')) {
-    $fail('CustomerProfileController missing CustomerPublicDto::fromCustomer');
+if (!str_contains($controllerSrc, 'CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3)')) {
+    $fail('CustomerProfileController missing CustomerPublicDto::fromCustomer with modx/ms3');
 }
 
 fwrite(STDOUT, "OK CustomerPublicDtoTest\n");

--- a/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
+++ b/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
@@ -1,47 +1,71 @@
 <?php
 
 /**
- * Regression #413: customer/add must not write GDPR consent timestamp.
+ * Regression #413/#424: customer/add allowlist must block GDPR/system fields.
  *
  * Run: php tests/ProfileQuickUpdateForbiddenTest.php
  */
 
 declare(strict_types=1);
 
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Customer\CustomerPublicDto;
+
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
     exit(1);
 };
 
-$src = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CustomerProfileController.php');
-if ($src === false || $src === '') {
+$controllerSrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CustomerProfileController.php');
+if ($controllerSrc === false || $controllerSrc === '') {
     $fail('unable to read CustomerProfileController.php');
 }
 
-if (
-    !preg_match(
-        '/private const PROFILE_QUICK_UPDATE_FORBIDDEN\s*=\s*\[(.*?)\];/s',
-        $src,
-        $match
-    )
-) {
-    $fail('PROFILE_QUICK_UPDATE_FORBIDDEN constant not found');
+if (str_contains($controllerSrc, 'PROFILE_QUICK_UPDATE_FORBIDDEN')) {
+    $fail('blacklist PROFILE_QUICK_UPDATE_FORBIDDEN must be removed in favor of allowlist');
 }
 
-$forbiddenBlock = $match[1];
-if (!preg_match_all("/'([^']+)'/", $forbiddenBlock, $keys)) {
-    $fail('no forbidden field keys parsed');
+if (!str_contains($controllerSrc, 'CustomerPublicDto::editableFieldKeys')) {
+    $fail('updateField must enforce CustomerPublicDto allowlist via editableFieldKeys');
 }
 
-$forbidden = $keys[1];
+if (!preg_match('/foreach \\(array_keys\\(\\$rules\\)/', $controllerSrc)) {
+    $fail('update must require all core profile fields before validation');
+}
+
 foreach (['privacy_accepted_at', 'privacy_ip', 'password', 'token', 'email_verified_at'] as $key) {
-    if (!in_array($key, $forbidden, true)) {
-        $fail("PROFILE_QUICK_UPDATE_FORBIDDEN must include {$key}");
+    if (!in_array($key, CustomerPublicDto::SYSTEM_NON_EDITABLE_FIELDS, true)) {
+        $fail("SYSTEM_NON_EDITABLE_FIELDS must include {$key}");
     }
 }
 
-if (!str_contains($src, 'in_array($key, self::PROFILE_QUICK_UPDATE_FORBIDDEN, true)')) {
-    $fail('updateField must enforce PROFILE_QUICK_UPDATE_FORBIDDEN');
+$coreEditable = CustomerPublicDto::CORE_PROFILE_EDITABLE_FIELDS;
+foreach (['first_name', 'last_name', 'email', 'phone'] as $key) {
+    if (!in_array($key, $coreEditable, true)) {
+        $fail("CORE_PROFILE_EDITABLE_FIELDS must include {$key}");
+    }
+}
+
+$merged = CustomerPublicDto::mergeEditableFieldKeys(['company', 'password', 'privacy_accepted_at']);
+if (!in_array('company', $merged, true)) {
+    $fail('active extra field key must merge into editable allowlist');
+}
+foreach (['password', 'privacy_accepted_at'] as $blocked) {
+    if (in_array($blocked, $merged, true)) {
+        $fail("non-editable key must not merge: {$blocked}");
+    }
+}
+
+$publicWithExtra = CustomerPublicDto::fromArray(
+    ['id' => 1, 'company' => 'ACME', 'password' => 'secret'],
+    ['company']
+);
+if (($publicWithExtra['company'] ?? null) !== 'ACME') {
+    $fail('extra public field must appear when registered in msExtraField keys');
+}
+if (array_key_exists('password', $publicWithExtra)) {
+    $fail('password must never appear in public DTO');
 }
 
 fwrite(STDOUT, "OK ProfileQuickUpdateForbiddenTest\n");

--- a/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
+++ b/core/components/minishop3/tests/ProfileQuickUpdateForbiddenTest.php
@@ -30,8 +30,11 @@ if (!str_contains($controllerSrc, 'CustomerPublicDto::editableFieldKeys')) {
     $fail('updateField must enforce CustomerPublicDto allowlist via editableFieldKeys');
 }
 
-if (!preg_match('/foreach \\(array_keys\\(\\$rules\\)/', $controllerSrc)) {
-    $fail('update must require all core profile fields before validation');
+if (preg_match('/foreach \\(array_keys\\(\\$rules\\)/', $controllerSrc)) {
+    $fail('update must not require all core profile fields — partial updates only (#424)');
+}
+if (!preg_match('/array_intersect_key\\(\\$this->getProfileFieldRules\\(\\),\\s*\\$data\\)/', $controllerSrc)) {
+    $fail('update must restrict validation to core rules for fields present in $data');
 }
 
 foreach (['privacy_accepted_at', 'privacy_ip', 'password', 'token', 'email_verified_at'] as $key) {

--- a/core/components/minishop3/tests/stubs/StubMsCustomer.php
+++ b/core/components/minishop3/tests/stubs/StubMsCustomer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MiniShop3\Model\msCustomer;
+
+/**
+ * Minimal msCustomer stand-in for DTO serialization tests (#424).
+ */
+final class StubMsCustomer extends msCustomer
+{
+    /** @var array<string, mixed> */
+    private array $fields;
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function __construct(array $fields = [])
+    {
+        $this->fields = $fields;
+    }
+
+    public function get($key)
+    {
+        return $this->fields[$key] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->fields;
+    }
+}


### PR DESCRIPTION
## Описание

Единый публичный контракт покупателя для Web API и явный allowlist редактируемых полей вместо blacklist по fieldMeta.

- `CustomerPublicDto` — allowlist ответа (`PUBLIC_FIELDS` + active `msExtraField`), core editable fields и `editableFieldKeys()` с dynamic extra columns
- `POST /customer/add` и `PUT /customer/profile` принимают только allowlist; системные/GDPR поля отклоняются
- Login, Register, VerifyEmail processor и JSON-ответ email verify отдают `CustomerPublicDto::fromCustomer()`
- Smoke-тесты на DTO, allowlist и auth processors

Closes #424

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [x] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

**Breaking:** в ответах login/register/verify вместо `customer.email_verified: bool` теперь `email_verified_at` в составе полного public DTO. Расширен payload (stats, timestamps) — без секретов.

## Связанные Issues

Closes #424

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php
# exit 0 — php -l (377 files) + 19 smoke tests
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`, `npm run lint:ci` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch feat/issue-424-customer-public-dto
- MODX: n/a (smoke без MODX)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность (кроме задокументированного API контракта)
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (локально; в CI пока нет)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не затронут
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — по политике репо, при релизе

## Дополнительные заметки

- Закрывает класс утечек из #410/#413: fail-closed public serializer + allowlist записи
- Active `msExtraField` для `msCustomer` попадают в public JSON и в editable allowlist (если колонка есть в map)
- `PUT /profile` по-прежнему требует все 4 core поля; forbidden keys отсекаются до validation
- Deferred: выделение `CustomerProfileFieldPolicy` из DTO (structural review); runtime integration tests с mock modX