### PR TITLE
Унификация расчёта стоимости заказа: checkout ↔ manager

### DIFF
--- a/core/components/minishop3/src/Controllers/Delivery/Delivery.php
+++ b/core/components/minishop3/src/Controllers/Delivery/Delivery.php
@@ -5,7 +5,7 @@ namespace MiniShop3\Controllers\Delivery;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msOrder;
-use MiniShop3\Utils\PriceAdjustment;
+use MiniShop3\Services\Order\OrderCostEngine;
 use MODX\Revolution\modX;
 
 /**
@@ -77,8 +77,6 @@ abstract class Delivery implements DeliveryProviderInterface
      */
     public function getCost(msOrder $order, msDelivery $delivery, float $cost): float
     {
-        $deliveryCost = 0;
-
         // Get cart data for weight calculation
         $cart = [
             'total_weight' => 0,
@@ -98,51 +96,14 @@ abstract class Delivery implements DeliveryProviderInterface
             }
         }
 
-        // Check free delivery threshold first
-        // Use $cost parameter (cart cost passed from calculator) for threshold check
-        $freeDeliveryAmount = (float)$delivery->get('free_delivery_amount');
+        $cartWeight = (float) ($cart['total_weight'] ?? 0);
 
-        if ($freeDeliveryAmount > 0 && $cost >= $freeDeliveryAmount) {
-            return 0;
-        }
-
-        // Cost by weight
-        $weightPrice = (float)$delivery->get('weight_price');
-        $cartWeight = (float)($cart['total_weight'] ?? 0);
-
-        if ($weightPrice < 0) {
-            $this->modx->log(
-                modX::LOG_LEVEL_ERROR,
-                "[Delivery] Invalid weight_price for delivery #{$delivery->get('id')}: {$weightPrice}. Must be >= 0."
-            );
-            $weightPrice = 0;
-        }
-
-        $deliveryCost += $weightPrice * $cartWeight;
-
-        // Base delivery cost
-        $addPrice = $delivery->get('price');
-
-        if (empty($addPrice)) {
-            return $deliveryCost;
-        }
-
-        if (PriceAdjustment::isPercent($addPrice)) {
-            $percent = PriceAdjustment::getPercent($addPrice);
-            if (!PriceAdjustment::isAllowedPercent($percent)) {
-                $this->modx->log(
-                    modX::LOG_LEVEL_ERROR,
-                    sprintf(
-                        '[Delivery] Invalid percent value for delivery #%s: %s%%. Must be between -100%% and 100%%.',
-                        $delivery->get('id'),
-                        $percent
-                    )
-                );
-                return $deliveryCost;
-            }
-        }
-
-        return $deliveryCost + PriceAdjustment::calculate($cost, $addPrice);
+        return OrderCostEngine::calculateDefaultDeliveryCost(
+            $this->modx,
+            $delivery,
+            $cost,
+            $cartWeight
+        );
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Payment/Payment.php
+++ b/core/components/minishop3/src/Controllers/Payment/Payment.php
@@ -5,7 +5,7 @@ namespace MiniShop3\Controllers\Payment;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msOrder;
 use MiniShop3\Model\msPayment;
-use MiniShop3\Utils\PriceAdjustment;
+use MiniShop3\Services\Order\OrderCostEngine;
 use MODX\Revolution\modX;
 
 /**
@@ -137,33 +137,14 @@ abstract class Payment implements PaymentProviderInterface
      *
      * @param msOrder $order Order (can be used for fee calculation)
      * @param msPayment $payment Payment method with fee settings
-     * @param float $cost Current order cost
+     * @param float $cost Commission base before surcharge: cart lines only (MS2 parity, #460)
      * @return float Cost including fee
      */
     public function getCost(msOrder $order, msPayment $payment, float $cost): float
     {
-        $addPrice = $payment->get('price');
+        $surcharge = OrderCostEngine::calculatePaymentSurcharge($this->modx, $payment, $cost);
 
-        if (empty($addPrice)) {
-            return $cost;
-        }
-
-        if (PriceAdjustment::isPercent($addPrice)) {
-            $percent = PriceAdjustment::getPercent($addPrice);
-            if (!PriceAdjustment::isAllowedPercent($percent)) {
-                $this->modx->log(
-                    modX::LOG_LEVEL_ERROR,
-                    sprintf(
-                        '[Payment] Invalid percent value for payment #%s: %s%%. Must be between -100%% and 100%%.',
-                        $payment->get('id'),
-                        $percent
-                    )
-                );
-                return $cost;
-            }
-        }
-
-        return $cost + PriceAdjustment::calculate($cost, $addPrice);
+        return OrderCostEngine::calculatePaymentTotal($cost, $surcharge);
     }
 
     /**

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -530,7 +530,34 @@ class ServiceRegistry
 
         $modx = $this->modx;
 
+<<<<<<< HEAD
         if (in_array($serviceKey, self::CONTROLLERS_WITH_MS3_ONLY, true)) {
+=======
+        // Controllers requiring only MiniShop3 instance: __construct(MiniShop3 $ms3)
+        $controllersWithMs3Only = ['ms3_cart', 'ms3_order', 'ms3_customer'];
+
+        // Services requiring both modX and MiniShop3: __construct(modX $modx, MiniShop3 $ms3)
+        $servicesWithModxAndMs3 = [
+            'ms3_order_draft_manager',
+            'ms3_order_cost_calculator',
+            'ms3_manager_order_cost_recalculator',
+            'ms3_order_user_resolver',
+            'ms3_order_log',
+            'ms3_cart_item_manager',
+            'ms3_customer_address_manager',
+        ];
+
+        // Services with complex dependencies (resolved via DI)
+        $servicesWithDependencies = [
+            'ms3_order_field_manager',
+            'ms3_order_address_manager',
+            'ms3_order_submit_handler',
+            'ms3_order_status',
+            'ms3_order_finalize',
+        ];
+
+        if (in_array($serviceKey, $controllersWithMs3Only)) {
+>>>>>>> 33e55983 (refactor(order): unify checkout and manager cost formulas)
             $this->modx->services->add($serviceKey, function () use ($validatedClass, $modx) {
                 $ms3 = $modx->getService('MiniShop3', \MiniShop3\MiniShop3::class);
                 return new $validatedClass($ms3);

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -530,34 +530,7 @@ class ServiceRegistry
 
         $modx = $this->modx;
 
-<<<<<<< HEAD
         if (in_array($serviceKey, self::CONTROLLERS_WITH_MS3_ONLY, true)) {
-=======
-        // Controllers requiring only MiniShop3 instance: __construct(MiniShop3 $ms3)
-        $controllersWithMs3Only = ['ms3_cart', 'ms3_order', 'ms3_customer'];
-
-        // Services requiring both modX and MiniShop3: __construct(modX $modx, MiniShop3 $ms3)
-        $servicesWithModxAndMs3 = [
-            'ms3_order_draft_manager',
-            'ms3_order_cost_calculator',
-            'ms3_manager_order_cost_recalculator',
-            'ms3_order_user_resolver',
-            'ms3_order_log',
-            'ms3_cart_item_manager',
-            'ms3_customer_address_manager',
-        ];
-
-        // Services with complex dependencies (resolved via DI)
-        $servicesWithDependencies = [
-            'ms3_order_field_manager',
-            'ms3_order_address_manager',
-            'ms3_order_submit_handler',
-            'ms3_order_status',
-            'ms3_order_finalize',
-        ];
-
-        if (in_array($serviceKey, $controllersWithMs3Only)) {
->>>>>>> 33e55983 (refactor(order): unify checkout and manager cost formulas)
             $this->modx->services->add($serviceKey, function () use ($validatedClass, $modx) {
                 $ms3 = $modx->getService('MiniShop3', \MiniShop3\MiniShop3::class);
                 return new $validatedClass($ms3);

--- a/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
+++ b/core/components/minishop3/src/Services/Order/ManagerOrderCostRecalculator.php
@@ -5,7 +5,6 @@ namespace MiniShop3\Services\Order;
 use MiniShop3\Controllers\Delivery\DefaultDelivery;
 use MiniShop3\Controllers\Payment\DefaultPayment;
 use MiniShop3\MiniShop3;
-use MiniShop3\Utils\PriceAdjustment;
 use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msOrder;
 use MiniShop3\Model\msOrderLog;
@@ -19,11 +18,13 @@ use MODX\Revolution\modX;
  * Used by manager «Пересчитать стоимость» ({@see calculateBreakdown()} / {@see recalculate()})
  * and draft finalize ({@see OrderFinalizeService}).
  *
+ * Manager adapter: modes (auto/manual/force_provider), warnings, order log — no msOn* cost events.
+ * Default-handler formulas delegate to {@see OrderCostEngine} (shared with web checkout).
+ *
  * External delivery/payment provider classes are not invoked in {@see self::MODE_AUTO};
  * callers should use manual delivery cost or {@see self::MODE_FORCE_PROVIDER}.
  *
  * Payment commission is reflected only in aggregated {@see msOrder cost}, not stored in a column.
- * Default handler math lives in {@see OrderPersistedCostRules}.
  */
 class ManagerOrderCostRecalculator
 {
@@ -93,7 +94,7 @@ class ManagerOrderCostRecalculator
         $warnings = array_merge($warnings, $deliveryResult['warnings']);
         $deliveryCost = $deliveryResult['delivery_cost'];
 
-        $paymentBase = OrderService::paymentCommissionBase($cartCost);
+        $paymentBase = OrderCostEngine::paymentCommissionBase($cartCost);
         $paymentResult = $this->resolvePaymentFee($order, $paymentBase, $mode, $options);
         if (!$paymentResult['success']) {
             return $paymentResult;
@@ -104,7 +105,8 @@ class ManagerOrderCostRecalculator
 
         /** @var OrderService $orderService */
         $orderService = $this->modx->services->get('ms3_order_service');
-        $cost = round($orderService->clampComputedTotal($order, $cartCost, $deliveryCost, $paymentFee), 6);
+        $breakdown = OrderCostEngine::composeBreakdown($order, $orderService, $cartCost, $deliveryCost, $paymentFee);
+        $cost = $breakdown['cost'];
 
         return $this->ms3->utils->success('', [
             'breakdown' => [
@@ -257,7 +259,12 @@ class ManagerOrderCostRecalculator
         if ($this->isSimpleDelivery($msDelivery)) {
             return [
                 'success' => true,
-                'delivery_cost' => $this->calculateDefaultDeliveryCost($msDelivery, $cartCost, $orderWeight),
+                'delivery_cost' => OrderCostEngine::calculateDefaultDeliveryCost(
+                    $this->modx,
+                    $msDelivery,
+                    $cartCost,
+                    $orderWeight
+                ),
                 'warnings' => $warnings,
             ];
         }
@@ -336,7 +343,7 @@ class ManagerOrderCostRecalculator
         if ($this->isSimplePayment($msPayment)) {
             return [
                 'success' => true,
-                'payment_fee' => $this->calculateDefaultPaymentCommission($msPayment, $paymentBase),
+                'payment_fee' => OrderCostEngine::calculatePaymentSurcharge($this->modx, $msPayment, $paymentBase),
                 'warnings' => $warnings,
             ];
         }
@@ -348,65 +355,6 @@ class ManagerOrderCostRecalculator
             'payment_fee' => 0.0,
             'warnings' => $warnings,
         ];
-    }
-
-    protected function calculateDefaultDeliveryCost(msDelivery $delivery, float $cartCost, float $orderWeight): float
-    {
-        $weightPrice = (float) $delivery->get('weight_price');
-        if ($weightPrice < 0) {
-            $this->modx->log(
-                modX::LOG_LEVEL_ERROR,
-                '[ManagerOrderCostRecalculator] Invalid weight_price for delivery #' . $delivery->get(
-                    'id'
-                ) . ': ' . $weightPrice,
-            );
-        }
-
-        $addPrice = $delivery->get('price');
-        if (!empty($addPrice) && PriceAdjustment::isPercent($addPrice)) {
-            $percent = PriceAdjustment::getPercent($addPrice);
-            if (!PriceAdjustment::isAllowedPercent($percent)) {
-                $this->modx->log(
-                    modX::LOG_LEVEL_ERROR,
-                    sprintf(
-                        '[ManagerOrderCostRecalculator] Invalid percent for delivery #%s: %s%%. Must be between -100%% and 100%%.',
-                        $delivery->get('id'),
-                        $percent
-                    )
-                );
-            }
-        }
-
-        return OrderPersistedCostRules::calculateDefaultDeliveryCost(
-            (float) $delivery->get('free_delivery_amount'),
-            $weightPrice,
-            $addPrice,
-            $cartCost,
-            $orderWeight
-        );
-    }
-
-    /**
-     * Surcharge only (excluding base), aligned with {@see \MiniShop3\Controllers\Payment\Payment::getCost()}.
-     */
-    protected function calculateDefaultPaymentCommission(msPayment $payment, float $baseCost): float
-    {
-        $addPrice = $payment->get('price');
-        if (!empty($addPrice) && PriceAdjustment::isPercent($addPrice)) {
-            $percent = PriceAdjustment::getPercent($addPrice);
-            if (!PriceAdjustment::isAllowedPercent($percent)) {
-                $this->modx->log(
-                    modX::LOG_LEVEL_ERROR,
-                    sprintf(
-                        '[ManagerOrderCostRecalculator] Invalid percent for payment #%s: %s%%. Must be between -100%% and 100%%.',
-                        $payment->get('id'),
-                        $percent
-                    )
-                );
-            }
-        }
-
-        return OrderPersistedCostRules::calculateDefaultPaymentCommission($addPrice, $baseCost);
     }
 
     protected function isSimpleDelivery(msDelivery $delivery): bool

--- a/core/components/minishop3/src/Services/Order/OrderCostCalculator.php
+++ b/core/components/minishop3/src/Services/Order/OrderCostCalculator.php
@@ -11,8 +11,12 @@ use MODX\Revolution\modX;
 /**
  * Order Cost Calculator
  *
- * Calculates order costs: cart, delivery, payment, and total.
- * Supports events for cost modification by plugins.
+ * Web/checkout adapter: cart status, delivery/payment providers, MODX cost events.
+ * Core formulas live in {@see OrderCostEngine}; manager path uses {@see ManagerOrderCostRecalculator}.
+ *
+ * Events (web-only): msOnBeforeGetCartCost, msOnGetCartCost, msOnBeforeGetDeliveryCost,
+ * msOnGetDeliveryCost, msOnBeforeGetPaymentCost, msOnGetPaymentCost,
+ * msOnBeforeGetOrderCost, msOnGetOrderCost.
  */
 class OrderCostCalculator
 {
@@ -151,10 +155,18 @@ class OrderCostCalculator
      * @param array $orderData Order data array (with payment_id)
      * @param string $token Session token
      * @param string $ctx Context
+     * @param float|null $knownCartCost Skip cart pipeline when already computed (e.g. from {@see getTotalCost})
+     * @param float|null $knownDeliveryCost Skip delivery pipeline when already computed
      * @return array Response with 'cost' key
      */
-    public function getPaymentCost(?msOrder $draft, array $orderData, string $token, string $ctx = 'web'): array
-    {
+    public function getPaymentCost(
+        ?msOrder $draft,
+        array $orderData,
+        string $token,
+        string $ctx = 'web',
+        ?float $knownCartCost = null,
+        ?float $knownDeliveryCost = null
+    ): array {
         // No draft = no order = zero payment cost
         if (!$draft) {
             return $this->success('ms3_order_getcost_success', ['cost' => 0]);
@@ -186,12 +198,15 @@ class OrderCostCalculator
             return $this->success('ms3_order_getcost_success', ['cost' => $paymentCost]);
         }
 
-        // Get cart cost for payment calculation (MS2-compatible base: cart only)
-        $cartCostResponse = $this->getCartCost($draft, $token, $ctx);
-        $cartCost = $cartCostResponse['success'] ? $cartCostResponse['data']['cost'] : 0;
-        $paymentBase = OrderService::paymentCommissionBase((float) $cartCost);
+        // Payment commission base: cart-only (MS2 parity, #460)
+        if ($knownCartCost === null) {
+            $cartCostResponse = $this->getCartCost($draft, $token, $ctx);
+            $knownCartCost = $cartCostResponse['success'] ? (float) $cartCostResponse['data']['cost'] : 0.0;
+        }
 
-        // Payment getCost returns total with payment fee, so subtract base
+        $paymentBase = OrderCostEngine::paymentCommissionBase($knownCartCost);
+
+        // Payment getCost returns total with payment fee, so subtract commission base
         $costWithPayment = $msPayment->getCost($draft, $paymentBase);
         $paymentCost = $costWithPayment - $paymentBase;
 
@@ -240,22 +255,25 @@ class OrderCostCalculator
         }
 
         $cartCostResponse = $this->getCartCost($draft, $token, $ctx);
-        $cartCost = $cartCostResponse['success'] ? $cartCostResponse['data']['cost'] : 0;
+        $cartCost = $cartCostResponse['success'] ? (float) $cartCostResponse['data']['cost'] : 0.0;
 
         $deliveryCostResponse = $this->getDeliveryCost($draft, $orderData, $token, $ctx);
-        $deliveryCost = $deliveryCostResponse['success'] ? $deliveryCostResponse['data']['cost'] : 0;
+        $deliveryCost = $deliveryCostResponse['success'] ? (float) $deliveryCostResponse['data']['cost'] : 0.0;
 
-        $paymentCostResponse = $this->getPaymentCost($draft, $orderData, $token, $ctx);
-        $paymentCost = $paymentCostResponse['success'] ? $paymentCostResponse['data']['cost'] : 0;
+        $paymentCostResponse = $this->getPaymentCost(
+            $draft,
+            $orderData,
+            $token,
+            $ctx,
+            $cartCost,
+            $deliveryCost
+        );
+        $paymentCost = $paymentCostResponse['success'] ? (float) $paymentCostResponse['data']['cost'] : 0.0;
 
         /** @var OrderService $orderService */
         $orderService = $this->modx->services->get('ms3_order_service');
-        $cost = $orderService->clampComputedTotal(
-            $draft,
-            (float) $cartCost,
-            (float) $deliveryCost,
-            (float) $paymentCost
-        );
+        $breakdown = OrderCostEngine::composeBreakdown($draft, $orderService, $cartCost, $deliveryCost, $paymentCost);
+        $cost = $breakdown['cost'];
 
         $after = $this->ms3->utils->invokeEvent('msOnGetOrderCost', [
             'calculator' => $this,
@@ -276,7 +294,8 @@ class OrderCostCalculator
         $cartCost = (float) ($after['data']['cart_cost'] ?? $cartCost);
         $deliveryCost = (float) ($after['data']['delivery_cost'] ?? $deliveryCost);
         $paymentCost = (float) ($after['data']['payment_cost'] ?? $paymentCost);
-        $cost = $orderService->clampComputedTotal($draft, $cartCost, $deliveryCost, $paymentCost);
+        $breakdown = OrderCostEngine::composeBreakdown($draft, $orderService, $cartCost, $deliveryCost, $paymentCost);
+        $cost = $breakdown['cost'];
 
         if ($onlyCost) {
             return $this->success('ms3_order_getcost_success', ['cost' => $cost]);

--- a/core/components/minishop3/src/Services/Order/OrderCostEngine.php
+++ b/core/components/minishop3/src/Services/Order/OrderCostEngine.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Order;
+
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Utils\PriceAdjustment;
+use MODX\Revolution\modX;
+
+/**
+ * Shared order cost formulas for checkout and manager recalc (#366).
+ *
+ * Event hooks stay in adapters:
+ * - Web: {@see OrderCostCalculator} — msOnBefore/GetCartCost, DeliveryCost, PaymentCost, OrderCost
+ * - Manager: {@see ManagerOrderCostRecalculator} — no cost events; mgr modes + warnings + persistence
+ *
+ * Payment commission base is cart-only (MS2 parity, #460); canonical helper is {@see OrderService::paymentCommissionBase()}.
+ */
+final class OrderCostEngine
+{
+    public static function paymentCommissionBase(float $cartCost): float
+    {
+        return OrderService::paymentCommissionBase($cartCost);
+    }
+
+    /**
+     * Default delivery formula (weight_price × weight, free_delivery_amount, price/percent on cart).
+     */
+    public static function calculateDefaultDeliveryCost(
+        modX $modx,
+        msDelivery $delivery,
+        float $cartCost,
+        float $orderWeight
+    ): float {
+        $freeDeliveryAmount = (float) $delivery->get('free_delivery_amount');
+
+        if ($freeDeliveryAmount > 0 && $cartCost >= $freeDeliveryAmount) {
+            return 0.0;
+        }
+
+        $deliveryCost = 0.0;
+        $weightPrice = (float) $delivery->get('weight_price');
+        if ($weightPrice < 0) {
+            $modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[OrderCostEngine] Invalid weight_price for delivery #' . $delivery->get('id') . ': ' . $weightPrice
+            );
+            $weightPrice = 0.0;
+        }
+
+        $deliveryCost += $weightPrice * $orderWeight;
+
+        $addPrice = $delivery->get('price');
+        if (empty($addPrice)) {
+            return round($deliveryCost, 6);
+        }
+
+        if (PriceAdjustment::isPercent($addPrice)) {
+            $percent = PriceAdjustment::getPercent($addPrice);
+            if (!PriceAdjustment::isAllowedPercent($percent)) {
+                $modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    sprintf(
+                        '[OrderCostEngine] Invalid percent for delivery #%s: %s%%. Must be between -100%% and 100%%.',
+                        $delivery->get('id'),
+                        $percent
+                    )
+                );
+
+                return round($deliveryCost, 6);
+            }
+        }
+
+        return round($deliveryCost + PriceAdjustment::calculate($cartCost, $addPrice), 6);
+    }
+
+    /**
+     * Payment surcharge only (excluding commission base), aligned with {@see \MiniShop3\Controllers\Payment\Payment::getCost()}.
+     */
+    public static function calculatePaymentSurcharge(modX $modx, msPayment $payment, float $baseCost): float
+    {
+        $addPrice = $payment->get('price');
+        if (empty($addPrice)) {
+            return 0.0;
+        }
+
+        if (PriceAdjustment::isPercent($addPrice)) {
+            $percent = PriceAdjustment::getPercent($addPrice);
+            if (!PriceAdjustment::isAllowedPercent($percent)) {
+                $modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    sprintf(
+                        '[OrderCostEngine] Invalid percent for payment #%s: %s%%. Must be between -100%% and 100%%.',
+                        $payment->get('id'),
+                        $percent
+                    )
+                );
+
+                return 0.0;
+            }
+        }
+
+        return round(PriceAdjustment::calculate($baseCost, $addPrice), 6);
+    }
+
+    public static function calculatePaymentTotal(float $baseCost, float $surcharge): float
+    {
+        return round($baseCost + $surcharge, 6);
+    }
+
+    /**
+     * @return array{cart_cost: float, delivery_cost: float, payment_cost: float, cost: float}
+     */
+    public static function composeBreakdown(
+        ?msOrder $order,
+        OrderService $orderService,
+        float $cartCost,
+        float $deliveryCost,
+        float $paymentSurcharge
+    ): array {
+        $cartCost = round($cartCost, 6);
+        $deliveryCost = round($deliveryCost, 6);
+        $paymentCost = round($paymentSurcharge, 6);
+        $cost = round(
+            $orderService->clampComputedTotal($order, $cartCost, $deliveryCost, $paymentCost),
+            6
+        );
+
+        return [
+            'cart_cost' => $cartCost,
+            'delivery_cost' => $deliveryCost,
+            'payment_cost' => $paymentCost,
+            'cost' => $cost,
+        ];
+    }
+}

--- a/core/components/minishop3/tests/OrderCostEngineTest.php
+++ b/core/components/minishop3/tests/OrderCostEngineTest.php
@@ -34,13 +34,18 @@ $assertFloat = static function (float $expected, float $actual, string $case) us
 
 $modx = new modX();
 
-$assertFloat(150.0, OrderCostEngine::paymentCommissionBase(100.0, 50.0), 'payment base cart+delivery');
-$assertFloat(154.5, OrderCostEngine::calculatePaymentTotal(150.0, 4.5), 'payment total');
+$engineSource = file_get_contents(__DIR__ . '/../src/Services/Order/OrderCostEngine.php');
+if ($engineSource === false || !str_contains($engineSource, 'OrderService::paymentCommissionBase')) {
+    $fail('OrderCostEngine must delegate paymentCommissionBase to OrderService');
+}
 
-// #372: payment % base = cart + delivery (1000 + 500 → 3% fee = 45, not 30 on cart-only)
-$issue372Base = OrderCostEngine::paymentCommissionBase(1000.0, 500.0);
-$assertFloat(1500.0, $issue372Base, '#372 commission base');
-$assertFloat(45.0, PriceAdjustment::calculate($issue372Base, '3%'), '#372 payment surcharge on cart+delivery');
+$assertFloat(100.0, OrderCostEngine::paymentCommissionBase(100.0), 'payment base cart-only');
+$assertFloat(104.5, OrderCostEngine::calculatePaymentTotal(100.0, 4.5), 'payment total');
+
+// #460: payment % base = cart only (1000 → 3% fee = 30, delivery excluded)
+$cartOnlyBase = OrderCostEngine::paymentCommissionBase(1000.0);
+$assertFloat(1000.0, $cartOnlyBase, '#460 commission base cart-only');
+$assertFloat(30.0, PriceAdjustment::calculate($cartOnlyBase, '3%'), '#460 payment surcharge on cart-only');
 
 // Delivery free-threshold edge cases (#366 review).
 // free_delivery_amount = 1000: cart at or above threshold → delivery is free.
@@ -80,20 +85,20 @@ $noFreeThreshold = new StubMsDelivery([
 ]);
 $assertFloat(75.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $noFreeThreshold, 100000.0, 0.0), 'fixed delivery with no free threshold');
 
-// Payment percent surcharge base = cart + delivery (#372): 3% of (1000 + 500) = 45.
+// Payment percent surcharge base = cart only (#460): 3% of 1000 = 30.
 $percentPayment = new StubMsPayment(['id' => 10, 'price' => '3%']);
-$percentBase = OrderCostEngine::paymentCommissionBase(1000.0, 500.0);
+$percentBase = OrderCostEngine::paymentCommissionBase(1000.0);
 $percentSurcharge = OrderCostEngine::calculatePaymentSurcharge($modx, $percentPayment, $percentBase);
-$assertFloat(45.0, $percentSurcharge, 'payment 3% surcharge on cart+delivery base');
-$assertFloat(1545.0, OrderCostEngine::calculatePaymentTotal($percentBase, $percentSurcharge), 'payment total with percent on cart+delivery');
+$assertFloat(30.0, $percentSurcharge, 'payment 3% surcharge on cart-only base');
+$assertFloat(1030.0, OrderCostEngine::calculatePaymentTotal($percentBase, $percentSurcharge), 'payment total with percent on cart-only');
 
 // Fixed payment surcharge is independent of the base.
 $fixedPayment = new StubMsPayment(['id' => 11, 'price' => 30]);
-$assertFloat(30.0, OrderCostEngine::calculatePaymentSurcharge($modx, $fixedPayment, 1500.0), 'fixed payment surcharge');
+$assertFloat(30.0, OrderCostEngine::calculatePaymentSurcharge($modx, $fixedPayment, 1000.0), 'fixed payment surcharge');
 
 // Empty payment price → zero surcharge regardless of base.
 $noPricePayment = new StubMsPayment(['id' => 12, 'price' => 0]);
-$assertFloat(0.0, OrderCostEngine::calculatePaymentSurcharge($modx, $noPricePayment, 1500.0), 'zero payment surcharge when price empty');
+$assertFloat(0.0, OrderCostEngine::calculatePaymentSurcharge($modx, $noPricePayment, 1000.0), 'zero payment surcharge when price empty');
 
 $paths = [
     'ManagerOrderCostRecalculator.php' => [
@@ -141,6 +146,10 @@ if ($ordersCtrl === false || !str_contains($ordersCtrl, "services->get('ms3_mana
 $calcSrc = file_get_contents(__DIR__ . '/../src/Services/Order/OrderCostCalculator.php');
 if ($calcSrc === false || !preg_match('/getPaymentCost\([^)]+\$cartCost,\s*\$deliveryCost/', $calcSrc)) {
     $fail('getTotalCost must pass precomputed cart/delivery into getPaymentCost (single pipeline pass)');
+}
+
+if ($calcSrc !== false && preg_match('/paymentCommissionBase\s*\([^)]*,/', $calcSrc) === 1) {
+    $fail('OrderCostCalculator must not pass delivery into paymentCommissionBase');
 }
 
 fwrite(STDOUT, "OK OrderCostEngineTest\n");

--- a/core/components/minishop3/tests/OrderCostEngineTest.php
+++ b/core/components/minishop3/tests/OrderCostEngineTest.php
@@ -8,10 +8,18 @@
 
 declare(strict_types=1);
 
+require __DIR__ . '/support/xpdo_stub.php';
+require __DIR__ . '/support/xpdo_om_stub.php';
 require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/StubMsDelivery.php';
+require __DIR__ . '/stubs/StubMsPayment.php';
 
 use MiniShop3\Services\Order\OrderCostEngine;
+use MiniShop3\Tests\Stubs\StubMsDelivery;
+use MiniShop3\Tests\Stubs\StubMsPayment;
 use MiniShop3\Utils\PriceAdjustment;
+use MODX\Revolution\modX;
 
 $fail = static function (string $message): never {
     fwrite(STDERR, "FAIL: {$message}\n");
@@ -24,6 +32,8 @@ $assertFloat = static function (float $expected, float $actual, string $case) us
     }
 };
 
+$modx = new modX();
+
 $assertFloat(150.0, OrderCostEngine::paymentCommissionBase(100.0, 50.0), 'payment base cart+delivery');
 $assertFloat(154.5, OrderCostEngine::calculatePaymentTotal(150.0, 4.5), 'payment total');
 
@@ -31,6 +41,59 @@ $assertFloat(154.5, OrderCostEngine::calculatePaymentTotal(150.0, 4.5), 'payment
 $issue372Base = OrderCostEngine::paymentCommissionBase(1000.0, 500.0);
 $assertFloat(1500.0, $issue372Base, '#372 commission base');
 $assertFloat(45.0, PriceAdjustment::calculate($issue372Base, '3%'), '#372 payment surcharge on cart+delivery');
+
+// Delivery free-threshold edge cases (#366 review).
+// free_delivery_amount = 1000: cart at or above threshold → delivery is free.
+$freeDelivery = new StubMsDelivery([
+    'id' => 1,
+    'free_delivery_amount' => 1000.0,
+    'weight_price' => 10.0,
+    'price' => 0,
+]);
+$assertFloat(0.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $freeDelivery, 1000.0, 5.0), 'free delivery at threshold');
+$assertFloat(0.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $freeDelivery, 1500.0, 5.0), 'free delivery above threshold');
+
+// Just below threshold: weight_price × weight + price (10×5 + 50 = 100).
+$paidDelivery = new StubMsDelivery([
+    'id' => 2,
+    'free_delivery_amount' => 1000.0,
+    'weight_price' => 10.0,
+    'price' => 50.0,
+]);
+$assertFloat(100.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $paidDelivery, 999.99, 5.0), 'paid delivery weight + fixed price below threshold');
+
+// Percent delivery price applied to cart (5% of 1000 = 50), no weight component.
+$percentDelivery = new StubMsDelivery([
+    'id' => 3,
+    'free_delivery_amount' => 0,
+    'weight_price' => 0.0,
+    'price' => '5%',
+]);
+$assertFloat(50.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $percentDelivery, 1000.0, 0.0), 'percent delivery on cart');
+
+// free_delivery_amount = 0 disables the free threshold (price-only delivery).
+$noFreeThreshold = new StubMsDelivery([
+    'id' => 4,
+    'free_delivery_amount' => 0,
+    'weight_price' => 0.0,
+    'price' => 75.0,
+]);
+$assertFloat(75.0, OrderCostEngine::calculateDefaultDeliveryCost($modx, $noFreeThreshold, 100000.0, 0.0), 'fixed delivery with no free threshold');
+
+// Payment percent surcharge base = cart + delivery (#372): 3% of (1000 + 500) = 45.
+$percentPayment = new StubMsPayment(['id' => 10, 'price' => '3%']);
+$percentBase = OrderCostEngine::paymentCommissionBase(1000.0, 500.0);
+$percentSurcharge = OrderCostEngine::calculatePaymentSurcharge($modx, $percentPayment, $percentBase);
+$assertFloat(45.0, $percentSurcharge, 'payment 3% surcharge on cart+delivery base');
+$assertFloat(1545.0, OrderCostEngine::calculatePaymentTotal($percentBase, $percentSurcharge), 'payment total with percent on cart+delivery');
+
+// Fixed payment surcharge is independent of the base.
+$fixedPayment = new StubMsPayment(['id' => 11, 'price' => 30]);
+$assertFloat(30.0, OrderCostEngine::calculatePaymentSurcharge($modx, $fixedPayment, 1500.0), 'fixed payment surcharge');
+
+// Empty payment price → zero surcharge regardless of base.
+$noPricePayment = new StubMsPayment(['id' => 12, 'price' => 0]);
+$assertFloat(0.0, OrderCostEngine::calculatePaymentSurcharge($modx, $noPricePayment, 1500.0), 'zero payment surcharge when price empty');
 
 $paths = [
     'ManagerOrderCostRecalculator.php' => [

--- a/core/components/minishop3/tests/OrderCostEngineTest.php
+++ b/core/components/minishop3/tests/OrderCostEngineTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Shared order cost engine (#366) — no MODX/MySQL.
+ *
+ * Run: php tests/OrderCostEngineTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Order\OrderCostEngine;
+use MiniShop3\Utils\PriceAdjustment;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertFloat = static function (float $expected, float $actual, string $case) use ($fail): void {
+    if (abs($expected - $actual) > 0.000001) {
+        $fail($case . ': expected ' . $expected . ', got ' . $actual);
+    }
+};
+
+$assertFloat(150.0, OrderCostEngine::paymentCommissionBase(100.0, 50.0), 'payment base cart+delivery');
+$assertFloat(154.5, OrderCostEngine::calculatePaymentTotal(150.0, 4.5), 'payment total');
+
+// #372: payment % base = cart + delivery (1000 + 500 → 3% fee = 45, not 30 on cart-only)
+$issue372Base = OrderCostEngine::paymentCommissionBase(1000.0, 500.0);
+$assertFloat(1500.0, $issue372Base, '#372 commission base');
+$assertFloat(45.0, PriceAdjustment::calculate($issue372Base, '3%'), '#372 payment surcharge on cart+delivery');
+
+$paths = [
+    'ManagerOrderCostRecalculator.php' => [
+        'OrderCostEngine::paymentCommissionBase',
+        'OrderCostEngine::composeBreakdown',
+        'OrderCostEngine::calculateDefaultDeliveryCost',
+        'OrderCostEngine::calculatePaymentSurcharge',
+    ],
+    'OrderCostCalculator.php' => [
+        'OrderCostEngine::paymentCommissionBase',
+    ],
+    'Delivery.php' => [
+        'OrderCostEngine::calculateDefaultDeliveryCost',
+    ],
+    'Payment.php' => [
+        'OrderCostEngine::calculatePaymentSurcharge',
+        'OrderCostEngine::calculatePaymentTotal',
+    ],
+];
+
+foreach ($paths as $file => $needles) {
+    $src = file_get_contents(__DIR__ . '/../src/' . ($file === 'Delivery.php' || $file === 'Payment.php'
+        ? 'Controllers/' . ($file === 'Delivery.php' ? 'Delivery/Delivery.php' : 'Payment/Payment.php')
+        : 'Services/Order/' . $file));
+    if ($src === false) {
+        $fail("unable to read {$file}");
+    }
+    foreach ($needles as $needle) {
+        if (!str_contains($src, $needle)) {
+            $fail("{$file} must reference {$needle}");
+        }
+    }
+}
+
+$registry = file_get_contents(__DIR__ . '/../src/ServiceRegistry.php');
+if ($registry === false || !str_contains($registry, 'ms3_manager_order_cost_recalculator')) {
+    $fail('ServiceRegistry must register ms3_manager_order_cost_recalculator');
+}
+
+$ordersCtrl = file_get_contents(__DIR__ . '/../src/Controllers/Api/Manager/OrdersController.php');
+if ($ordersCtrl === false || !str_contains($ordersCtrl, "services->get('ms3_manager_order_cost_recalculator')")) {
+    $fail('OrdersController must resolve manager recalculator from DI');
+}
+
+$calcSrc = file_get_contents(__DIR__ . '/../src/Services/Order/OrderCostCalculator.php');
+if ($calcSrc === false || !preg_match('/getPaymentCost\([^)]+\$cartCost,\s*\$deliveryCost/', $calcSrc)) {
+    $fail('getTotalCost must pass precomputed cart/delivery into getPaymentCost (single pipeline pass)');
+}
+
+fwrite(STDOUT, "OK OrderCostEngineTest\n");
+exit(0);

--- a/core/components/minishop3/tests/PaymentCommissionBaseTest.php
+++ b/core/components/minishop3/tests/PaymentCommissionBaseTest.php
@@ -41,13 +41,18 @@ if (abs($fee - $wrongFee) < 0.000001) {
     $fail('cart-only and cart+delivery bases must differ for this repro');
 }
 
+$engineSource = file_get_contents(__DIR__ . '/../src/Services/Order/OrderCostEngine.php');
+if ($engineSource === false || !str_contains($engineSource, 'OrderService::paymentCommissionBase')) {
+    $fail('OrderCostEngine must delegate paymentCommissionBase to OrderService');
+}
+
 $recalculatorSource = file_get_contents(__DIR__ . '/../src/Services/Order/ManagerOrderCostRecalculator.php');
 if ($recalculatorSource === false) {
     $fail('cannot read ManagerOrderCostRecalculator.php');
 }
 
-if (!str_contains($recalculatorSource, 'OrderService::paymentCommissionBase($cartCost)')) {
-    $fail('ManagerOrderCostRecalculator must use OrderService::paymentCommissionBase($cartCost)');
+if (!str_contains($recalculatorSource, 'OrderCostEngine::paymentCommissionBase($cartCost)')) {
+    $fail('ManagerOrderCostRecalculator must use OrderCostEngine::paymentCommissionBase($cartCost)');
 }
 
 if (preg_match('/paymentBase\s*=\s*round\s*\(\s*\$cartCost\s*\+\s*\$deliveryCost/s', $recalculatorSource) === 1) {
@@ -59,8 +64,12 @@ if ($calculatorSource === false) {
     $fail('cannot read OrderCostCalculator.php');
 }
 
-if (!str_contains($calculatorSource, 'OrderService::paymentCommissionBase')) {
-    $fail('OrderCostCalculator must use OrderService::paymentCommissionBase');
+if (!str_contains($calculatorSource, 'OrderCostEngine::paymentCommissionBase')) {
+    $fail('OrderCostCalculator must use OrderCostEngine::paymentCommissionBase');
+}
+
+if (preg_match('/paymentCommissionBase\s*\([^)]*,/', $calculatorSource) === 1) {
+    $fail('OrderCostCalculator must not pass delivery into paymentCommissionBase');
 }
 
 fwrite(STDOUT, "OK PaymentCommissionBaseTest\n");

--- a/core/components/minishop3/tests/stubs/StubMsDelivery.php
+++ b/core/components/minishop3/tests/stubs/StubMsDelivery.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MiniShop3\Model\msDelivery;
+
+final class StubMsDelivery extends msDelivery
+{
+    /** @var array<string, mixed> */
+    private array $fields;
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function __construct(array $fields = [])
+    {
+        $this->fields = $fields;
+    }
+
+    public function get($key)
+    {
+        return $this->fields[$key] ?? null;
+    }
+}


### PR DESCRIPTION
## Описание

Общий слой формул стоимости заказа для витрины и менеджера вместо дублирования в `OrderCostCalculator`, `ManagerOrderCostRecalculator`, `Delivery` и `Payment`.

- **`OrderCostEngine`** — delivery (weight, free threshold, price/%), payment surcharge, `paymentCommissionBase()` делегирует в `OrderService::paymentCommissionBase()` (cart-only, #460), `composeBreakdown()` через `OrderService::clampComputedTotal`
- **Web adapter** (`OrderCostCalculator`) — MODX cost events; payment fee от cart-only; `getTotalCost` передаёт уже посчитанный cart в `getPaymentCost` (один проход pipeline)
- **Manager adapter** (`ManagerOrderCostRecalculator`) — modes/warnings/log; default handlers делегируют в engine
- **DI:** `ms3_manager_order_cost_recalculator` в `ServiceRegistry`, `OrdersController` берёт сервис из контейнера

Closes #366

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

**Поведение storefront:** `%`-комиссия оплаты — **cart-only** (MS2-паритет, #460). Rebase на beta после #460. Округление/clamp без изменений.

## Связанные Issues

Closes #366  
Refs #372, #373, #338, #363, #361, #460

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0 — php -l + 37 smoke + 109 PHPUnit
composer stan     # exit 0
```

`OrderCostEngineTest.php`: cart-only commission base, delivery free-threshold/percent edge cases, wiring grep, single-pass `getTotalCost`.  
`PaymentCommissionBaseTest.php`: cart-only guards (#460).

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`, `composer stan`)
- [ ] Тестирование на разных версиях PHP/MODX

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Комментарии в class docblocks (web vs mgr events)
- [x] Изменения согласованы между checkout и manager для default handlers
- [ ] Лексиконы — не требуется
- [ ] CHANGELOG — при релизе

## Дополнительные заметки

**Events (документировано в docblocks):**
- Web: `msOnBefore/GetCartCost`, `DeliveryCost`, `PaymentCost`, `OrderCost`
- Manager recalc: событий cost нет; mgr-only modes (`auto` / `manual` / `force_provider`) и warnings

**Deferred:** `OrderFinalizeService` payment fee (#373) — отдельный issue; полный runtime integration smoke с mock modX.