### PR TITLE
GridConfigService: request-scoped memoize getGridConfig

### DIFF
--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -28,8 +28,14 @@ class GridConfigService
     /**
      * Request-scoped memo for getGridConfig(): gridKey:includeHidden → column config.
      *
-     * Safe only while GridConfigService is a request-scoped DI singleton (ServiceRegistry):
-     * one instance per request, not shared across requests, not persisted.
+     * This cache is safe only because GridConfigService is registered in the
+     * MODX DI container as a request-scoped singleton (see ServiceRegistry):
+     * one instance per request, never shared across requests. The memo must
+     * never be persisted to a long-lived process cache or serialized — it
+     * holds no TTL and would leak stale data across requests. Mutation
+     * methods (saveGridConfig, addField, updateField, deleteField) invalidate
+     * the affected gridKey entries via invalidateGridConfigCache() so the next
+     * read re-loads from the database.
      *
      * @var array<string, array<int, array<string, mixed>>>
      */

--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -118,6 +118,14 @@ class GridConfigService
         return $gridKey . ':' . ($includeHidden ? '1' : '0');
     }
 
+    /**
+     * Call at the start of any msGridField mutation so request-scoped cache stays consistent.
+     */
+    private function beginGridMutation(string $gridKey): void
+    {
+        $this->invalidateGridConfigCache($gridKey);
+    }
+
     private function invalidateGridConfigCache(string $gridKey): void
     {
         unset(
@@ -150,7 +158,7 @@ class GridConfigService
      */
     public function saveGridConfig(string $gridKey, array $fields): bool
     {
-        $this->invalidateGridConfigCache($gridKey);
+        $this->beginGridMutation($gridKey);
 
         try {
             $fieldNamesToKeep = [];
@@ -258,7 +266,7 @@ class GridConfigService
      */
     public function deleteField(string $gridKey, string $fieldName): array
     {
-        $this->invalidateGridConfigCache($gridKey);
+        $this->beginGridMutation($gridKey);
 
         try {
             $field = $this->repository->findOne($gridKey, $fieldName);
@@ -311,7 +319,7 @@ class GridConfigService
      */
     public function addField(string $gridKey, array $data): array
     {
-        $this->invalidateGridConfigCache($gridKey);
+        $this->beginGridMutation($gridKey);
 
         try {
             if (empty($data['field_name'])) {
@@ -386,7 +394,7 @@ class GridConfigService
      */
     public function updateField(string $gridKey, string $fieldName, array $data): array
     {
-        $this->invalidateGridConfigCache($gridKey);
+        $this->beginGridMutation($gridKey);
 
         try {
             $field = $this->repository->findOne($gridKey, $fieldName);

--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -25,6 +25,16 @@ class GridConfigService
 
     private GridRelationFieldExtractor $relationExtractor;
 
+    /**
+     * Request-scoped memo for getGridConfig(): gridKey:includeHidden → column config.
+     *
+     * Safe only while GridConfigService is a request-scoped DI singleton (ServiceRegistry):
+     * one instance per request, not shared across requests, not persisted.
+     *
+     * @var array<string, array<int, array<string, mixed>>>
+     */
+    private array $gridConfigCache = [];
+
     /** @var list<string> */
     private const SAVE_CONFIG_KEYS = [
         'template', 'type', 'format', 'actions',
@@ -54,6 +64,22 @@ class GridConfigService
      */
     public function getGridConfig(string $gridKey, bool $includeHidden = false): array
     {
+        $cacheKey = $this->gridConfigCacheKey($gridKey, $includeHidden);
+        if (array_key_exists($cacheKey, $this->gridConfigCache)) {
+            return $this->gridConfigCache[$cacheKey];
+        }
+
+        $fields = $this->loadGridConfig($gridKey, $includeHidden);
+        $this->gridConfigCache[$cacheKey] = $fields;
+
+        return $fields;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadGridConfig(string $gridKey, bool $includeHidden): array
+    {
         $fields = [];
 
         foreach ($this->repository->findByGridKey($gridKey, $includeHidden) as $field) {
@@ -81,6 +107,19 @@ class GridConfigService
         return $fields;
     }
 
+    private function gridConfigCacheKey(string $gridKey, bool $includeHidden): string
+    {
+        return $gridKey . ':' . ($includeHidden ? '1' : '0');
+    }
+
+    private function invalidateGridConfigCache(string $gridKey): void
+    {
+        unset(
+            $this->gridConfigCache[$this->gridConfigCacheKey($gridKey, false)],
+            $this->gridConfigCache[$this->gridConfigCacheKey($gridKey, true)]
+        );
+    }
+
     protected function resolveLabel(msGridField $field): string
     {
         $label = $field->get('label');
@@ -105,6 +144,8 @@ class GridConfigService
      */
     public function saveGridConfig(string $gridKey, array $fields): bool
     {
+        $this->invalidateGridConfigCache($gridKey);
+
         try {
             $fieldNamesToKeep = [];
 
@@ -211,6 +252,8 @@ class GridConfigService
      */
     public function deleteField(string $gridKey, string $fieldName): array
     {
+        $this->invalidateGridConfigCache($gridKey);
+
         try {
             $field = $this->repository->findOne($gridKey, $fieldName);
             if (!$field) {
@@ -262,6 +305,8 @@ class GridConfigService
      */
     public function addField(string $gridKey, array $data): array
     {
+        $this->invalidateGridConfigCache($gridKey);
+
         try {
             if (empty($data['field_name'])) {
                 return ['success' => false, 'message' => 'field_name is required'];
@@ -335,6 +380,8 @@ class GridConfigService
      */
     public function updateField(string $gridKey, string $fieldName, array $data): array
     {
+        $this->invalidateGridConfigCache($gridKey);
+
         try {
             $field = $this->repository->findOne($gridKey, $fieldName);
             if (!$field) {

--- a/core/components/minishop3/tests/Unit/Services/GridConfigServiceMemoTest.php
+++ b/core/components/minishop3/tests/Unit/Services/GridConfigServiceMemoTest.php
@@ -47,7 +47,8 @@ final class GridConfigServiceMemoTest extends TestCase
         $service->saveGridConfig('orders', []);
         $service->getGridConfig('orders', true);
 
-        // 1st read + saveGridConfig delete scan + 2nd read after cache invalidation
-        self::assertSame(3, $modx->getCollectionCalls);
+        // 1st read + 2nd read after cache invalidation.
+        // Empty save keep-list short-circuits findNonSystemNotIn (no getCollection).
+        self::assertSame(2, $modx->getCollectionCalls);
     }
 }

--- a/core/components/minishop3/tests/Unit/Services/GridConfigServiceMemoTest.php
+++ b/core/components/minishop3/tests/Unit/Services/GridConfigServiceMemoTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services;
+
+require_once __DIR__ . '/../../stubs/ModxStub.php';
+require_once __DIR__ . '/../../stubs/GridConfigQueryStub.php';
+require_once __DIR__ . '/../../stubs/GridConfigModxStub.php';
+
+use MiniShop3\Services\GridConfigService;
+use MiniShop3\Tests\Stubs\GridConfigModxStub;
+use PHPUnit\Framework\TestCase;
+
+final class GridConfigServiceMemoTest extends TestCase
+{
+    public function testGetGridConfigMemoizesWithinSameInstance(): void
+    {
+        $modx = new GridConfigModxStub();
+        $service = new GridConfigService($modx);
+
+        $first = $service->getGridConfig('orders', true);
+        $second = $service->getGridConfig('orders', true);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, $modx->getCollectionCalls);
+        self::assertSame([], $first);
+    }
+
+    public function testIncludeHiddenUsesSeparateCacheEntry(): void
+    {
+        $modx = new GridConfigModxStub();
+        $service = new GridConfigService($modx);
+
+        $service->getGridConfig('orders', false);
+        $service->getGridConfig('orders', true);
+
+        self::assertSame(2, $modx->getCollectionCalls);
+    }
+
+    public function testSaveGridConfigInvalidatesMemoForSameRequest(): void
+    {
+        $modx = new GridConfigModxStub();
+        $service = new GridConfigService($modx);
+
+        $service->getGridConfig('orders', true);
+        $service->saveGridConfig('orders', []);
+        $service->getGridConfig('orders', true);
+
+        // 1st read + saveGridConfig delete scan + 2nd read after cache invalidation
+        self::assertSame(3, $modx->getCollectionCalls);
+    }
+}

--- a/core/components/minishop3/tests/stubs/GridConfigModxStub.php
+++ b/core/components/minishop3/tests/stubs/GridConfigModxStub.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MODX\Revolution\modX;
+
+/**
+ * modX stub that counts msGridField collection loads for GridConfigService tests.
+ */
+final class GridConfigModxStub extends modX
+{
+    public int $getCollectionCalls = 0;
+
+    /** @var list<object> */
+    public array $gridFields = [];
+
+    /** @var object */
+    public object $lexicon;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->lexicon = new class {
+            public function load(string $topic): void
+            {
+            }
+
+            public function __invoke(string $key): string
+            {
+                return $key;
+            }
+        };
+    }
+
+    public function newQuery($class = ''): GridConfigQueryStub
+    {
+        return new GridConfigQueryStub();
+    }
+
+    public function getCollection($className, $criteria = null): array
+    {
+        $this->getCollectionCalls++;
+
+        return $this->gridFields;
+    }
+
+    public function getObject($className, $criteria = null, $cacheFlag = true): ?object
+    {
+        return null;
+    }
+}

--- a/core/components/minishop3/tests/stubs/GridConfigModxStub.php
+++ b/core/components/minishop3/tests/stubs/GridConfigModxStub.php
@@ -17,7 +17,7 @@ final class GridConfigModxStub extends modX
     public array $gridFields = [];
 
     /** @var object */
-    public object $lexicon;
+    public $lexicon;
 
     public function __construct()
     {

--- a/core/components/minishop3/tests/stubs/GridConfigQueryStub.php
+++ b/core/components/minishop3/tests/stubs/GridConfigQueryStub.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+/**
+ * Fluent query stub — GridConfigService only chains where/sortby before getCollection.
+ */
+final class GridConfigQueryStub
+{
+    public function where(array $criteria): self
+    {
+        return $this;
+    }
+
+    public function sortby(string $column, string $direction = 'ASC'): self
+    {
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
## Описание

`GridConfigService::getGridConfig()` теперь кэширует результат в памяти инстанса сервиса (request-scoped через DI). Повторные вызовы с теми же `(gridKey, includeHidden)` не делают второй `getCollection(msGridField)`.

Кэш сбрасывается в начале мутаций: `saveGridConfig`, `addField`, `updateField`, `deleteField`.

## Тип изменений

- [ ] Исправление бага
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change
- [x] Рефакторинг / perf

## Связанные Issues

Closes #352

## Как это было протестировано?

```bash
cd core/components/minishop3
vendor/bin/phpunit tests/Unit/Services/GridConfigServiceMemoTest.php  # exit 0 (3 tests)
composer ci:php  # exit 0 (smoke 20 + phpunit 42 tests)
php -l src/Services/GridConfigService.php  # exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация:** PHP 8.4.17, branch `feat/issue-352-grid-config-memo`

## Чеклист

- [x] Повторный `getGridConfig` с теми же аргументами — один hit в коллекцию
- [x] После `saveGridConfig` следующий read идёт в БД (invalidation)
- [x] Публичный shape ответа без изменений
- [ ] CHANGELOG — по политике репозитория не обновлялся