### PR TITLE
refactor(mgr-api): extract extra-fields CRUD into controller

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -174,128 +174,24 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
     $router->group('/extra-fields', function($router) use ($modx) {
         $router->get('', function($params) use ($modx) {
-            try {
-                /** @var \MiniShop3\Services\ExtraFieldsService $service */
-                $service = new \MiniShop3\Services\ExtraFieldsService($modx);
-
-                $class = $_GET['class'] ?? null;
-                $criteria = $class ? ['class' => $class] : [];
-
-                $fields = $service->getFields($criteria);
-
-                return Response::success([
-                    'fields' => $fields,
-                    'total' => count($fields)
-                ]);
-            } catch (\Exception $e) {
-                $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to load extra fields: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
-            }
+            $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
+            return $controller->getList(array_merge($_GET, $params));
         });
         $router->get('/{id}', function($params) use ($modx) {
-            $id = (int)($params['id'] ?? 0);
-
-            if (!$id) {
-                return Response::error('Field ID is required', HttpStatus::BAD_REQUEST);
-            }
-
-            $field = $modx->getObject(\MiniShop3\Model\msExtraField::class, $id);
-
-            if (!$field) {
-                return Response::error('Field not found', HttpStatus::NOT_FOUND);
-            }
-
-            $data = $field->toArray();
-
-            $extraFieldsUtil = new \MiniShop3\Utils\ExtraFields($modx);
-            $data['column_exists'] = $extraFieldsUtil->columnExists($field->get('class'), $field->get('key'));
-
-            return Response::success(['field' => $data]);
+            $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
+            return $controller->get($params);
         });
         $router->post('', function($params) use ($modx) {
-            try {
-                $data = json_decode(file_get_contents('php://input'), true);
-
-                if (empty($data)) {
-                    return Response::error('Request body is empty', HttpStatus::BAD_REQUEST);
-                }
-
-                /** @var \MiniShop3\Services\ExtraFieldsService $service */
-                $service = new \MiniShop3\Services\ExtraFieldsService($modx);
-
-                $result = $service->createField($data);
-
-                if (!$result['success']) {
-                    return Response::error($result['message'], HttpStatus::BAD_REQUEST);
-                }
-
-                return Response::success([
-                    'message' => $result['message'],
-                    'field' => $result['data'],
-                    'migration' => $result['migration']
-                ]);
-            } catch (\Exception $e) {
-                $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to create field: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
-            }
+            $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
+            return $controller->create();
         });
         $router->put('/{id}', function($params) use ($modx) {
-            $id = (int)($params['id'] ?? 0);
-
-            if (!$id) {
-                return Response::error('Field ID is required', HttpStatus::BAD_REQUEST);
-            }
-
-            try {
-                $data = json_decode(file_get_contents('php://input'), true);
-
-                if (empty($data)) {
-                    return Response::error('Request body is empty', HttpStatus::BAD_REQUEST);
-                }
-
-                /** @var \MiniShop3\Services\ExtraFieldsService $service */
-                $service = new \MiniShop3\Services\ExtraFieldsService($modx);
-
-                $result = $service->updateField($id, $data);
-
-                if (!$result['success']) {
-                    return Response::error($result['message'], HttpStatus::BAD_REQUEST);
-                }
-
-                return Response::success([
-                    'message' => $result['message'],
-                    'field' => $result['data']
-                ]);
-            } catch (\Exception $e) {
-                $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to update field: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
-            }
+            $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
+            return $controller->update($params);
         });
         $router->delete('/{id}', function($params) use ($modx) {
-            $id = (int)($params['id'] ?? 0);
-
-            if (!$id) {
-                return Response::error('Field ID is required', HttpStatus::BAD_REQUEST);
-            }
-
-            try {
-                /** @var \MiniShop3\Services\ExtraFieldsService $service */
-                $service = new \MiniShop3\Services\ExtraFieldsService($modx);
-
-                $result = $service->deleteField($id);
-
-                if (!$result['success']) {
-                    return Response::error($result['message'], HttpStatus::BAD_REQUEST);
-                }
-
-                return Response::success([
-                    'message' => $result['message'],
-                    'migration' => $result['migration']
-                ]);
-            } catch (\Exception $e) {
-                $modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
-                return Response::error('Failed to delete field: ' . $e->getMessage(), HttpStatus::INTERNAL_SERVER_ERROR);
-            }
+            $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
+            return $controller->delete($params);
         });
 
     }, [

--- a/core/components/minishop3/src/Controllers/Api/Manager/ExtraFieldsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ExtraFieldsController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace MiniShop3\Controllers\Api\Manager;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MiniShop3\Services\ExtraFieldsService;
+use MODX\Revolution\modX;
+
+/**
+ * Manager API for extra-fields CRUD (Vue ExtraFieldsManager).
+ *
+ * @package MiniShop3\Controllers\Api\Manager
+ */
+class ExtraFieldsController
+{
+    protected modX $modx;
+
+    protected ExtraFieldsService $service;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+        /** @var ExtraFieldsService $service */
+        $service = $modx->services->get('ms3_extra_fields');
+        $this->service = $service;
+    }
+
+    /**
+     * GET /api/mgr/extra-fields
+     */
+    public function getList(array $params = []): array
+    {
+        try {
+            $class = $params['class'] ?? null;
+            $criteria = $class ? ['class' => $class] : [];
+            $fields = $this->service->getFields($criteria);
+
+            return Response::success([
+                'fields' => $fields,
+                'total' => count($fields),
+            ])->getData();
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return Response::error(
+                'Failed to load extra fields: ' . $e->getMessage(),
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+    }
+
+    /**
+     * GET /api/mgr/extra-fields/{id}
+     */
+    public function get(array $params = []): array
+    {
+        $id = (int)($params['id'] ?? 0);
+
+        if (!$id) {
+            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
+        }
+
+        $field = $this->service->getField($id);
+
+        if ($field === null) {
+            return Response::error('Field not found', HttpStatus::NOT_FOUND)->getData();
+        }
+
+        return Response::success(['field' => $field])->getData();
+    }
+
+    /**
+     * POST /api/mgr/extra-fields
+     */
+    public function create(): array
+    {
+        try {
+            $data = $this->readJsonBody();
+
+            if ($data === []) {
+                return Response::error('Request body is empty', HttpStatus::BAD_REQUEST)->getData();
+            }
+
+            $result = $this->service->createField($data);
+
+            if (!$result['success']) {
+                return Response::error($result['message'], HttpStatus::BAD_REQUEST)->getData();
+            }
+
+            return Response::success([
+                'message' => $result['message'],
+                'field' => $result['data'],
+                'migration' => $result['migration'],
+            ])->getData();
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return Response::error(
+                'Failed to create field: ' . $e->getMessage(),
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+    }
+
+    /**
+     * PUT /api/mgr/extra-fields/{id}
+     */
+    public function update(array $params = []): array
+    {
+        $id = (int)($params['id'] ?? 0);
+
+        if (!$id) {
+            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
+        }
+
+        try {
+            $data = $this->readJsonBody();
+
+            if ($data === []) {
+                return Response::error('Request body is empty', HttpStatus::BAD_REQUEST)->getData();
+            }
+
+            $result = $this->service->updateField($id, $data);
+
+            if (!$result['success']) {
+                return Response::error($result['message'], HttpStatus::BAD_REQUEST)->getData();
+            }
+
+            return Response::success([
+                'message' => $result['message'],
+                'field' => $result['data'],
+            ])->getData();
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return Response::error(
+                'Failed to update field: ' . $e->getMessage(),
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+    }
+
+    /**
+     * DELETE /api/mgr/extra-fields/{id}
+     */
+    public function delete(array $params = []): array
+    {
+        $id = (int)($params['id'] ?? 0);
+
+        if (!$id) {
+            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
+        }
+
+        try {
+            $result = $this->service->deleteField($id);
+
+            if (!$result['success']) {
+                return Response::error($result['message'], HttpStatus::BAD_REQUEST)->getData();
+            }
+
+            return Response::success([
+                'message' => $result['message'],
+                'migration' => $result['migration'],
+            ])->getData();
+        } catch (\Exception $e) {
+            $this->logError($e);
+
+            return Response::error(
+                'Failed to delete field: ' . $e->getMessage(),
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJsonBody(): array
+    {
+        $data = json_decode(file_get_contents('php://input'), true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    private function logError(\Exception $e): void
+    {
+        $this->modx->log(modX::LOG_LEVEL_ERROR, '[ExtraFields API] ' . $e->getMessage());
+    }
+}

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -63,6 +63,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\ExtraFields\RepeaterFieldService::class,
             'interface' => null,
         ],
+        'ms3_extra_fields' => [
+            'class' => \MiniShop3\Services\ExtraFieldsService::class,
+            'interface' => null,
+        ],
         'ms3_product_image' => [
             'class' => \MiniShop3\Services\Product\ProductImageService::class,
             'interface' => null,

--- a/core/components/minishop3/src/Services/ExtraFieldsService.php
+++ b/core/components/minishop3/src/Services/ExtraFieldsService.php
@@ -145,17 +145,42 @@ class ExtraFieldsService
 
         $result = [];
         foreach ($fields as $field) {
-            $data = $field->toArray();
-
-            $data['column_exists'] = $this->extraFieldsUtil->columnExists(
-                $field->get('class'),
-                $field->get('key')
-            );
-
-            $result[] = $data;
+            $result[] = $this->formatField($field);
         }
 
         return $result;
+    }
+
+    /**
+     * Get single extra field by ID (with column_exists flag).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getField(int $id): ?array
+    {
+        /** @var msExtraField|null $field */
+        $field = $this->modx->getObject(msExtraField::class, $id);
+
+        if (!$field) {
+            return null;
+        }
+
+        return $this->formatField($field);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatField(msExtraField $field): array
+    {
+        $data = $field->toArray();
+
+        $data['column_exists'] = $this->extraFieldsUtil->columnExists(
+            $field->get('class'),
+            $field->get('key')
+        );
+
+        return $data;
     }
 
     /**

--- a/core/components/minishop3/tests/ExtraFieldsControllerRoutesTest.php
+++ b/core/components/minishop3/tests/ExtraFieldsControllerRoutesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Smoke: extra-fields routes dispatch to ExtraFieldsController (#355).
+ */
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$fail = static function (string $message): void {
+    fwrite(STDERR, "FAIL ExtraFieldsControllerRoutesTest: {$message}\n");
+    exit(1);
+};
+
+$routesPath = $root . '/config/routes/manager.php';
+if (!is_readable($routesPath)) {
+    $fail('manager.php not readable');
+}
+
+$src = file_get_contents($routesPath);
+if ($src === false) {
+    $fail('manager.php read failed');
+}
+
+$start = strpos($src, "\$router->group('/extra-fields'");
+if ($start === false) {
+    $fail("extra-fields group not found");
+}
+
+$nextGroup = strpos($src, "\$router->group('/customers'", $start);
+if ($nextGroup === false) {
+    $fail('anchor after /extra-fields (/customers) not found');
+}
+
+$block = substr($src, $start, $nextGroup - $start);
+
+if (str_contains($block, 'getObject')) {
+    $fail('extra-fields block must not call getObject');
+}
+
+if (str_contains($block, "file_get_contents('php://input')")) {
+    $fail('extra-fields block must not parse request body');
+}
+
+if (str_contains($block, 'new \\MiniShop3\\Services\\ExtraFieldsService')) {
+    $fail('extra-fields block must not instantiate ExtraFieldsService');
+}
+
+if (!str_contains($block, 'ExtraFieldsController')) {
+    $fail('extra-fields block must dispatch to ExtraFieldsController');
+}
+
+$controllerPath = $root . '/src/Controllers/Api/Manager/ExtraFieldsController.php';
+if (!is_readable($controllerPath)) {
+    $fail('ExtraFieldsController.php missing');
+}
+
+$controllerSrc = file_get_contents($controllerPath);
+if ($controllerSrc === false) {
+    $fail('ExtraFieldsController read failed');
+}
+
+foreach (['getList', 'get', 'create', 'update', 'delete'] as $method) {
+    if (!preg_match('/function\s+' . preg_quote($method, '/') . '\s*\(/', $controllerSrc)) {
+        $fail("ExtraFieldsController missing method {$method}");
+    }
+}
+
+if (!str_contains($controllerSrc, "services->get('ms3_extra_fields')")) {
+    $fail('ExtraFieldsController must resolve ms3_extra_fields from DI');
+}
+
+$registryPath = $root . '/src/ServiceRegistry.php';
+$registry = file_get_contents($registryPath);
+if ($registry === false || !str_contains($registry, "'ms3_extra_fields'")) {
+    $fail('ServiceRegistry must register ms3_extra_fields');
+}
+
+$servicePath = $root . '/src/Services/ExtraFieldsService.php';
+$serviceSrc = file_get_contents($servicePath);
+if ($serviceSrc === false || !str_contains($serviceSrc, 'function getField(')) {
+    $fail('ExtraFieldsService must expose getField()');
+}
+
+echo "OK ExtraFieldsControllerRoutesTest\n";


### PR DESCRIPTION
## Описание

CRUD `/api/mgr/extra-fields` вынесен из толстых closure в `ExtraFieldsController`. Маршруты только диспатчат в контроллер. Сервис `ExtraFieldsService` зарегистрирован в DI как `ms3_extra_fields`; добавлен `getField()` с общим `formatField()` для `column_exists`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #355

## Как это было протестировано?

```bash
php -l core/components/minishop3/src/Controllers/Api/Manager/ExtraFieldsController.php
php -l core/components/minishop3/src/Services/ExtraFieldsService.php
php -l core/components/minishop3/config/routes/manager.php
# exit 0

cd core/components/minishop3 && composer test:smoke
# OK smoke tests (27), включая ExtraFieldsControllerRoutesTest
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test:smoke`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `feat/issue-355-extra-fields-controller`
- MODX: n/a (smoke без полной установки)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требовались
- [ ] PHPStan проходит без новых ошибок — полный stan в CI
- [x] ESLint проходит без ошибок — Vue не трогали
- [ ] Обновлён CHANGELOG.md — по политике репо при релизе

## Дополнительные заметки

### AC #355

| Критерий | Реализация |
|----------|------------|
| В `manager.php` нет `getObject` / разбора body для extra-fields | smoke `ExtraFieldsControllerRoutesTest` |
| Поведение REST без breaking changes | те же endpoints, envelope `Response`, те же коды ошибок |
| Ответы через `Response` | контроллер возвращает `Response::*()->getData()` |
| `php -l` | exit 0 на затронутых файлах |

### Вне scope

- Split всего `manager.php` на файлы
- Vue ExtraFieldsManager UI
- Runtime dispatch-тест с stub-сервисом (follow-up, по аналогии с `ConfigRoutePermissionsTest`)

Refs #341, #345