### PR TITLE
test(integration): finalize required fields + cart SQLite draft

### DIFF
--- a/core/components/minishop3/tests/Integration/Cart/CartFacadeDraftStoreTest.php
+++ b/core/components/minishop3/tests/Integration/Cart/CartFacadeDraftStoreTest.php
@@ -14,11 +14,13 @@ use MiniShop3\Services\Order\OrderDraftManager;
 use MiniShop3\Services\Order\OrderLogService;
 use MiniShop3\Services\Order\OrderService;
 use MiniShop3\Tests\RecordingMsOrder;
+use MiniShop3\Tests\Support\OrderProductSqliteStore;
+use MiniShop3\Tests\Support\SqliteOrderProduct;
 use MODX\Revolution\modX;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Level-2: Cart facade add/change/remove against in-memory draft product store.
+ * Level-2: Cart facade add/change/remove against SQLite-backed draft product store.
  */
 final class CartFacadeDraftStoreTest extends TestCase
 {
@@ -27,11 +29,12 @@ final class CartFacadeDraftStoreTest extends TestCase
         if (!class_exists(modX::class, false)) {
             require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
         }
+        require_once dirname(__DIR__, 2) . '/support/OrderProductSqliteStore.php';
     }
 
-    public function testAddChangeRemoveAgainstDraftStore(): void
+    public function testAddChangeRemoveAgainstSqliteDraftStore(): void
     {
-        $store = new DraftProductStore();
+        $store = new OrderProductSqliteStore();
         $draft = new RecordingMsOrder(['id' => 42, 'cart_cost' => 0, 'delivery_cost' => 0, 'cost' => 0, 'weight' => 0]);
         $product = new LightweightCartProduct([
             'id' => 11,
@@ -53,21 +56,29 @@ final class CartFacadeDraftStoreTest extends TestCase
         $key = $added['data']['last_key'];
         self::assertSame(2, $added['data']['cart'][$key]['count']);
         self::assertSame(50.0, $added['data']['cart'][$key]['cost']);
+        self::assertSame(1, $store->countAll());
+        $row = $store->findOne(['order_id' => 42, 'product_key' => $key]);
+        self::assertNotNull($row);
+        self::assertSame(['color' => 'red'], $row['options']);
+        self::assertSame(2, $row['count']);
 
         $changed = $cart->change($key, 3);
         self::assertTrue($changed['success'], $changed['message'] ?? '');
         self::assertSame(3, $changed['data']['cart'][$key]['count']);
         self::assertSame(75.0, $changed['data']['cart'][$key]['cost']);
+        $row = $store->findOne(['order_id' => 42, 'product_key' => $key]);
+        self::assertSame(3, $row['count']);
+        self::assertSame(75.0, $row['cost']);
 
         $removed = $cart->remove($key);
         self::assertTrue($removed['success'], $removed['message'] ?? '');
         self::assertArrayNotHasKey($key, $removed['data']['cart']);
-        self::assertSame([], $store->items);
+        self::assertSame(0, $store->countAll());
     }
 
     public function testAddRejectsInvalidCount(): void
     {
-        $store = new DraftProductStore();
+        $store = new OrderProductSqliteStore();
         $draft = new RecordingMsOrder(['id' => 42]);
         $product = new LightweightCartProduct([
             'id' => 11,
@@ -85,10 +96,14 @@ final class CartFacadeDraftStoreTest extends TestCase
         $result = $cart->add(11, 0);
         self::assertFalse($result['success']);
         self::assertSame('ms3_cart_add_err_count', $result['message']);
+        self::assertSame(0, $store->countAll());
     }
 
-    private function makeCart(DraftProductStore $store, RecordingMsOrder $draft, LightweightCartProduct $product): Cart
-    {
+    private function makeCart(
+        OrderProductSqliteStore $store,
+        RecordingMsOrder $draft,
+        LightweightCartProduct $product
+    ): Cart {
         $utils = new class {
             public function success(string $message = '', array $data = [], array $placeholders = []): array
             {
@@ -110,7 +125,7 @@ final class CartFacadeDraftStoreTest extends TestCase
         $modx = new class ($store, $product, $orderService) extends modX {
 
             public function __construct(
-                private DraftProductStore $store,
+                private OrderProductSqliteStore $store,
                 private LightweightCartProduct $product,
                 OrderService $orderService,
             ) {
@@ -163,9 +178,15 @@ final class CartFacadeDraftStoreTest extends TestCase
                 }
 
                 if ($className === msOrderProduct::class && is_array($criteria)) {
-                    $key = (string) ($criteria['product_key'] ?? '');
+                    $row = $this->store->findOne($criteria);
+                    if ($row === null) {
+                        return null;
+                    }
+                    $item = new SqliteOrderProduct();
+                    $item->bindStore($this->store);
+                    $item->hydrate($row);
 
-                    return $this->store->items[$key] ?? null;
+                    return $item;
                 }
 
                 return null;
@@ -174,11 +195,11 @@ final class CartFacadeDraftStoreTest extends TestCase
             public function newObject($className, $fields = [])
             {
                 if ($className === msOrderProduct::class) {
-                    $item = new RecordingOrderProduct();
+                    $item = new SqliteOrderProduct();
+                    $item->bindStore($this->store);
                     if (is_array($fields) && $fields !== []) {
                         $item->fromArray($fields);
                     }
-                    $this->store->track($item);
 
                     return $item;
                 }
@@ -189,10 +210,28 @@ final class CartFacadeDraftStoreTest extends TestCase
             public function getIterator($className, $criteria = null, $cacheFlag = true): \ArrayIterator
             {
                 if ($className === msOrderProduct::class) {
-                    return new \ArrayIterator(array_values($this->store->items));
+                    $rows = $this->store->findAll(is_array($criteria) ? $criteria : []);
+                    $items = [];
+                    foreach ($rows as $row) {
+                        $item = new SqliteOrderProduct();
+                        $item->bindStore($this->store);
+                        $item->hydrate($row);
+                        $items[] = $item;
+                    }
+
+                    return new \ArrayIterator($items);
                 }
 
                 return new \ArrayIterator([]);
+            }
+
+            public function getCount($className, $criteria = null)
+            {
+                if ($className === msOrderProduct::class) {
+                    return count($this->store->findAll(is_array($criteria) ? $criteria : []));
+                }
+
+                return 0;
             }
         };
 
@@ -204,6 +243,12 @@ final class CartFacadeDraftStoreTest extends TestCase
         $draftManager = $this->createStub(OrderDraftManager::class);
         $draftManager->method('getDraft')->willReturn($draft);
         $draftManager->method('getOrCreateDraft')->willReturn($draft);
+        $draftManager->method('isEmpty')->willReturnCallback(
+            static function (msOrder $order) use ($store): bool {
+                return $store->findAll(['order_id' => (int) $order->get('id')]) === [];
+            }
+        );
+        $draftManager->method('deleteDraft')->willReturn(true);
         $draftManager->method('recalculate')->willReturnCallback(
             static function (msOrder $order) use ($orderService, $itemManager): void {
                 $items = $itemManager->loadItems($order);
@@ -237,90 +282,6 @@ final class CartFacadeDraftStoreTest extends TestCase
         );
 
         return new HarnessCart($ms3, $itemManager, $draftManager);
-    }
-}
-
-final class DraftProductStore
-{
-    /** @var array<string, RecordingOrderProduct> */
-    public array $items = [];
-
-    public function track(RecordingOrderProduct $item): void
-    {
-        $item->bindStore($this);
-    }
-
-    public function sync(RecordingOrderProduct $item): void
-    {
-        $key = (string) $item->get('product_key');
-        if ($key === '' || $item->removed) {
-            foreach ($this->items as $k => $existing) {
-                if ($existing === $item) {
-                    unset($this->items[$k]);
-                }
-            }
-
-            return;
-        }
-        $this->items[$key] = $item;
-    }
-}
-
-final class RecordingOrderProduct extends msOrderProduct
-{
-    /** @var array<string, mixed> */
-    private array $fields = [];
-
-    private ?DraftProductStore $store = null;
-
-    public bool $removed = false;
-
-    public function bindStore(DraftProductStore $store): void
-    {
-        $this->store = $store;
-    }
-
-    public function fromArray($fields, $keyPrefix = '', $setPrimaryKeys = false, $rawValues = false, $adhoc = false)
-    {
-        foreach ($fields as $key => $value) {
-            $this->fields[$key] = $value;
-        }
-        $this->store?->sync($this);
-
-        return true;
-    }
-
-    public function get($k, $format = null, $formatTemplate = null)
-    {
-        return $this->fields[$k] ?? null;
-    }
-
-    public function set($key, $value)
-    {
-        $this->fields[$key] = $value;
-        $this->store?->sync($this);
-
-        return true;
-    }
-
-    public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
-    {
-        return $this->fields;
-    }
-
-    public function save($cacheFlag = null)
-    {
-        $this->store?->sync($this);
-
-        return true;
-    }
-
-    public function remove(array $ancestors = [])
-    {
-        $this->removed = true;
-        $this->store?->sync($this);
-
-        return true;
     }
 }
 

--- a/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
@@ -10,6 +10,7 @@ use MiniShop3\Model\msOrder;
 use MiniShop3\Model\msOrderAddress;
 use MiniShop3\Model\msOrderProduct;
 use MiniShop3\Model\msPayment;
+use MiniShop3\Services\Delivery\DeliveryService;
 use MiniShop3\Services\Order\OrderFinalizeService;
 use MiniShop3\Services\Order\OrderNumberGenerator;
 use MiniShop3\Services\Order\OrderService;
@@ -89,22 +90,18 @@ final class OrderFinalizeServiceTest extends TestCase
                 }
             },
         ];
-        $delivery = new class extends xPDOSimpleObject {
-            public function get($k)
-            {
-                return match ($k) {
-                    'price' => 0.0,
-                    'weight_price' => 0.0,
-                    'active' => 1,
-                    'validation_rules' => json_encode([
-                        'email' => 'required|email',
-                        'phone' => 'required',
-                        'city' => 'max:100',
-                    ]),
-                    default => null,
-                };
-            }
-        };
+        $delivery = $this->makeDeliveryStub([
+            'price' => 0.0,
+            'weight_price' => 0.0,
+            'active' => 1,
+            'class' => '',
+            'free_delivery_amount' => 0,
+            'validation_rules' => json_encode([
+                'email' => 'required|email',
+                'phone' => 'required',
+                'city' => 'max:100',
+            ]),
+        ]);
         $address = new class extends xPDOSimpleObject {
             public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
             {
@@ -160,21 +157,17 @@ final class OrderFinalizeServiceTest extends TestCase
                 }
             },
         ];
-        $delivery = new class extends xPDOSimpleObject {
-            public function get($k)
-            {
-                return match ($k) {
-                    'price' => 20.0,
-                    'weight_price' => 0.0,
-                    'active' => 1,
-                    'validation_rules' => json_encode([
-                        'email' => 'required|email',
-                        'receiver' => 'required',
-                    ]),
-                    default => null,
-                };
-            }
-        };
+        $delivery = $this->makeDeliveryStub([
+            'price' => 20.0,
+            'weight_price' => 0.0,
+            'active' => 1,
+            'class' => '',
+            'free_delivery_amount' => 0,
+            'validation_rules' => json_encode([
+                'email' => 'required|email',
+                'receiver' => 'required',
+            ]),
+        ]);
         $address = new class extends xPDOSimpleObject {
             public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
             {
@@ -245,15 +238,13 @@ final class OrderFinalizeServiceTest extends TestCase
             },
         ];
 
-        $delivery = $this->createStub(msDelivery::class);
-        $delivery->method('get')->willReturnCallback(static function (string $k) {
-            return match ($k) {
-                'price' => 50.0,
-                'weight_price' => 10.0,
-                'active' => 1,
-                default => null,
-            };
-        });
+        $delivery = $this->makeDeliveryStub([
+            'price' => 50.0,
+            'weight_price' => 10.0,
+            'active' => 1,
+            'class' => '',
+            'free_delivery_amount' => 0,
+        ]);
 
         $statusCalls = [];
         $service = $this->makeService(
@@ -286,6 +277,19 @@ final class OrderFinalizeServiceTest extends TestCase
         self::assertCount(1, $statusCalls);
         self::assertSame(2, $statusCalls[0]['status']);
         self::assertTrue($statusCalls[0]['skip']);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function makeDeliveryStub(array $fields): msDelivery
+    {
+        $delivery = $this->createStub(msDelivery::class);
+        $delivery->method('get')->willReturnCallback(static function (string $k) use ($fields) {
+            return $fields[$k] ?? null;
+        });
+
+        return $delivery;
     }
 
     /**
@@ -340,10 +344,28 @@ final class OrderFinalizeServiceTest extends TestCase
 
         $payment = $this->createStub(msPayment::class);
         $payment->method('get')->willReturnCallback(static function (string $k) {
-            return $k === 'active' ? 1 : null;
+            return match ($k) {
+                'active' => 1,
+                'class' => '',
+                'price' => 0,
+                default => null,
+            };
         });
 
-        $modx = new class ($orders, $productCount, $products, $delivery, $payment, $address, $orderService, $statusService) extends modX {
+        $deliveryService = $this->createStub(DeliveryService::class);
+        $deliveryService->method('getDeliveryPaymentPairError')->willReturn(null);
+
+        $modx = new class (
+            $orders,
+            $productCount,
+            $products,
+            $delivery,
+            $payment,
+            $address,
+            $orderService,
+            $statusService,
+            $deliveryService,
+        ) extends modX {
 
             /**
              * @param array<int, RecordingMsOrder> $orders
@@ -358,18 +380,24 @@ final class OrderFinalizeServiceTest extends TestCase
                 private ?object $address,
                 OrderService $orderService,
                 object $statusService,
+                DeliveryService $deliveryService,
             ) {
                 parent::__construct();
-                $this->services = new class ($orderService, $statusService) {
+                $this->services = new class ($orderService, $statusService, $deliveryService) {
                     public function __construct(
                         private OrderService $orderService,
                         private object $statusService,
+                        private DeliveryService $deliveryService,
                     ) {
                     }
 
                     public function has(string $key): bool
                     {
-                        return in_array($key, ['ms3_order_service', 'ms3_order_status'], true);
+                        return in_array($key, [
+                            'ms3_order_service',
+                            'ms3_order_status',
+                            'ms3_delivery_service',
+                        ], true);
                     }
 
                     public function get(string $key): mixed
@@ -377,6 +405,7 @@ final class OrderFinalizeServiceTest extends TestCase
                         return match ($key) {
                             'ms3_order_service' => $this->orderService,
                             'ms3_order_status' => $this->statusService,
+                            'ms3_delivery_service' => $this->deliveryService,
                             default => null,
                         };
                     }

--- a/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/OrderFinalizeServiceTest.php
@@ -7,6 +7,7 @@ namespace MiniShop3\Tests\Integration\Order;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msDelivery;
 use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderAddress;
 use MiniShop3\Model\msOrderProduct;
 use MiniShop3\Model\msPayment;
 use MiniShop3\Services\Order\OrderFinalizeService;
@@ -64,6 +65,155 @@ final class OrderFinalizeServiceTest extends TestCase
         self::assertContains('products', $result['data']);
         self::assertContains('delivery_id', $result['data']);
         self::assertContains('payment_id', $result['data']);
+    }
+
+
+    public function testFinalizeFailsOnMissingDeliveryRequiredFields(): void
+    {
+        $order = new RecordingMsOrder([
+            'id' => 5,
+            'status_id' => 1,
+            'delivery_id' => 3,
+            'payment_id' => 4,
+        ]);
+        $products = [
+            new class {
+                public function get(string $field): float|int
+                {
+                    return match ($field) {
+                        'cost' => 10.0,
+                        'weight' => 1.0,
+                        'count' => 1,
+                        default => 0,
+                    };
+                }
+            },
+        ];
+        $delivery = new class extends xPDOSimpleObject {
+            public function get($k)
+            {
+                return match ($k) {
+                    'price' => 0.0,
+                    'weight_price' => 0.0,
+                    'active' => 1,
+                    'validation_rules' => json_encode([
+                        'email' => 'required|email',
+                        'phone' => 'required',
+                        'city' => 'max:100',
+                    ]),
+                    default => null,
+                };
+            }
+        };
+        $address = new class extends xPDOSimpleObject {
+            public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
+            {
+                return [
+                    'order_id' => 5,
+                    'email' => '',
+                    'phone' => '',
+                    'city' => 'Moscow',
+                ];
+            }
+        };
+
+        $service = $this->makeService(
+            orders: [5 => $order],
+            productCount: 1,
+            products: $products,
+            delivery: $delivery,
+            address: $address,
+        );
+        $result = $service->finalize(5);
+
+        self::assertFalse($result['success']);
+        self::assertSame('ms3_order_err_validation', $result['message']);
+        self::assertContains('email', $result['data']);
+        self::assertContains('phone', $result['data']);
+        self::assertNotContains('city', $result['data']);
+    }
+
+    public function testFinalizeHappyPathWithoutSkipValidation(): void
+    {
+        $order = new RecordingMsOrder([
+            'id' => 5,
+            'status_id' => 1,
+            'delivery_id' => 3,
+            'payment_id' => 4,
+            'num' => '2501/7',
+            'customer_id' => 0,
+            'cost' => 0,
+            'cart_cost' => 0,
+            'delivery_cost' => 0,
+            'weight' => 0,
+        ]);
+        $products = [
+            new class {
+                public function get(string $field): float|int
+                {
+                    return match ($field) {
+                        'cost' => 40.0,
+                        'weight' => 0.5,
+                        'count' => 2,
+                        default => 0,
+                    };
+                }
+            },
+        ];
+        $delivery = new class extends xPDOSimpleObject {
+            public function get($k)
+            {
+                return match ($k) {
+                    'price' => 20.0,
+                    'weight_price' => 0.0,
+                    'active' => 1,
+                    'validation_rules' => json_encode([
+                        'email' => 'required|email',
+                        'receiver' => 'required',
+                    ]),
+                    default => null,
+                };
+            }
+        };
+        $address = new class extends xPDOSimpleObject {
+            public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
+            {
+                return [
+                    'order_id' => 5,
+                    'email' => 'buyer@example.com',
+                    'receiver' => 'Ivan',
+                ];
+            }
+        };
+
+        $statusCalls = [];
+        $service = $this->makeService(
+            orders: [5 => $order],
+            productCount: 1,
+            products: $products,
+            delivery: $delivery,
+            address: $address,
+            onStatusChange: static function (int $id, int $status, bool $skip) use (&$statusCalls, $order): bool {
+                $statusCalls[] = compact('id', 'status', 'skip');
+                $order->set('status_id', $status);
+
+                return true;
+            }
+        );
+
+        $result = $service->finalize(5, ['skip_notifications' => true]);
+
+        self::assertTrue($result['success'], $result['message'] ?? '');
+        self::assertSame('ms3_order_finalized', $result['message']);
+        self::assertSame(5, $result['data']['order_id']);
+        self::assertSame('2501/7', $result['data']['order_num']);
+        self::assertSame(2, $result['data']['status_id']);
+        self::assertSame(40.0, $order->get('cart_cost'));
+        self::assertSame(20.0, $order->get('delivery_cost'));
+        self::assertSame(60.0, $order->get('cost'));
+        self::assertSame(1.0, $order->get('weight'));
+        self::assertCount(1, $statusCalls);
+        self::assertTrue($statusCalls[0]['skip']);
     }
 
     public function testFinalizeHappyPathWithSkipValidation(): void
@@ -147,6 +297,7 @@ final class OrderFinalizeServiceTest extends TestCase
         int $productCount = 0,
         array $products = [],
         ?object $delivery = null,
+        ?object $address = null,
         ?callable $onStatusChange = null,
     ): OrderFinalizeService {
         $orderService = new OrderService(new modX());
@@ -192,7 +343,7 @@ final class OrderFinalizeServiceTest extends TestCase
             return $k === 'active' ? 1 : null;
         });
 
-        $modx = new class ($orders, $productCount, $products, $delivery, $payment, $orderService, $statusService) extends modX {
+        $modx = new class ($orders, $productCount, $products, $delivery, $payment, $address, $orderService, $statusService) extends modX {
 
             /**
              * @param array<int, RecordingMsOrder> $orders
@@ -204,6 +355,7 @@ final class OrderFinalizeServiceTest extends TestCase
                 private array $products,
                 private ?object $delivery,
                 private object $payment,
+                private ?object $address,
                 OrderService $orderService,
                 object $statusService,
             ) {
@@ -260,6 +412,10 @@ final class OrderFinalizeServiceTest extends TestCase
 
                 if ($className === msPayment::class) {
                     return $this->payment;
+                }
+
+                if ($className === msOrderAddress::class) {
+                    return $this->address;
                 }
 
                 return null;

--- a/core/components/minishop3/tests/RecordingMsOrder.php
+++ b/core/components/minishop3/tests/RecordingMsOrder.php
@@ -64,6 +64,17 @@ final class RecordingMsOrder extends msOrder
     public function save($cacheFlag = null)
     {
         $this->saved = true;
+        foreach ($this->products as $product) {
+            if (!is_object($product) || !method_exists($product, 'save')) {
+                continue;
+            }
+            // Persist only new lines. Re-saving attached instances after an out-of-band
+            // DB update would overwrite fresh rows with stale in-memory fields.
+            if (method_exists($product, 'get') && !empty($product->get('id'))) {
+                continue;
+            }
+            $product->save();
+        }
 
         return true;
     }

--- a/core/components/minishop3/tests/support/OrderProductSqliteStore.php
+++ b/core/components/minishop3/tests/support/OrderProductSqliteStore.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use MiniShop3\Model\msOrderProduct;
+use PDO;
+
+/**
+ * In-memory SQLite store for ms_order_product rows used by Cart Level-2 tests.
+ */
+final class OrderProductSqliteStore
+{
+    private PDO $pdo;
+
+    private int $nextId = 1;
+
+    public function __construct()
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->query(
+            'CREATE TABLE ms_order_product (
+                id INTEGER PRIMARY KEY,
+                order_id INTEGER NOT NULL,
+                product_id INTEGER NOT NULL,
+                product_key TEXT NOT NULL,
+                name TEXT NOT NULL DEFAULT \'\',
+                count INTEGER NOT NULL DEFAULT 0,
+                price REAL NOT NULL DEFAULT 0,
+                weight REAL NOT NULL DEFAULT 0,
+                cost REAL NOT NULL DEFAULT 0,
+                options TEXT NOT NULL DEFAULT \'{}\',
+                properties TEXT NOT NULL DEFAULT \'{}\'
+            )'
+        );
+    }
+
+    public function insert(array $fields): int
+    {
+        $id = (int) ($fields['id'] ?? 0);
+        if ($id <= 0) {
+            $id = $this->nextId++;
+        } else {
+            $this->nextId = max($this->nextId, $id + 1);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO ms_order_product (
+                id, order_id, product_id, product_key, name, count, price, weight, cost, options, properties
+            ) VALUES (
+                :id, :order_id, :product_id, :product_key, :name, :count, :price, :weight, :cost, :options, :properties
+            )'
+        );
+        $stmt->execute([
+            ':id' => $id,
+            ':order_id' => (int) ($fields['order_id'] ?? 0),
+            ':product_id' => (int) ($fields['product_id'] ?? 0),
+            ':product_key' => (string) ($fields['product_key'] ?? ''),
+            ':name' => (string) ($fields['name'] ?? ''),
+            ':count' => (int) ($fields['count'] ?? 0),
+            ':price' => (float) ($fields['price'] ?? 0),
+            ':weight' => (float) ($fields['weight'] ?? 0),
+            ':cost' => (float) ($fields['cost'] ?? 0),
+            ':options' => $this->encodeJson($fields['options'] ?? []),
+            ':properties' => $this->encodeJson($fields['properties'] ?? []),
+        ]);
+
+        return $id;
+    }
+
+    public function update(int $id, array $fields): bool
+    {
+        $existing = $this->findById($id);
+        if ($existing === null) {
+            return false;
+        }
+
+        $merged = array_merge($existing, $fields, ['id' => $id]);
+        $stmt = $this->pdo->prepare(
+            'UPDATE ms_order_product SET
+                order_id = :order_id,
+                product_id = :product_id,
+                product_key = :product_key,
+                name = :name,
+                count = :count,
+                price = :price,
+                weight = :weight,
+                cost = :cost,
+                options = :options,
+                properties = :properties
+             WHERE id = :id'
+        );
+
+        return $stmt->execute([
+            ':id' => $id,
+            ':order_id' => (int) ($merged['order_id'] ?? 0),
+            ':product_id' => (int) ($merged['product_id'] ?? 0),
+            ':product_key' => (string) ($merged['product_key'] ?? ''),
+            ':name' => (string) ($merged['name'] ?? ''),
+            ':count' => (int) ($merged['count'] ?? 0),
+            ':price' => (float) ($merged['price'] ?? 0),
+            ':weight' => (float) ($merged['weight'] ?? 0),
+            ':cost' => (float) ($merged['cost'] ?? 0),
+            ':options' => $this->encodeJson($merged['options'] ?? []),
+            ':properties' => $this->encodeJson($merged['properties'] ?? []),
+        ]);
+    }
+
+    public function delete(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM ms_order_product WHERE id = ?');
+
+        return $stmt->execute([$id]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findById(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM ms_order_product WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->decodeRow($row);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return array<string, mixed>|null
+     */
+    public function findOne(array $criteria): ?array
+    {
+        [$sql, $params] = $this->buildWhere($criteria);
+        $stmt = $this->pdo->prepare('SELECT * FROM ms_order_product WHERE ' . $sql . ' LIMIT 1');
+        $stmt->execute($params);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->decodeRow($row);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return list<array<string, mixed>>
+     */
+    public function findAll(array $criteria = []): array
+    {
+        if ($criteria === []) {
+            $stmt = $this->pdo->query('SELECT * FROM ms_order_product ORDER BY id');
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        } else {
+            [$sql, $params] = $this->buildWhere($criteria);
+            $stmt = $this->pdo->prepare('SELECT * FROM ms_order_product WHERE ' . $sql . ' ORDER BY id');
+            $stmt->execute($params);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        }
+
+        return array_map(fn(array $row): array => $this->decodeRow($row), $rows);
+    }
+
+    public function countAll(): int
+    {
+        return (int) $this->pdo->query('SELECT COUNT(*) FROM ms_order_product')->fetchColumn();
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return array{0: string, 1: list<mixed>}
+     */
+    private function buildWhere(array $criteria): array
+    {
+        $parts = [];
+        $params = [];
+        foreach ($criteria as $key => $value) {
+            $parts[] = $key . ' = ?';
+            $params[] = $value;
+        }
+
+        return [implode(' AND ', $parts), $params];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function decodeRow(array $row): array
+    {
+        $row['id'] = (int) $row['id'];
+        $row['order_id'] = (int) $row['order_id'];
+        $row['product_id'] = (int) $row['product_id'];
+        $row['count'] = (int) $row['count'];
+        $row['price'] = (float) $row['price'];
+        $row['weight'] = (float) $row['weight'];
+        $row['cost'] = (float) $row['cost'];
+        $row['options'] = $this->decodeJson((string) $row['options']);
+        $row['properties'] = $this->decodeJson((string) $row['properties']);
+
+        return $row;
+    }
+
+    private function encodeJson(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return json_encode($value ?? [], JSON_UNESCAPED_UNICODE) ?: '{}';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(string $json): array
+    {
+        $decoded = json_decode($json, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}
+
+/**
+ * msOrderProduct that persists fields into OrderProductSqliteStore.
+ */
+final class SqliteOrderProduct extends msOrderProduct
+{
+    /** @var array<string, mixed> */
+    private array $fields = [];
+
+    private ?OrderProductSqliteStore $store = null;
+
+    private bool $persisted = false;
+
+    public function bindStore(OrderProductSqliteStore $store): void
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function hydrate(array $fields): void
+    {
+        $this->fields = $fields;
+        $this->persisted = isset($fields['id']);
+    }
+
+    public function fromArray($fields, $keyPrefix = '', $setPrimaryKeys = false, $rawValues = false, $adhoc = false)
+    {
+        foreach ($fields as $key => $value) {
+            $this->fields[$key] = $value;
+        }
+
+        return true;
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->fields[$k] ?? null;
+    }
+
+    public function set($key, $value)
+    {
+        $this->fields[$key] = $value;
+
+        return true;
+    }
+
+    public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
+    {
+        return $this->fields;
+    }
+
+    public function save($cacheFlag = null)
+    {
+        if ($this->store === null) {
+            return false;
+        }
+
+        if ($this->persisted && isset($this->fields['id'])) {
+            return $this->store->update((int) $this->fields['id'], $this->fields);
+        }
+
+        $id = $this->store->insert($this->fields);
+        $this->fields['id'] = $id;
+        $this->persisted = true;
+
+        return true;
+    }
+
+    public function remove(array $ancestors = [])
+    {
+        if ($this->store === null || !isset($this->fields['id'])) {
+            return false;
+        }
+
+        $ok = $this->store->delete((int) $this->fields['id']);
+        $this->persisted = false;
+
+        return $ok;
+    }
+}


### PR DESCRIPTION
## Описание

Интеграционные тесты для `#429`: finalize без `skip_validation` (отказ при пустых required delivery fields + happy path) и cart add/change/remove через SQLite-store `ms_order_product`. `RecordingMsOrder::save` каскадит только новые product lines, чтобы не затирать строки после UPDATE в БД.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [x] Другое (опишите): интеграционные тесты

## Связанные Issues

Refs #429

## Как это было протестировано?

```bash
cd core/components/minishop3
composer test   # 106 OK
php -l tests/Integration/Cart/CartFacadeDraftStoreTest.php \
  tests/Integration/Order/OrderFinalizeServiceTest.php \
  tests/RecordingMsOrder.php \
  tests/support/OrderProductSqliteStore.php
```

GitHub Actions CI на PR: PHP lint + smoke, PHPStan, vueManager lint — pass.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `test/issue-429-finalize-cart-sqlite`
- MODX: n/a (SQLite harness без runtime MODX)
- PHP: локальный + CI

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [x] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Лексиконы, Vue и CHANGELOG не затрагивались.