### PR TITLE
test(integration): MySQL CI + AuthManager lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,25 @@ jobs:
       run:
         working-directory: core/components/minishop3
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: ms3_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+
+    env:
+      MS3_TEST_MYSQL_DSN: mysql:host=127.0.0.1;port=3306;dbname=ms3_test;charset=utf8mb4
+      MS3_TEST_MYSQL_USER: root
+      MS3_TEST_MYSQL_PASSWORD: root
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,6 +52,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
+          extensions: pdo_mysql
           tools: composer:v2
 
       - name: Install Composer dependencies

--- a/core/components/minishop3/scripts/ci-php.sh
+++ b/core/components/minishop3/scripts/ci-php.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# PHP CI gate: syntax check + smoke + PHPUnit (no MODX/MySQL).
+# PHP CI gate: syntax check + smoke + PHPUnit.
+# MySQL Level-2 tests (@group mysql) run when MS3_TEST_MYSQL_DSN is set (CI service).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
+++ b/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
@@ -265,8 +265,6 @@ class AuthManagerLifecycleTest extends TestCase
         );
 
         $modx = new class ($store, $options, $orderDraftManager) extends modX {
-            public object $services;
-
             /**
              * @param array<string, mixed> $options
              */

--- a/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
+++ b/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\Customer;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\TokenService;
+use MiniShop3\Tests\Support\CustomerAuthPdoStore;
+use MiniShop3\Tests\Support\StoredMsCustomer;
+use MiniShop3\Tests\Support\StoredMsCustomerToken;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Level-2: AuthManager authenticate → establish session → logout lifecycle.
+ *
+ * Uses PDO store (SQLite by default). Subclass/override createStore() for MySQL.
+ */
+class AuthManagerLifecycleTest extends TestCase
+{
+    private CustomerAuthPdoStore $store;
+
+    /** @var list<string> */
+    private array $draftCalls = [];
+
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
+        }
+        require_once dirname(__DIR__, 2) . '/support/CustomerAuthPdoStore.php';
+
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+        $_SESSION = [];
+        $_COOKIE = [];
+
+        $this->store = $this->createStore();
+        $this->store->reset();
+        $this->draftCalls = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $_COOKIE = [];
+    }
+
+    protected function createStore(): CustomerAuthPdoStore
+    {
+        return CustomerAuthPdoStore::sqliteMemory();
+    }
+
+    public function testAuthenticateRejectsBlockedAndInactive(): void
+    {
+        $blocked = $this->seedCustomer([
+            'email' => 'blocked@example.com',
+            'is_active' => 1,
+            'is_blocked' => 1,
+            'blocked_until' => date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $inactive = $this->seedCustomer([
+            'email' => 'inactive@example.com',
+            'is_active' => 0,
+            'is_blocked' => 0,
+        ]);
+
+        $modx = $this->makeModx();
+        $auth = $this->makeAuthManager($modx);
+        self::assertNull($auth->authenticate(['email' => 'blocked@example.com', 'password' => 'secret']));
+        self::assertSame('blocked', $auth->getLastAuthFailure());
+
+        $auth = $this->makeAuthManager($modx);
+        self::assertNull($auth->authenticate(['email' => 'inactive@example.com', 'password' => 'secret']));
+        self::assertSame('inactive', $auth->getLastAuthFailure());
+    }
+
+    public function testEstablishSessionRotatesTokenAndLogoutMintsGuest(): void
+    {
+        $customer = $this->seedCustomer([
+            'email' => 'buyer@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+        ]);
+
+        $modx = $this->makeModx();
+        $tokenService = new TokenService($modx);
+
+        // Plant a guest token in the browser (session + cookie).
+        $guest = $tokenService->persistApiToken(0, null, 3600);
+        self::assertNotNull($guest);
+        $guestToken = (string) $guest->get('token');
+        self::assertSame(0, (int) ($_SESSION['ms3']['customer_id'] ?? -1));
+        self::assertSame($guestToken, $_SESSION['ms3']['customer_token'] ?? null);
+
+        $auth = $this->makeAuthManager($modx);
+        $authed = $auth->authenticate(['email' => 'buyer@example.com', 'password' => 'secret']);
+        self::assertNotNull($authed);
+        self::assertSame('none', $auth->getLastAuthFailure());
+        self::assertNotEmpty($authed->get('last_login_at'));
+
+        $session = $auth->establishCustomerSession($authed);
+        self::assertNotNull($session);
+        $loginToken = $session['token'];
+        self::assertNotSame($guestToken, $loginToken);
+        self::assertSame((int) $customer->id, (int) ($_SESSION['ms3']['customer_id'] ?? 0));
+        self::assertSame($loginToken, $_SESSION['ms3']['customer_token'] ?? null);
+        self::assertSame($loginToken, $_COOKIE['ms3_token'] ?? null);
+
+        // Previous guest token must be gone (anti fixation).
+        self::assertNull($this->store->findToken(['token' => $guestToken, 'type' => msCustomerToken::TYPE_API]));
+        self::assertSame(1, $this->store->countTokens((int) $customer->id, msCustomerToken::TYPE_API));
+        self::assertContains('transfer:' . $guestToken . '=>' . $loginToken, $this->draftCalls);
+
+        self::assertTrue($auth->logoutCurrentCustomer());
+        self::assertSame(0, (int) ($_SESSION['ms3']['customer_id'] ?? 0));
+        self::assertSame(0, $this->store->countTokens((int) $customer->id, msCustomerToken::TYPE_API));
+
+        $guestAfter = $_SESSION['ms3']['customer_token'] ?? '';
+        self::assertNotSame('', $guestAfter);
+        self::assertNotSame($loginToken, $guestAfter);
+        $guestRow = $this->store->findToken(['token' => $guestAfter, 'type' => msCustomerToken::TYPE_API]);
+        self::assertNotNull($guestRow);
+        self::assertSame(0, (int) $guestRow['customer_id']);
+    }
+
+    public function testForeignTokenDoesNotTransferCartButIsRevoked(): void
+    {
+        $customer = $this->seedCustomer([
+            'email' => 'buyer@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+        ]);
+        $other = $this->seedCustomer([
+            'email' => 'other@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+        ]);
+
+        $modx = $this->makeModx();
+        $tokenService = new TokenService($modx);
+        $planted = $tokenService->persistApiToken((int) $other->id, null, 3600);
+        self::assertNotNull($planted);
+        $plantedToken = (string) $planted->get('token');
+
+        $auth = $this->makeAuthManager($modx);
+        $authed = $auth->authenticate(['email' => 'buyer@example.com', 'password' => 'secret']);
+        self::assertNotNull($authed);
+
+        $session = $auth->establishCustomerSession($authed);
+        self::assertNotNull($session);
+        self::assertNull($this->store->findToken(['token' => $plantedToken, 'type' => msCustomerToken::TYPE_API]));
+        self::assertTrue(
+            (bool) array_filter(
+                $this->draftCalls,
+                static fn(string $call): bool => str_starts_with($call, 'bind:')
+            )
+        );
+        self::assertFalse(
+            (bool) array_filter(
+                $this->draftCalls,
+                static fn(string $call): bool => str_starts_with($call, 'transfer:')
+            )
+        );
+    }
+
+    public function testValidateTokenAndRevokeTokens(): void
+    {
+        $customer = $this->seedCustomer([
+            'email' => 'buyer@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+        ]);
+        $modx = $this->makeModx();
+        $auth = $this->makeAuthManager($modx);
+
+        $token = $auth->createToken($customer, msCustomerToken::TYPE_API, 3600);
+        self::assertNotNull($token);
+        $validated = $auth->validateToken((string) $token->get('token'), msCustomerToken::TYPE_API);
+        self::assertNotNull($validated);
+        self::assertSame((int) $customer->id, (int) $validated->id);
+
+        $expired = new StoredMsCustomerToken();
+        $expired->bindStore($this->store);
+        $expired->set('customer_id', (int) $customer->id);
+        $expired->set('token', 'expired-' . bin2hex(random_bytes(8)));
+        $expired->set('type', msCustomerToken::TYPE_API);
+        $expired->set('expires_at', date('Y-m-d H:i:s', time() - 10));
+        $expired->set('created_at', date('Y-m-d H:i:s'));
+        self::assertTrue($expired->save());
+        self::assertNull($auth->validateToken((string) $expired->get('token'), msCustomerToken::TYPE_API));
+        self::assertNull($this->store->findToken(['token' => (string) $expired->get('token')]));
+
+        self::assertSame(1, $auth->revokeTokens($customer, msCustomerToken::TYPE_API));
+        self::assertSame(0, $this->store->countTokens((int) $customer->id, msCustomerToken::TYPE_API));
+    }
+
+    public function testHandleFailedLoginBlocksAfterMaxAttempts(): void
+    {
+        $customer = $this->seedCustomer([
+            'email' => 'buyer@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+            'failed_login_attempts' => 0,
+        ]);
+        $modx = $this->makeModx(['ms3_customer_max_login_attempts' => 3, 'ms3_customer_block_duration' => 1800]);
+        $auth = $this->makeAuthManager($modx);
+
+        $auth->handleFailedLogin($customer);
+        $auth->handleFailedLogin($customer);
+        self::assertFalse((bool) $customer->get('is_blocked'));
+        $auth->handleFailedLogin($customer);
+        self::assertTrue((bool) $customer->get('is_blocked'));
+        self::assertSame(3, (int) $customer->get('failed_login_attempts'));
+        self::assertNotEmpty($customer->get('blocked_until'));
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function seedCustomer(array $fields): StoredMsCustomer
+    {
+        if (!isset($fields['password']) || $fields['password'] === '') {
+            $fields['password'] = password_hash('secret', PASSWORD_BCRYPT);
+        } elseif (!str_starts_with((string) $fields['password'], '$2')) {
+            $fields['password'] = password_hash((string) $fields['password'], PASSWORD_BCRYPT);
+        }
+        $id = $this->store->insertCustomer($fields);
+        $row = $this->store->findCustomerById($id);
+        self::assertNotNull($row);
+        $customer = new StoredMsCustomer();
+        $customer->bindStore($this->store);
+        $customer->hydrate($row);
+
+        return $customer;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function makeModx(array $options = []): modX
+    {
+        $store = $this->store;
+        $draftCalls = &$this->draftCalls;
+
+        $orderDraftManager = $this->createStub(OrderDraftManager::class);
+        $orderDraftManager->method('transferDraftToToken')->willReturnCallback(
+            static function (string $fromToken, string $toToken, int $customerId, string $ctx = 'web') use (&$draftCalls): bool {
+                $draftCalls[] = 'transfer:' . $fromToken . '=>' . $toToken;
+
+                return true;
+            }
+        );
+        $orderDraftManager->method('bindDraftToCustomer')->willReturnCallback(
+            static function (string $token, int $customerId, string $ctx = 'web') use (&$draftCalls): bool {
+                $draftCalls[] = 'bind:' . $token;
+
+                return true;
+            }
+        );
+
+        $modx = new class ($store, $options, $orderDraftManager) extends modX {
+            public object $services;
+
+            /**
+             * @param array<string, mixed> $options
+             */
+            public function __construct(
+                private CustomerAuthPdoStore $store,
+                private array $options,
+                OrderDraftManager $orderDraftManager,
+            ) {
+                parent::__construct();
+                $tokenService = new TokenService($this);
+                $this->services = new class ($tokenService, $orderDraftManager) {
+                    public function __construct(
+                        private TokenService $tokenService,
+                        private OrderDraftManager $orderDraftManager,
+                    ) {
+                    }
+
+                    public function has(string $key): bool
+                    {
+                        return in_array($key, ['ms3_token_service', 'ms3_order_draft_manager'], true);
+                    }
+
+                    public function get(string $key): mixed
+                    {
+                        return match ($key) {
+                            'ms3_token_service' => $this->tokenService,
+                            'ms3_order_draft_manager' => $this->orderDraftManager,
+                            default => null,
+                        };
+                    }
+                };
+            }
+
+            public function getOption($key, $options = null, $default = null, $skipEmpty = false)
+            {
+                $name = (string) $key;
+                if (array_key_exists($name, $this->options)) {
+                    return $this->options[$name];
+                }
+
+                return match ($name) {
+                    'ms3_customer_token_ttl' => 604800,
+                    'ms3_customer_max_login_attempts' => 5,
+                    'ms3_customer_block_duration' => 3600,
+                    'session_cookie_domain' => '',
+                    'session_cookie_path' => '/',
+                    'session_cookie_secure' => false,
+                    'session_cookie_samesite' => 'Lax',
+                    default => $default,
+                };
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className === msCustomer::class) {
+                    $row = null;
+                    if (is_numeric($criteria)) {
+                        $row = $this->store->findCustomerById((int) $criteria);
+                    } elseif (is_array($criteria)) {
+                        if (isset($criteria['id'])) {
+                            $row = $this->store->findCustomerById((int) $criteria['id']);
+                        } elseif (isset($criteria['email'])) {
+                            $row = $this->store->findCustomerByEmail((string) $criteria['email']);
+                        }
+                    }
+                    if ($row === null) {
+                        return null;
+                    }
+                    $customer = new StoredMsCustomer();
+                    $customer->bindStore($this->store);
+                    $customer->hydrate($row);
+
+                    return $customer;
+                }
+
+                if ($className === msCustomerToken::class && is_array($criteria)) {
+                    $row = $this->store->findToken($criteria);
+                    if ($row === null) {
+                        return null;
+                    }
+                    $token = new StoredMsCustomerToken();
+                    $token->bindStore($this->store);
+                    $token->hydrate($row);
+
+                    return $token;
+                }
+
+                return null;
+            }
+
+            public function newObject($className, $fields = [])
+            {
+                if ($className === msCustomerToken::class) {
+                    $token = new StoredMsCustomerToken();
+                    $token->bindStore($this->store);
+                    if (is_array($fields) && $fields !== []) {
+                        foreach ($fields as $key => $value) {
+                            $token->set($key, $value);
+                        }
+                    }
+
+                    return $token;
+                }
+
+                if ($className === msCustomer::class) {
+                    $customer = new StoredMsCustomer();
+                    $customer->bindStore($this->store);
+
+                    return $customer;
+                }
+
+                return null;
+            }
+
+            public function getCollection($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className !== msCustomerToken::class) {
+                    return [];
+                }
+                $rows = $this->store->findTokens(is_array($criteria) ? $criteria : []);
+                $items = [];
+                foreach ($rows as $row) {
+                    $token = new StoredMsCustomerToken();
+                    $token->bindStore($this->store);
+                    $token->hydrate($row);
+                    $items[] = $token;
+                }
+
+                return $items;
+            }
+        };
+
+        return $modx;
+    }
+
+    private function makeAuthManager(modX $modx): AuthManager
+    {
+        return new AuthManager($modx);
+    }
+}

--- a/core/components/minishop3/tests/Integration/Mysql/AuthManagerMysqlLifecycleTest.php
+++ b/core/components/minishop3/tests/Integration/Mysql/AuthManagerMysqlLifecycleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\Mysql;
+
+use MiniShop3\Tests\Integration\Customer\AuthManagerLifecycleTest;
+use MiniShop3\Tests\Support\CustomerAuthPdoStore;
+use MiniShop3\Tests\Support\MysqlTestConnection;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Same AuthManager lifecycle against real MySQL (CI service / local DSN).
+ */
+#[Group('mysql')]
+final class AuthManagerMysqlLifecycleTest extends AuthManagerLifecycleTest
+{
+    protected function createStore(): CustomerAuthPdoStore
+    {
+        require_once dirname(__DIR__, 2) . '/support/MysqlTestConnection.php';
+        require_once dirname(__DIR__, 2) . '/support/CustomerAuthPdoStore.php';
+
+        $pdo = MysqlTestConnection::requireOrSkip($this);
+
+        return new CustomerAuthPdoStore($pdo);
+    }
+}

--- a/core/components/minishop3/tests/Integration/Mysql/OptionSyncMysqlTest.php
+++ b/core/components/minishop3/tests/Integration/Mysql/OptionSyncMysqlTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\Mysql;
+
+use MiniShop3\Services\Option\OptionSyncService;
+use MiniShop3\Tests\Support\MysqlTestConnection;
+use MiniShop3\Tests\Support\ProductOptionPdoXpdo;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OptionSyncService against MySQL (CI service).
+ */
+#[Group('mysql')]
+final class OptionSyncMysqlTest extends TestCase
+{
+    private ProductOptionPdoXpdo $xpdo;
+
+    private OptionSyncService $sync;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 2) . '/support/xpdo_stub.php';
+        require_once dirname(__DIR__, 2) . '/support/MysqlTestConnection.php';
+        require_once dirname(__DIR__, 2) . '/support/ProductOptionPdoXpdo.php';
+
+        $pdo = MysqlTestConnection::requireOrSkip($this);
+        $this->xpdo = new ProductOptionPdoXpdo($pdo);
+        $this->xpdo->reset();
+        $this->sync = new OptionSyncService($this->xpdo);
+    }
+
+    public function testSaveAndRemoveOtherOnMysql(): void
+    {
+        self::assertTrue($this->sync->saveProductOptions(10, [
+            'color' => 'Red',
+            'tags' => ['a', 'b'],
+        ]));
+        self::assertSame(
+            [
+                'color' => ['Red'],
+                'tags' => ['a', 'b'],
+            ],
+            $this->sync->getForProduct(10)
+        );
+
+        $this->sync->saveProductOptions(10, ['color' => 'Blue'], true);
+        self::assertSame(['color' => ['Blue']], $this->sync->getForProduct(10));
+    }
+}

--- a/core/components/minishop3/tests/Integration/Mysql/OptionSyncMysqlTest.php
+++ b/core/components/minishop3/tests/Integration/Mysql/OptionSyncMysqlTest.php
@@ -38,12 +38,14 @@ final class OptionSyncMysqlTest extends TestCase
             'color' => 'Red',
             'tags' => ['a', 'b'],
         ]));
+        $loaded = $this->sync->getForProduct(10);
+        ksort($loaded);
         self::assertSame(
             [
                 'color' => ['Red'],
                 'tags' => ['a', 'b'],
             ],
-            $this->sync->getForProduct(10)
+            $loaded
         );
 
         $this->sync->saveProductOptions(10, ['color' => 'Blue'], true);

--- a/core/components/minishop3/tests/stubs/ModxStub.php
+++ b/core/components/minishop3/tests/stubs/ModxStub.php
@@ -12,6 +12,7 @@ class modX
     public const LOG_LEVEL_ERROR = 1;
     public const LOG_LEVEL_WARN = 2;
     public const LOG_LEVEL_INFO = 3;
+    public const LOG_LEVEL_DEBUG = 4;
 
     /** @var object|null */
     public $user;

--- a/core/components/minishop3/tests/support/CustomerAuthPdoStore.php
+++ b/core/components/minishop3/tests/support/CustomerAuthPdoStore.php
@@ -1,0 +1,503 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Utils\ApiTokenExpiry;
+use PDO;
+
+/**
+ * PDO store for ms_customer + ms_customer_token used by AuthManager lifecycle tests.
+ */
+final class CustomerAuthPdoStore
+{
+    private PDO $pdo;
+
+    private bool $sqlite;
+
+    private int $nextCustomerId = 1;
+
+    private int $nextTokenId = 1;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+        $this->sqlite = str_starts_with((string) $pdo->getAttribute(PDO::ATTR_DRIVER_NAME), 'sqlite');
+        $this->ensureSchema();
+    }
+
+    public static function sqliteMemory(): self
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        return new self($pdo);
+    }
+
+    public function reset(): void
+    {
+        $this->pdo->query('DELETE FROM ms_customer_token');
+        $this->pdo->query('DELETE FROM ms_customer');
+        $this->nextCustomerId = 1;
+        $this->nextTokenId = 1;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function insertCustomer(array $fields): int
+    {
+        $id = (int) ($fields['id'] ?? 0);
+        if ($id <= 0) {
+            $id = $this->nextCustomerId++;
+        } else {
+            $this->nextCustomerId = max($this->nextCustomerId, $id + 1);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO ms_customer (
+                id, email, password, is_active, is_blocked, failed_login_attempts, blocked_until, last_login_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $id,
+            (string) ($fields['email'] ?? ''),
+            (string) ($fields['password'] ?? ''),
+            (int) ($fields['is_active'] ?? 1),
+            (int) ($fields['is_blocked'] ?? 0),
+            (int) ($fields['failed_login_attempts'] ?? 0),
+            $fields['blocked_until'] ?? null,
+            $fields['last_login_at'] ?? null,
+        ]);
+
+        return $id;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findCustomerById(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM ms_customer WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->decodeCustomer($row);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findCustomerByEmail(string $email): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM ms_customer WHERE email = ?');
+        $stmt->execute([$email]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->decodeCustomer($row);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function updateCustomer(int $id, array $fields): bool
+    {
+        $existing = $this->findCustomerById($id);
+        if ($existing === null) {
+            return false;
+        }
+        $merged = array_merge($existing, $fields, ['id' => $id]);
+        $stmt = $this->pdo->prepare(
+            'UPDATE ms_customer SET
+                email = ?, password = ?, is_active = ?, is_blocked = ?, failed_login_attempts = ?,
+                blocked_until = ?, last_login_at = ?
+             WHERE id = ?'
+        );
+
+        return $stmt->execute([
+            (string) $merged['email'],
+            (string) ($merged['password'] ?? ''),
+            (int) $merged['is_active'],
+            (int) $merged['is_blocked'],
+            (int) $merged['failed_login_attempts'],
+            $merged['blocked_until'],
+            $merged['last_login_at'],
+            $id,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function insertToken(array $fields): int
+    {
+        $id = (int) ($fields['id'] ?? 0);
+        if ($id <= 0) {
+            $id = $this->nextTokenId++;
+        } else {
+            $this->nextTokenId = max($this->nextTokenId, $id + 1);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO ms_customer_token (
+                id, customer_id, token, type, expires_at, created_at, used_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $id,
+            (int) ($fields['customer_id'] ?? 0),
+            (string) ($fields['token'] ?? ''),
+            (string) ($fields['type'] ?? msCustomerToken::TYPE_API),
+            (string) ($fields['expires_at'] ?? ''),
+            $fields['created_at'] ?? date('Y-m-d H:i:s'),
+            $fields['used_at'] ?? null,
+        ]);
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return array<string, mixed>|null
+     */
+    public function findToken(array $criteria): ?array
+    {
+        $parts = [];
+        $params = [];
+        foreach ($criteria as $key => $value) {
+            if (str_contains((string) $key, ':')) {
+                [$col, $op] = explode(':', (string) $key, 2);
+                if ($op === '<') {
+                    $parts[] = $col . ' < ?';
+                    $params[] = $value;
+                    continue;
+                }
+            }
+            $parts[] = $key . ' = ?';
+            $params[] = $value;
+        }
+        $sql = 'SELECT * FROM ms_customer_token WHERE ' . implode(' AND ', $parts) . ' LIMIT 1';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->decodeToken($row);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return list<array<string, mixed>>
+     */
+    public function findTokens(array $criteria = []): array
+    {
+        if ($criteria === []) {
+            $stmt = $this->pdo->query('SELECT * FROM ms_customer_token ORDER BY id');
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        } else {
+            $parts = [];
+            $params = [];
+            foreach ($criteria as $key => $value) {
+                if (str_contains((string) $key, ':')) {
+                    [$col, $op] = explode(':', (string) $key, 2);
+                    if ($op === '<') {
+                        $parts[] = $col . ' < ?';
+                        $params[] = $value;
+                        continue;
+                    }
+                }
+                $parts[] = $key . ' = ?';
+                $params[] = $value;
+            }
+            $stmt = $this->pdo->prepare(
+                'SELECT * FROM ms_customer_token WHERE ' . implode(' AND ', $parts) . ' ORDER BY id'
+            );
+            $stmt->execute($params);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        }
+
+        return array_map(fn(array $row): array => $this->decodeToken($row), $rows);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function updateToken(int $id, array $fields): bool
+    {
+        $existing = $this->findToken(['id' => $id]);
+        if ($existing === null) {
+            return false;
+        }
+        $merged = array_merge($existing, $fields, ['id' => $id]);
+        $stmt = $this->pdo->prepare(
+            'UPDATE ms_customer_token SET
+                customer_id = ?, token = ?, type = ?, expires_at = ?, created_at = ?, used_at = ?
+             WHERE id = ?'
+        );
+
+        return $stmt->execute([
+            (int) $merged['customer_id'],
+            (string) $merged['token'],
+            (string) $merged['type'],
+            (string) $merged['expires_at'],
+            $merged['created_at'],
+            $merged['used_at'],
+            $id,
+        ]);
+    }
+
+    public function deleteToken(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM ms_customer_token WHERE id = ?');
+
+        return $stmt->execute([$id]);
+    }
+
+    public function countTokens(?int $customerId = null, ?string $type = null): int
+    {
+        $criteria = [];
+        if ($customerId !== null) {
+            $criteria['customer_id'] = $customerId;
+        }
+        if ($type !== null) {
+            $criteria['type'] = $type;
+        }
+
+        return count($this->findTokens($criteria));
+    }
+
+    private function ensureSchema(): void
+    {
+        $this->pdo->query('DROP TABLE IF EXISTS ms_customer_token');
+        $this->pdo->query('DROP TABLE IF EXISTS ms_customer');
+
+        if ($this->sqlite) {
+            $this->pdo->query(
+                'CREATE TABLE ms_customer (
+                    id INTEGER PRIMARY KEY,
+                    email TEXT NOT NULL DEFAULT \'\',
+                    password TEXT NOT NULL DEFAULT \'\',
+                    is_active INTEGER NOT NULL DEFAULT 1,
+                    is_blocked INTEGER NOT NULL DEFAULT 0,
+                    failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+                    blocked_until TEXT NULL,
+                    last_login_at TEXT NULL
+                )'
+            );
+            $this->pdo->query(
+                'CREATE TABLE ms_customer_token (
+                    id INTEGER PRIMARY KEY,
+                    customer_id INTEGER NOT NULL DEFAULT 0,
+                    token TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    created_at TEXT NULL,
+                    used_at TEXT NULL
+                )'
+            );
+
+            return;
+        }
+
+        $this->pdo->query(
+            'CREATE TABLE ms_customer (
+                id INT NOT NULL PRIMARY KEY,
+                email VARCHAR(191) NOT NULL DEFAULT \'\',
+                password VARCHAR(255) NOT NULL DEFAULT \'\',
+                is_active TINYINT NOT NULL DEFAULT 1,
+                is_blocked TINYINT NOT NULL DEFAULT 0,
+                failed_login_attempts INT NOT NULL DEFAULT 0,
+                blocked_until DATETIME NULL,
+                last_login_at DATETIME NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+        );
+        $this->pdo->query(
+            'CREATE TABLE ms_customer_token (
+                id INT NOT NULL PRIMARY KEY,
+                customer_id INT NOT NULL DEFAULT 0,
+                token VARCHAR(128) NOT NULL,
+                type VARCHAR(32) NOT NULL,
+                expires_at DATETIME NOT NULL,
+                created_at DATETIME NULL,
+                used_at DATETIME NULL,
+                UNIQUE KEY uniq_token_type (token, type),
+                KEY idx_customer_type (customer_id, type)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function decodeCustomer(array $row): array
+    {
+        return [
+            'id' => (int) $row['id'],
+            'email' => (string) $row['email'],
+            'password' => (string) ($row['password'] ?? ''),
+            'is_active' => (int) $row['is_active'],
+            'is_blocked' => (int) $row['is_blocked'],
+            'failed_login_attempts' => (int) $row['failed_login_attempts'],
+            'blocked_until' => $row['blocked_until'],
+            'last_login_at' => $row['last_login_at'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function decodeToken(array $row): array
+    {
+        return [
+            'id' => (int) $row['id'],
+            'customer_id' => (int) $row['customer_id'],
+            'token' => (string) $row['token'],
+            'type' => (string) $row['type'],
+            'expires_at' => (string) $row['expires_at'],
+            'created_at' => $row['created_at'],
+            'used_at' => $row['used_at'],
+        ];
+    }
+}
+
+final class StoredMsCustomer extends msCustomer
+{
+    public $id;
+
+    /** @var array<string, mixed> */
+    private array $fields = [];
+
+    private ?CustomerAuthPdoStore $store = null;
+
+    public function bindStore(CustomerAuthPdoStore $store): void
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function hydrate(array $fields): void
+    {
+        $this->fields = $fields;
+        $this->id = (int) ($fields['id'] ?? 0);
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->fields[$k] ?? null;
+    }
+
+    public function set($key, $value)
+    {
+        $this->fields[$key] = $value;
+        if ($key === 'id') {
+            $this->id = (int) $value;
+        }
+
+        return true;
+    }
+
+    public function save($cacheFlag = null)
+    {
+        if ($this->store === null) {
+            return false;
+        }
+        $id = (int) ($this->fields['id'] ?? 0);
+        if ($id > 0 && $this->store->findCustomerById($id)) {
+            return $this->store->updateCustomer($id, $this->fields);
+        }
+        $id = $this->store->insertCustomer($this->fields);
+        $this->fields['id'] = $id;
+        $this->id = $id;
+
+        return true;
+    }
+}
+
+final class StoredMsCustomerToken extends msCustomerToken
+{
+    /** @var array<string, mixed> */
+    private array $fields = [];
+
+    private ?CustomerAuthPdoStore $store = null;
+
+    private bool $persisted = false;
+
+    public function bindStore(CustomerAuthPdoStore $store): void
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function hydrate(array $fields): void
+    {
+        $this->fields = $fields;
+        $this->persisted = isset($fields['id']);
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->fields[$k] ?? null;
+    }
+
+    public function set($key, $value)
+    {
+        $this->fields[$key] = $value;
+
+        return true;
+    }
+
+    public function isExpired()
+    {
+        return ApiTokenExpiry::isExpiresAtBefore((string) $this->get('expires_at'), time());
+    }
+
+    public function getOne($alias, $criteria = null, $cacheFlag = true)
+    {
+        if ($alias !== 'Customer' || $this->store === null) {
+            return null;
+        }
+        $row = $this->store->findCustomerById((int) $this->get('customer_id'));
+        if ($row === null) {
+            return null;
+        }
+        $customer = new StoredMsCustomer();
+        $customer->bindStore($this->store);
+        $customer->hydrate($row);
+
+        return $customer;
+    }
+
+    public function save($cacheFlag = null)
+    {
+        if ($this->store === null) {
+            return false;
+        }
+        if ($this->persisted && isset($this->fields['id'])) {
+            return $this->store->updateToken((int) $this->fields['id'], $this->fields);
+        }
+        $id = $this->store->insertToken($this->fields);
+        $this->fields['id'] = $id;
+        $this->persisted = true;
+
+        return true;
+    }
+
+    public function remove(array $ancestors = [])
+    {
+        if ($this->store === null || !isset($this->fields['id'])) {
+            return false;
+        }
+        $ok = $this->store->deleteToken((int) $this->fields['id']);
+        $this->persisted = false;
+
+        return $ok;
+    }
+}

--- a/core/components/minishop3/tests/support/MysqlTestConnection.php
+++ b/core/components/minishop3/tests/support/MysqlTestConnection.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Optional MySQL connection for Level-2 CI / local integration tests.
+ *
+ * Env:
+ * - MS3_TEST_MYSQL_DSN (e.g. mysql:host=127.0.0.1;port=3306;dbname=ms3_test;charset=utf8mb4)
+ * - MS3_TEST_MYSQL_USER (default: root)
+ * - MS3_TEST_MYSQL_PASSWORD (default: empty)
+ */
+final class MysqlTestConnection
+{
+    public static function isConfigured(): bool
+    {
+        $dsn = getenv('MS3_TEST_MYSQL_DSN');
+
+        return is_string($dsn) && $dsn !== '';
+    }
+
+    public static function connect(): PDO
+    {
+        $dsn = (string) getenv('MS3_TEST_MYSQL_DSN');
+        $user = getenv('MS3_TEST_MYSQL_USER');
+        $pass = getenv('MS3_TEST_MYSQL_PASSWORD');
+        $user = is_string($user) && $user !== '' ? $user : 'root';
+        $pass = is_string($pass) ? $pass : '';
+
+        $pdo = new PDO($dsn, $user, $pass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+
+        return $pdo;
+    }
+
+    /**
+     * Skip the current test when MySQL env is missing or unreachable.
+     */
+    public static function requireOrSkip(TestCase $test): PDO
+    {
+        if (!self::isConfigured()) {
+            $test->markTestSkipped('MS3_TEST_MYSQL_DSN is not set');
+        }
+
+        try {
+            return self::connect();
+        } catch (PDOException $e) {
+            $test->markTestSkipped('MySQL unavailable: ' . $e->getMessage());
+        }
+    }
+}

--- a/core/components/minishop3/tests/support/ProductOptionPdoXpdo.php
+++ b/core/components/minishop3/tests/support/ProductOptionPdoXpdo.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use PDO;
+use xPDO\xPDO;
+
+/**
+ * PDO-backed xPDO stand-in for OptionSyncService (SQLite or MySQL).
+ */
+final class ProductOptionPdoXpdo extends xPDO
+{
+    private PDO $pdo;
+
+    private bool $sqlite;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+        $this->sqlite = str_starts_with((string) $pdo->getAttribute(PDO::ATTR_DRIVER_NAME), 'sqlite');
+        $this->ensureSchema();
+    }
+
+    public static function sqliteMemory(): self
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        return new self($pdo);
+    }
+
+    public function getTableName($className, $includeDb = false): string
+    {
+        return 'ms2_product_options';
+    }
+
+    public function prepare($sql, $options = [])
+    {
+        return $this->pdo->prepare($this->normalizeSql((string) $sql));
+    }
+
+    public function newQuery($class, $criteria = null, $cacheFlag = true): ProductOptionPdoQuery
+    {
+        return new ProductOptionPdoQuery($this->pdo, is_array($criteria) ? $criteria : [], $this->sqlite);
+    }
+
+    public function log($level, $msg): void
+    {
+    }
+
+    /**
+     * @param list<array{product_id: int, key: string, value: string}> $rows
+     */
+    public function seed(array $rows): void
+    {
+        $stmt = $this->pdo->prepare(
+            $this->normalizeSql('INSERT INTO ms2_product_options (product_id, `key`, value) VALUES (?, ?, ?)')
+        );
+        foreach ($rows as $row) {
+            $stmt->execute([(int) $row['product_id'], (string) $row['key'], (string) $row['value']]);
+        }
+    }
+
+    /**
+     * @return list<array{product_id: int, key: string, value: string}>
+     */
+    public function allRows(): array
+    {
+        $sql = $this->normalizeSql(
+            'SELECT product_id, `key` AS `key`, value FROM ms2_product_options ORDER BY product_id, `key`, value'
+        );
+        $stmt = $this->pdo->query($sql);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        return array_map(static function (array $row): array {
+            return [
+                'product_id' => (int) $row['product_id'],
+                'key' => (string) $row['key'],
+                'value' => (string) $row['value'],
+            ];
+        }, $rows);
+    }
+
+    public function reset(): void
+    {
+        $this->pdo->query('DELETE FROM ms2_product_options');
+    }
+
+    private function ensureSchema(): void
+    {
+        if ($this->sqlite) {
+            $this->pdo->query(
+                'CREATE TABLE IF NOT EXISTS ms2_product_options (
+                    product_id INTEGER NOT NULL,
+                    "key" TEXT NOT NULL,
+                    value TEXT NOT NULL
+                )'
+            );
+
+            return;
+        }
+
+        $this->pdo->query(
+            'CREATE TABLE IF NOT EXISTS ms2_product_options (
+                product_id INT NOT NULL,
+                `key` VARCHAR(191) NOT NULL,
+                value TEXT NOT NULL,
+                INDEX idx_product_key (product_id, `key`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+        );
+    }
+
+    private function normalizeSql(string $sql): string
+    {
+        if ($this->sqlite) {
+            return str_replace('`', '"', $sql);
+        }
+
+        return $sql;
+    }
+}
+
+final class ProductOptionPdoQuery
+{
+    /** @var \PDOStatement|null */
+    public $stmt;
+
+    /** @var array<string, mixed> */
+    private array $criteria;
+
+    /** @var list<string> */
+    private array $keyIn = [];
+
+    public function __construct(
+        private PDO $pdo,
+        array $criteria,
+        private bool $sqlite
+    ) {
+        $this->criteria = $criteria;
+    }
+
+    public function select($columns): self
+    {
+        return $this;
+    }
+
+    public function sortby($column, $dir = 'ASC'): self
+    {
+        return $this;
+    }
+
+    public function where($criteria): self
+    {
+        if (isset($criteria['key:IN']) && is_array($criteria['key:IN'])) {
+            $this->keyIn = array_values(array_map('strval', $criteria['key:IN']));
+        }
+
+        return $this;
+    }
+
+    public function prepare(): bool
+    {
+        $keyCol = $this->sqlite ? '"key"' : '`key`';
+        $sql = "SELECT {$keyCol} AS {$keyCol}, value FROM ms2_product_options WHERE product_id = ?";
+        $params = [(int) ($this->criteria['product_id'] ?? 0)];
+
+        if ($this->keyIn !== []) {
+            $placeholders = implode(',', array_fill(0, count($this->keyIn), '?'));
+            $sql .= " AND {$keyCol} IN ({$placeholders})";
+            foreach ($this->keyIn as $key) {
+                $params[] = $key;
+            }
+        }
+
+        $sql .= ' ORDER BY value';
+        $this->stmt = $this->pdo->prepare($sql);
+        foreach ($params as $index => $value) {
+            $this->stmt->bindValue($index + 1, $value);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Описание

Инфра и интеграционные тесты для `#429`: MySQL 8 service в job `PHP lint + smoke` (`MS3_TEST_MYSQL_*`, `pdo_mysql`). `AuthManagerLifecycleTest` на SQLite всегда: PasswordAuthProvider login, rotate токена, чужой токен без переноса корзины, logout с guest mint, validate/revoke, lockout. Группа `@group mysql` — тот же Auth lifecycle и `OptionSync` на реальном MySQL (локально skip без DSN). В OptionSync assert порядок ключей игнорируется через `ksort` (MySQL может вернуть `tags` раньше `color`).

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [x] Другое (опишите): интеграционные тесты + CI MySQL

## Связанные Issues

Refs #429

## Как это было протестировано?

Локально (MySQL group skip без DSN):

```bash
cd core/components/minishop3
composer install
composer ci:php
```

CI на PR: MySQL service поднимается, `@group mysql` не skip; PHP lint + smoke, PHPStan, vueManager lint — pass.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `test/issue-429-mysql-auth-lifecycle`
- MODX: n/a (PDO/SQLite harness)
- PHP: локальный + CI (MySQL 8 service)

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [x] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Лексиконы, Vue и CHANGELOG не затрагивались. Локально без `MS3_TEST_MYSQL_*` MySQL-тесты пропускаются; в CI DSN задаёт workflow.