### PR TITLE
fix(currency): символ рубля вместо "?" в ms3Config

### DIFF
--- a/_build/elements/settings.php
+++ b/_build/elements/settings.php
@@ -481,7 +481,8 @@ return [
 
     // Currency and Formatting Settings
     'ms3_currency_symbol' => [
-        'value' => '₽',
+        // Must match Format::DEFAULT_CURRENCY_SYMBOL (U+20BD); escape is ASCII-safe for transport builds
+        'value' => "\u{20BD}",
         'xtype' => 'textfield',
         'area' => 'ms3_product',
     ],

--- a/core/components/minishop3/migrations/20260801190000_repair_currency_symbol_mojibake.php
+++ b/core/components/minishop3/migrations/20260801190000_repair_currency_symbol_mojibake.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use MiniShop3\Utils\Format;
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Repair ms3_currency_symbol when the ruble was stored as ASCII "?" (mojibake).
+ *
+ * @see https://github.com/modx-pro/MiniShop3/issues/497
+ */
+final class RepairCurrencySymbolMojibake extends AbstractMigration
+{
+    private const SETTING_KEY = 'ms3_currency_symbol';
+
+    private const NAMESPACE = 'minishop3';
+
+    private const MOJIBAKE = '?';
+
+    public function up(): void
+    {
+        $prefix = $this->getAdapter()->getOption('table_prefix');
+        $table = $prefix . 'system_settings';
+        $pdo = $this->getAdapter()->getConnection();
+
+        $stmt = $pdo->prepare(
+            "UPDATE `{$table}` SET `value` = :symbol"
+            . " WHERE `key` = :key AND `namespace` = :namespace AND `value` = :broken"
+        );
+        $stmt->execute([
+            'symbol' => Format::DEFAULT_CURRENCY_SYMBOL,
+            'key' => self::SETTING_KEY,
+            'namespace' => self::NAMESPACE,
+            'broken' => self::MOJIBAKE,
+        ]);
+    }
+
+    public function down(): void
+    {
+        // Intentionally empty: repair is data correction; rolling back would re-corrupt the setting.
+    }
+}

--- a/core/components/minishop3/src/MiniShop3.php
+++ b/core/components/minishop3/src/MiniShop3.php
@@ -156,7 +156,7 @@ class MiniShop3
                     'connectorUrl' => $this->config['connectorUrl'],
                     'ctx' => $ctx,
                     'tokenName' => $tokenName,
-                    'currencySymbol' => $this->modx->getOption('ms3_currency_symbol', null, '₽'),
+                    'currencySymbol' => $this->format->getCurrencySymbol(),
                     'currencyPosition' => $this->modx->getOption('ms3_currency_position', null, 'after'),
                     'render' => [
                         'cart' => []

--- a/core/components/minishop3/src/Utils/Format.php
+++ b/core/components/minishop3/src/Utils/Format.php
@@ -15,6 +15,9 @@ use MiniShop3\MiniShop3;
  */
 class Format
 {
+    /** Default ruble sign (U+20BD), ASCII-safe for transport builds. */
+    public const DEFAULT_CURRENCY_SYMBOL = "\u{20BD}";
+
     /** @var \MODX\Revolution\modX */
     private $modx;
 
@@ -74,9 +77,24 @@ class Format
 
         $this->dateFormat = $this->modx->getOption('ms3_date_format', null, 'd.m.Y H:i');
 
-        $this->currencySymbol = $this->modx->getOption('ms3_currency_symbol', null, '₽');
+        $this->currencySymbol = self::normalizeCurrencySymbol(
+            $this->modx->getOption('ms3_currency_symbol', null, self::DEFAULT_CURRENCY_SYMBOL)
+        );
         $this->currencyPosition = $this->modx->getOption('ms3_currency_position', null, 'after');
         $this->weightUnit = $this->modx->getOption('ms3_weight_unit', null, 'kg');
+    }
+
+    /**
+     * Normalize system setting value for currency display.
+     * Non-strings and mojibake "?" become the default ruble; empty string is kept.
+     */
+    public static function normalizeCurrencySymbol(mixed $value): string
+    {
+        if (!is_string($value) || $value === '?') {
+            return self::DEFAULT_CURRENCY_SYMBOL;
+        }
+
+        return $value;
     }
 
     /**

--- a/core/components/minishop3/tests/Unit/Utils/NormalizeCurrencySymbolTest.php
+++ b/core/components/minishop3/tests/Unit/Utils/NormalizeCurrencySymbolTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Utils;
+
+use MiniShop3\Utils\Format;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class NormalizeCurrencySymbolTest extends TestCase
+{
+    #[DataProvider('symbolCases')]
+    public function testNormalizeCurrencySymbol(mixed $input, string $expected): void
+    {
+        self::assertSame($expected, Format::normalizeCurrencySymbol($input));
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: string}>
+     */
+    public static function symbolCases(): iterable
+    {
+        yield 'null uses default ruble' => [null, Format::DEFAULT_CURRENCY_SYMBOL];
+        yield 'non-string uses default ruble' => [false, Format::DEFAULT_CURRENCY_SYMBOL];
+        yield 'mojibake question mark' => ['?', Format::DEFAULT_CURRENCY_SYMBOL];
+        yield 'keeps intentional dollar' => ['$', '$'];
+        yield 'keeps ruble' => [Format::DEFAULT_CURRENCY_SYMBOL, Format::DEFAULT_CURRENCY_SYMBOL];
+        yield 'keeps empty string' => ['', ''];
+    }
+
+    public function testDefaultCurrencySymbolIsRubleCodepoint(): void
+    {
+        self::assertSame("\u{20BD}", Format::DEFAULT_CURRENCY_SYMBOL);
+        self::assertSame(mb_chr(0x20BD, 'UTF-8'), Format::DEFAULT_CURRENCY_SYMBOL);
+    }
+}


### PR DESCRIPTION
## Описание

При дефолтной установке `ms3_currency_symbol` иногда оказывается ASCII `?` (mojibake). Витрина читает настройку как есть, поэтому `ms3Config.currencySymbol` тоже `?`.

Фикс в трёх местах: ASCII-safe `\u{20BD}` в transport default, нормализация `?` в `Format` (и через него в `ms3Config`), Phinx-миграция для уже установленных сайтов.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #497

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Utils/Format.php src/MiniShop3.php migrations/20260801190000_repair_currency_symbol_mojibake.php tests/Unit/Utils/NormalizeCurrencySymbolTest.php
# exit 0

./vendor/bin/phpunit tests/Unit/Utils/NormalizeCurrencySymbolTest.php
# OK (7 tests, 8 assertions), exit 0

./vendor/bin/phpunit
# OK (111 tests, 188 assertions), exit 0

php -r '$s=include "_build/elements/settings.php"; exit($s["ms3_currency_symbol"]["value"]==="\u{20BD}"?0:1);'
# exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test` / PHPUnit)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `fix/issue-497-currency-symbol`
- MODX: n/a (unit)
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требовались
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — n/a
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — на релизе

## Дополнительные заметки

- После upgrade + Phinx поле в менеджере MODX тоже станет `₽`. До миграции витрина уже показывает рубль за счёт runtime-normalize.
- Намеренный символ валюты `?` больше не поддерживается (trade-off под #497).