### PR TITLE
fix(mgr): не грузить отсутствующий vue-dist/main.min.css на product/update

### DIFF
--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -61,7 +61,8 @@ class msProductUpdateManagerController extends msResourceUpdateController
         $this->addLastJavascript($assetsUrl . 'js/mgr/product/product.common.js');
         $this->addLastJavascript($assetsUrl . 'js/mgr/product/update.js');
 
-        // Product Tabs Vue module (contains Properties, Gallery, Categories, Links, Options tabs)
+        // Product Tabs Vue (Properties, Gallery, Categories, Links, Options).
+        // Only these vue-dist assets — do not add main.min.css (Vite never emits it; #503).
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/product-tabs.min.css');
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/DynamicField.min.css');
@@ -155,10 +156,6 @@ class msProductUpdateManagerController extends msResourceUpdateController
             'up_page' => $this->resource->parent,
             'mode' => 'update',
         ];
-
-        $this->addCss($assetsUrl . 'css/mgr/vue-dist/main.min.css');
-        // Vue module with VueTools dependency check
-        $this->addVueModule($assetsUrl . 'js/mgr/vue-dist/main.min.js');
 
         $this->addHtml('
         <script>

--- a/core/components/minishop3/tests/ProductUpdateVueAssetsTest.php
+++ b/core/components/minishop3/tests/ProductUpdateVueAssetsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Контракт #503: product/update не подключает отсутствующий vue-dist/main.min.css.
+ *
+ * Запуск: php tests/ProductUpdateVueAssetsTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$base = dirname(__DIR__);
+$controller = file_get_contents($base . '/controllers/product/update.class.php');
+if ($controller === false) {
+    $fail('cannot read controllers/product/update.class.php');
+}
+
+if (preg_match('/addCss\([^;]*main\.min\.css/', $controller) === 1) {
+    $fail('product/update must not call addCss(...main.min.css) (#503)');
+}
+
+if (preg_match('/addVueModule\([^;]*main\.min\.js/', $controller) === 1) {
+    $fail('product/update must not call addVueModule(...main.min.js) (unused; product-tabs covers UI)');
+}
+
+if (preg_match('/addVueModule\([^;]*product-tabs\.min\.js/', $controller) !== 1) {
+    $fail('product/update must still register product-tabs.min.js');
+}
+
+if (preg_match('/addCss\([^;]*primeicons\.min\.css/', $controller) !== 1) {
+    $fail('product/update must still register primeicons.min.css');
+}
+
+fwrite(STDOUT, "OK ProductUpdateVueAssetsTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

На странице редактирования товара менеджер запрашивал `css/mgr/vue-dist/main.min.css`, которого Vite не создаёт (CSS выходит под именами исходников вроде `primeicons.min.css`). В Network был 404.

Убраны `addCss(main.min.css)` и неиспользуемый `addVueModule(main.min.js)`. Вкладки товара по-прежнему поднимает `product-tabs` с `primeicons` и `DynamicField`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #503

## Как это было протестировано?

Локальный CI-гейт:

```bash
php -l core/components/minishop3/controllers/product/update.class.php   # exit 0
php -l core/components/minishop3/tests/ProductUpdateVueAssetsTest.php     # exit 0
cd core/components/minishop3 && composer test:smoke                       # exit 0, OK smoke tests (36)
cd core/components/minishop3 && composer test                             # exit 0, 109 tests
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test:smoke` / `composer test`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-503-main-min-css` от `beta`
- MODX: n/a (smoke без установки)
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — n/a, строк UI нет
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — n/a, Vue не трогали
- [x] Обновлён CHANGELOG.md (для значимых изменений) — n/a, по политике репо на релизе

## Дополнительные заметки

Альтернатива из issue (фиксировать имя CSS в Vite для entry `main`) не нужна: `main.min.js` на этой странице ничего не монтирует, стили уже даёт `product-tabs`.