### PR TITLE
refactor(api): единый Response envelope на HTTP boundary

### DIFF
--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -29,9 +29,9 @@ use MiniShop3\Services\Category\CategoryProductActionPermissions;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 
-$router->group('/api/mgr', function($router) use ($modx) {
+$router->group('/api/mgr', function ($router) use ($modx) {
 
-    $router->get('/health', function() use ($modx) {
+    $router->get('/health', function () use ($modx) {
         return Response::success([
             'status' => 'ok',
             'version' => $modx->getOption('ms3_version', null, '1.0.0'),
@@ -40,7 +40,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         ]);
     });
 
-    $router->get('/user/info', function() use ($modx) {
+    $router->get('/user/info', function () use ($modx) {
         if (!$modx->user || !$modx->user->isAuthenticated('mgr')) {
             return Response::error('Unauthorized', HttpStatus::UNAUTHORIZED);
         }
@@ -53,32 +53,32 @@ $router->group('/api/mgr', function($router) use ($modx) {
     })->middleware(new AuthMiddleware($modx, 'mgr'));
 
     // Config reads: any authenticated mgr (product forms load page-fields without settings perm)
-    $router->group('/config', function($router) use ($modx) {
-        $router->get('/page-fields/{page_key}', function($params) use ($modx) {
+    $router->group('/config', function ($router) use ($modx) {
+        $router->get('/page-fields/{page_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->getPageFields($params);
         });
-        $router->get('/page-fields/{page_key}/all', function($params) use ($modx) {
+        $router->get('/page-fields/{page_key}/all', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->getAllPageFields($params);
         });
-        $router->get('/sections/{page_key}', function($params) use ($modx) {
+        $router->get('/sections/{page_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->getSections($params);
         });
     });
 
     // Config writes: mssetting_save — same gate as model-fields / extra-fields writes (#381)
-    $router->group('/config', function($router) use ($modx) {
-        $router->put('/page-fields/{page_key}', function($params) use ($modx) {
+    $router->group('/config', function ($router) use ($modx) {
+        $router->put('/page-fields/{page_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->updatePageFields($params);
         });
-        $router->put('/sections/{page_key}', function($params) use ($modx) {
+        $router->put('/sections/{page_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->updateSections($params);
         });
-        $router->delete('/sections/{page_key}/{section_key}', function($params) use ($modx) {
+        $router->delete('/sections/{page_key}/{section_key}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ConfigController($modx);
             return $controller->deleteSection($params);
         });
@@ -86,8 +86,8 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'mssetting_save')
     ]);
 
-    $router->group('/models', function($router) use ($modx) {
-        $router->get('/{alias}/fields', function($params) use ($modx) {
+    $router->group('/models', function ($router) use ($modx) {
+        $router->get('/{alias}/fields', function ($params) use ($modx) {
             $alias = $params['alias'] ?? '';
 
             if (empty($alias)) {
@@ -119,12 +119,12 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
     });
 
-    $router->group('/product-data', function($router) use ($modx) {
-        $router->get('/{id}', function($params) use ($modx) {
+    $router->group('/product-data', function ($router) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ProductDataController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ProductDataController($modx);
             return $controller->update($params);
         });
@@ -134,32 +134,32 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'msproduct_save')
     ]);
 
-    $router->group('/references', function($router) use ($modx) {
-        $router->get('/vendors', function($params) use ($modx) {
+    $router->group('/references', function ($router) use ($modx) {
+        $router->get('/vendors', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->getVendors($params);
         });
-        $router->get('/autocomplete', function($params) use ($modx) {
+        $router->get('/autocomplete', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->getAutocomplete($params);
         });
-        $router->get('/options', function($params) use ($modx) {
+        $router->get('/options', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->getOptions($params);
         });
-        $router->get('/product-option-fields', function($params) use ($modx) {
+        $router->get('/product-option-fields', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->getProductOptionFields($params);
         });
-        $router->get('/product-field-values', function($params) use ($modx) {
+        $router->get('/product-field-values', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->getProductFieldValues($params);
         });
-        $router->get('/products', function($params) use ($modx) {
+        $router->get('/products', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->searchProducts($params);
         });
-        $router->get('/customers', function($params) use ($modx) {
+        $router->get('/customers', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\ReferencesController($modx);
             return $controller->searchCustomers($params);
         });
@@ -169,24 +169,24 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'view_document')
     ]);
 
-    $router->group('/extra-fields', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/extra-fields', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
             return $controller->getList(array_merge($_GET, $params));
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
             return $controller->get($params);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
             return $controller->create();
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
             return $controller->update($params);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ExtraFieldsController($modx);
             return $controller->delete($params);
         });
@@ -196,8 +196,8 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Customers: permissions align with legacy Customer* processors (#378)
-    $router->group('/customers', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/customers', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
@@ -206,7 +206,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             new PermissionMiddleware($modx, 'msorder_list')
         ]);
         // Bulk delete - must be before /{id} route
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
@@ -215,14 +215,14 @@ $router->group('/api/mgr', function($router) use ($modx) {
         }, [
             new PermissionMiddleware($modx, 'msorder_remove')
         ]);
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->get($params);
         }, [
             new PermissionMiddleware($modx, 'msorder_view')
         ]);
 
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -232,19 +232,19 @@ $router->group('/api/mgr', function($router) use ($modx) {
         }, [
             new PermissionMiddleware($modx, 'msorder_save')
         ]);
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomersController($modx);
             return $controller->delete($params);
         }, [
             new PermissionMiddleware($modx, 'msorder_remove')
         ]);
-        $router->get('/{id}/addresses', function($params) use ($modx) {
+        $router->get('/{id}/addresses', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
             return $controller->getList($params);
         }, [
             new PermissionMiddleware($modx, 'msorder_list')
         ]);
-        $router->post('/{id}/addresses', function($params) use ($modx) {
+        $router->post('/{id}/addresses', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['customer_id'] = $params['id'] ?? null;
@@ -254,7 +254,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         }, [
             new PermissionMiddleware($modx, 'msorder_save')
         ]);
-        $router->put('/{id}/addresses/{address_id}', function($params) use ($modx) {
+        $router->put('/{id}/addresses/{address_id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['customer_id'] = $params['id'] ?? null;
@@ -265,7 +265,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
         }, [
             new PermissionMiddleware($modx, 'msorder_save')
         ]);
-        $router->delete('/{id}/addresses/{address_id}', function($params) use ($modx) {
+        $router->delete('/{id}/addresses/{address_id}', function ($params) use ($modx) {
             $params['address_id'] = $params['address_id'] ?? null;
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CustomerAddressesController($modx);
@@ -276,9 +276,9 @@ $router->group('/api/mgr', function($router) use ($modx) {
     });
 
     // Category products: read vs mutate permissions (#378)
-    $router->group('/categories', function($router) use ($modx) {
+    $router->group('/categories', function ($router) use ($modx) {
         // Get products in category
-        $router->get('/{id}/products', function($params) use ($modx) {
+        $router->get('/{id}/products', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
@@ -287,14 +287,14 @@ $router->group('/api/mgr', function($router) use ($modx) {
             new PermissionMiddleware($modx, 'view_document')
         ]);
         // Get filters configuration
-        $router->get('/{id}/products/filters', function($params) use ($modx) {
+        $router->get('/{id}/products/filters', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\CategoryProductsController($modx);
             return $controller->getFilters($params);
         }, [
             new PermissionMiddleware($modx, 'view_document')
         ]);
         // Sort products (drag-drop)
-        $router->post('/{id}/products/sort', function($params) use ($modx) {
+        $router->post('/{id}/products/sort', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $allParams = array_merge($data, $params);
@@ -305,7 +305,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             new PermissionMiddleware($modx, 'msproduct_save')
         ]);
         // Bulk delete products
-        $router->delete('/{id}/products/bulk', function($params) use ($modx) {
+        $router->delete('/{id}/products/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $allParams = array_merge($data, $params);
@@ -316,7 +316,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             new PermissionMiddleware($modx, 'msproduct_delete')
         ]);
         // Multiple product actions — gate any product mutation perm; exact check per method in controller
-        $router->post('/{id}/products/multiple', function($params) use ($modx) {
+        $router->post('/{id}/products/multiple', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $allParams = array_merge($data, $params);
@@ -330,7 +330,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             )
         ]);
         // Toggle product publish status
-        $router->post('/{id}/products/{productId}/publish', function($params) use ($modx) {
+        $router->post('/{id}/products/{productId}/publish', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $allParams = array_merge($data, $params);
@@ -342,14 +342,14 @@ $router->group('/api/mgr', function($router) use ($modx) {
         ]);
     });
 
-    $router->group('/deliveries', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/deliveries', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
@@ -357,7 +357,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->create($data);
         });
         // Bulk delete - must be before /{id} route
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
@@ -365,7 +365,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->bulkDelete($data);
         });
         // Sort (reorder) - must be before /{id} route
-        $router->post('/sort', function($params) use ($modx) {
+        $router->post('/sort', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
@@ -373,18 +373,18 @@ $router->group('/api/mgr', function($router) use ($modx) {
             return $controller->sort($data);
         });
         // Update positions - must be before /{id} route
-        $router->put('/positions', function($params) use ($modx) {
+        $router->put('/positions', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->updatePositions($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -392,17 +392,17 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->delete($params);
         });
 
         // Delivery payments routes
-        $router->get('/{id}/payments', function($params) use ($modx) {
+        $router->get('/{id}/payments', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->getPayments($params);
         });
-        $router->post('/{id}/payments', function($params) use ($modx) {
+        $router->post('/{id}/payments', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['delivery_id'] = $params['id'] ?? null;
@@ -410,7 +410,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->addPayment($data);
         });
-        $router->delete('/{id}/payments/{payment_id}', function($params) use ($modx) {
+        $router->delete('/{id}/payments/{payment_id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
             return $controller->removePayment($params);
         });
@@ -420,46 +420,46 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Payments CRUD
-    $router->group('/payments', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/payments', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->create($data);
         });
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->bulkDelete($data);
         });
-        $router->post('/sort', function($params) use ($modx) {
+        $router->post('/sort', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->sort($data);
         });
-        $router->put('/positions', function($params) use ($modx) {
+        $router->put('/positions', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->updatePositions($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -467,17 +467,17 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->delete($params);
         });
 
         // Payment deliveries routes
-        $router->get('/{id}/deliveries', function($params) use ($modx) {
+        $router->get('/{id}/deliveries', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->getDeliveries($params);
         });
-        $router->post('/{id}/deliveries', function($params) use ($modx) {
+        $router->post('/{id}/deliveries', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['payment_id'] = $params['id'] ?? null;
@@ -485,7 +485,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->addDelivery($data);
         });
-        $router->delete('/{id}/deliveries/{delivery_id}', function($params) use ($modx) {
+        $router->delete('/{id}/deliveries/{delivery_id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\PaymentsController($modx);
             return $controller->removeDelivery($params);
         });
@@ -495,39 +495,39 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Vendors routes
-    $router->group('/vendors', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/vendors', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->create($data);
         });
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->bulkDelete($data);
         });
-        $router->post('/sort', function($params) use ($modx) {
+        $router->post('/sort', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->sort($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -535,7 +535,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\VendorsController($modx);
             return $controller->delete($params);
         });
@@ -545,46 +545,46 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Options CRUD (Settings → Options)
-    $router->group('/options', function($router) use ($modx) {
+    $router->group('/options', function ($router) use ($modx) {
         // Static routes must come before /{id} to avoid shadowing.
-        $router->get('/types', function() use ($modx) {
+        $router->get('/types', function () use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->getTypes();
         });
-        $router->get('/tree', function($params) use ($modx) {
+        $router->get('/tree', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->getTree($allParams);
         });
         // /options/modcategories removed in #10 — use /option-groups instead.
-        $router->get('/suggestions', function($params) use ($modx) {
+        $router->get('/suggestions', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->getSuggestions($allParams);
         });
-        $router->post('/bulk/assign', function() use ($modx) {
+        $router->post('/bulk/assign', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->bulkAssign($data);
         });
-        $router->delete('/bulk', function() use ($modx) {
+        $router->delete('/bulk', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->bulkDelete($data);
         });
 
-        $router->get('', function($params) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->getList($allParams);
         });
-        $router->post('', function() use ($modx) {
+        $router->post('', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->create($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['id'] = $params['id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OptionsController($modx))->delete($params);
         });
     }, [
@@ -592,33 +592,33 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Option groups (#10) — dedicated grouping model replacing legacy msOption.modcategory_id
-    $router->group('/option-groups', function($router) use ($modx) {
-        $router->put('/positions', function() use ($modx) {
+    $router->group('/option-groups', function ($router) use ($modx) {
+        $router->put('/positions', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->updatePositions($data);
         });
-        $router->delete('/bulk', function() use ($modx) {
+        $router->delete('/bulk', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->bulkDelete($data);
         });
 
-        $router->get('', function($params) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->getList($allParams);
         });
-        $router->post('', function() use ($modx) {
+        $router->post('', function () use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->create($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['id'] = $params['id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OptionGroupsController($modx))->delete($params);
         });
     }, [
@@ -626,39 +626,39 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Category → Options (link management for a specific category)
-    $router->group('/categories/{category_id}/options', function($router) use ($modx) {
-        $router->post('/sort', function($params) use ($modx) {
+    $router->group('/categories/{category_id}/options', function ($router) use ($modx) {
+        $router->post('/sort', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['category_id'] = $params['category_id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->sort($data);
         });
-        $router->post('/bulk', function($params) use ($modx) {
+        $router->post('/bulk', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['category_id'] = $params['category_id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->bulk($data);
         });
-        $router->post('/duplicate', function($params) use ($modx) {
+        $router->post('/duplicate', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['category_id'] = $params['category_id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->duplicate($data);
         });
 
-        $router->get('', function($params) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['category_id'] = $params['category_id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->create($data);
         });
-        $router->put('/{option_id}', function($params) use ($modx) {
+        $router->put('/{option_id}', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             $data['category_id'] = $params['category_id'] ?? null;
             $data['option_id'] = $params['option_id'] ?? null;
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->update($data);
         });
-        $router->delete('/{option_id}', function($params) use ($modx) {
+        $router->delete('/{option_id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\CategoryOptionsController($modx))->delete($params);
         });
     }, [
@@ -666,39 +666,39 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Statuses CRUD (for settings page)
-    $router->group('/statuses', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/statuses', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->create($data);
         });
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->bulkDelete($data);
         });
-        $router->post('/sort', function($params) use ($modx) {
+        $router->post('/sort', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->sort($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -706,7 +706,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\StatusesController($modx);
             return $controller->delete($params);
         });
@@ -716,36 +716,36 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Links CRUD (product link types)
-    $router->group('/links', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/links', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->getList($allParams);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->create($data);
         });
-        $router->get('/types', function($params) use ($modx) {
+        $router->get('/types', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->getTypes();
         });
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->bulkDelete($data);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->get($params);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -753,7 +753,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\LinksController($modx);
             return $controller->delete($params);
         });
@@ -763,22 +763,22 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Orders reads: list/get and related GET under msorder_list (#377)
-    $router->group('/orders', function($router) use ($modx) {
-        $router->get('', function($params) use ($modx) {
+    $router->group('/orders', function ($router) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->getList(array_merge($_GET, $params));
         });
         // Filters config - must be before /{id} route
-        $router->get('/filters', function($params) use ($modx) {
+        $router->get('/filters', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->getFilters($params);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->get($params);
         });
-        $router->get('/{id}/products', function($params) use ($modx) {
+        $router->get('/{id}/products', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->getProducts($params);
         });
-        $router->get('/{id}/logs', function($params) use ($modx) {
+        $router->get('/{id}/logs', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->getLogs($params);
         });
     }, [
@@ -786,47 +786,47 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Orders writes: mutations require msorder_save (#377)
-    $router->group('/orders', function($router) use ($modx) {
+    $router->group('/orders', function ($router) use ($modx) {
         // Create new order - must be before /{id} route
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->create($data);
         });
         // Bulk delete - must be before /{id} route
-        $router->delete('/bulk', function($params) use ($modx) {
+        $router->delete('/bulk', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->bulkDelete($data);
         });
         // Finalize order (convert draft to final) - must be before /{id} route
-        $router->post('/{id}/finalize', function($params) use ($modx) {
+        $router->post('/{id}/finalize', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->finalize(array_merge($params, $data));
         });
-        $router->post('/{id}/recalculate-cost', function($params) use ($modx) {
+        $router->post('/{id}/recalculate-cost', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->recalculateCost(array_merge($params, $data));
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->update(array_merge($params, $data, $_POST));
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->delete($params);
         });
-        $router->post('/{id}/products', function($params) use ($modx) {
+        $router->post('/{id}/products', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->addProduct(array_merge($params, $data));
         });
-        $router->put('/{id}/products/{product_id}', function($params) use ($modx) {
+        $router->put('/{id}/products/{product_id}', function ($params) use ($modx) {
             $data = json_decode(file_get_contents('php://input'), true) ?: [];
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))
                 ->updateProduct(array_merge($params, $data));
         });
-        $router->delete('/{id}/products/{product_id}', function($params) use ($modx) {
+        $router->delete('/{id}/products/{product_id}', function ($params) use ($modx) {
             return (new \MiniShop3\Controllers\Api\Manager\OrdersController($modx))->deleteProduct($params);
         });
     }, [
@@ -834,7 +834,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Statuses dropdown (with translated names for order forms)
-    $router->get('/statuses-dropdown', function($params) use ($modx) {
+    $router->get('/statuses-dropdown', function ($params) use ($modx) {
         $modx->lexicon->load('minishop3:manager');
         $results = [];
         $collection = $modx->getIterator(\MiniShop3\Model\msOrderStatus::class);
@@ -852,7 +852,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
     });
 
     // Dropdown list of active deliveries (for order forms; no properties/class secrets)
-    $router->get('/deliveries-active', function($params) use ($modx) {
+    $router->get('/deliveries-active', function ($params) use ($modx) {
         $controller = new \MiniShop3\Controllers\Api\Manager\DeliveriesController($modx);
         return $controller->getActiveDropdown($params);
     });
@@ -904,29 +904,29 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'mssetting_save')
     ]);
 
-    $router->group('/notifications', function($router) use ($modx) {
-        $router->get('/references', function($params) use ($modx) {
+    $router->group('/notifications', function ($router) use ($modx) {
+        $router->get('/references', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->getReferences();
         });
-        $router->get('', function($params) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->getList($allParams);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->get($params);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->create($data);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -934,7 +934,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\NotificationsController($modx);
             return $controller->delete($params);
         });
@@ -943,46 +943,46 @@ $router->group('/api/mgr', function($router) use ($modx) {
         new PermissionMiddleware($modx, 'mssetting_save')
     ]);
 
-    $router->group('/model-fields', function($router) use ($modx) {
-        $router->get('/models', function($params) use ($modx) {
+    $router->group('/model-fields', function ($router) use ($modx) {
+        $router->get('/models', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getModels();
         });
-        $router->get('/visible/{model}', function($params) use ($modx) {
+        $router->get('/visible/{model}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getVisibleFields($params);
         });
 
         // Combo options routes
-        $router->get('/combo-options/{model}', function($params) use ($modx) {
+        $router->get('/combo-options/{model}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getComboOptions($params);
         });
-        $router->get('/combo-options/{model}/{field_name}', function($params) use ($modx) {
+        $router->get('/combo-options/{model}/{field_name}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getFieldComboOptions($params);
         });
 
         // Section routes
-        $router->get('/sections/{model}', function($params) use ($modx) {
+        $router->get('/sections/{model}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getSections($params);
         });
-        $router->post('/sections', function($params) use ($modx) {
+        $router->post('/sections', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->createSection($data);
         });
-        $router->put('/sections/ranks', function($params) use ($modx) {
+        $router->put('/sections/ranks', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->updateSectionRanks($data);
         });
-        $router->put('/sections/{id}', function($params) use ($modx) {
+        $router->put('/sections/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -990,37 +990,37 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->updateSection($data);
         });
-        $router->delete('/sections/{id}', function($params) use ($modx) {
+        $router->delete('/sections/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->deleteSection($params);
         });
 
         // Field routes
-        $router->get('', function($params) use ($modx) {
+        $router->get('', function ($params) use ($modx) {
             $allParams = array_merge($_GET, $params);
 
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->getList($allParams);
         });
-        $router->get('/{id}', function($params) use ($modx) {
+        $router->get('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->get($params);
         });
-        $router->post('', function($params) use ($modx) {
+        $router->post('', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->create($data);
         });
-        $router->put('/ranks', function($params) use ($modx) {
+        $router->put('/ranks', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
 
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->updateRanks($data);
         });
-        $router->put('/{id}', function($params) use ($modx) {
+        $router->put('/{id}', function ($params) use ($modx) {
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
             $data['id'] = $params['id'] ?? null;
@@ -1028,7 +1028,7 @@ $router->group('/api/mgr', function($router) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->update($data);
         });
-        $router->delete('/{id}', function($params) use ($modx) {
+        $router->delete('/{id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ModelFieldsController($modx);
             return $controller->delete($params);
         });
@@ -1038,8 +1038,8 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Utilities Gallery routes
-    $router->group('/utilities/gallery', function($router) use ($modx) {
-        $router->post('/update', function($params) use ($modx) {
+    $router->group('/utilities/gallery', function ($router) use ($modx) {
+        $router->post('/update', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\UtilitiesGalleryController($modx);
             return $controller->update($params);
         });
@@ -1048,28 +1048,28 @@ $router->group('/api/mgr', function($router) use ($modx) {
     ]);
 
     // Import routes
-    $router->group('/import', function($router) use ($modx) {
-        $router->get('/fields', function($params) use ($modx) {
+    $router->group('/import', function ($router) use ($modx) {
+        $router->get('/fields', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
             return $controller->fields($params);
         });
 
-        $router->post('/upload', function($params) use ($modx) {
+        $router->post('/upload', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
             return $controller->upload($params);
         });
 
-        $router->post('/preview', function($params) use ($modx) {
+        $router->post('/preview', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
             return $controller->preview($params);
         });
 
-        $router->post('/start', function($params) use ($modx) {
+        $router->post('/start', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
             return $controller->start($params);
         });
 
-        $router->get('/progress/{import_id}', function($params) use ($modx) {
+        $router->get('/progress/{import_id}', function ($params) use ($modx) {
             $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
             return $controller->progress($params);
         });

--- a/core/components/minishop3/config/routes/manager.php
+++ b/core/components/minishop3/config/routes/manager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Manager API Routes for MiniShop3
  *
@@ -1038,81 +1039,40 @@ $router->group('/api/mgr', function($router) use ($modx) {
 
     // Utilities Gallery routes
     $router->group('/utilities/gallery', function($router) use ($modx) {
-        // Regenerate thumbnails
         $router->post('/update', function($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Gallery\\Update',
-                $data,
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\UtilitiesGalleryController($modx);
+            return $controller->update($params);
         });
-
     }, [
         new PermissionMiddleware($modx, 'msproductfile_generate')
     ]);
 
     // Import routes
     $router->group('/import', function($router) use ($modx) {
-        // Get available fields for mapping
         $router->get('/fields', function($params) use ($modx) {
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Import\\Fields',
-                [],
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
+            return $controller->fields($params);
         });
 
-        // Upload CSV file
         $router->post('/upload', function($params) use ($modx) {
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Import\\Upload',
-                $_POST,
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
+            return $controller->upload($params);
         });
 
-        // Preview CSV file
         $router->post('/preview', function($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Import\\Preview',
-                $data,
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
+            return $controller->preview($params);
         });
 
-        // Start import
         $router->post('/start', function($params) use ($modx) {
-            $input = file_get_contents('php://input');
-            $data = json_decode($input, true) ?: [];
-
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Import\\Import',
-                $data,
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
+            return $controller->start($params);
         });
 
-        // Get import progress
         $router->get('/progress/{import_id}', function($params) use ($modx) {
-            $response = $modx->runProcessor(
-                'MiniShop3\\Processors\\Utilities\\Import\\Progress',
-                ['import_id' => $params['import_id'] ?? ''],
-                ['processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/']
-            );
-            return $response->getResponse();
+            $controller = new \MiniShop3\Controllers\Api\Manager\ImportController($modx);
+            return $controller->progress($params);
         });
-
     }, [
         new PermissionMiddleware($modx, 'msproduct_save')
     ]);

--- a/core/components/minishop3/src/Controllers/Api/Manager/Concerns/RunsMs3Processors.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/Concerns/RunsMs3Processors.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MiniShop3\Controllers\Api\Manager\Concerns;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+
+/**
+ * Run a MiniShop3 processor and map the result to the HTTP Response envelope (#341).
+ *
+ * Host class must expose `protected modX $modx`.
+ */
+trait RunsMs3Processors
+{
+    /**
+     * @param class-string $action Fully-qualified processor class
+     */
+    protected function runMs3Processor(string $action, array $scriptProperties = []): Response
+    {
+        $processorResponse = $this->modx->runProcessor(
+            $action,
+            $scriptProperties,
+            [
+                'processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/',
+            ]
+        );
+
+        if (!is_object($processorResponse)) {
+            return Response::error(
+                'Processor failed',
+                HttpStatus::INTERNAL_SERVER_ERROR
+            );
+        }
+
+        return Response::fromProcessor($processorResponse);
+    }
+
+    protected function jsonBody(): array
+    {
+        $data = json_decode(file_get_contents('php://input') ?: '', true);
+
+        return is_array($data) ? $data : [];
+    }
+}

--- a/core/components/minishop3/src/Controllers/Api/Manager/Concerns/RunsMs3Processors.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/Concerns/RunsMs3Processors.php
@@ -21,7 +21,8 @@ trait RunsMs3Processors
             $action,
             $scriptProperties,
             [
-                'processors_path' => MODX_CORE_PATH . 'components/minishop3/src/Processors/',
+                // …/src/Controllers/Api/Manager/Concerns → …/src/Processors
+                'processors_path' => dirname(__DIR__, 4) . '/Processors/',
             ]
         );
 

--- a/core/components/minishop3/src/Controllers/Api/Manager/ImportController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ImportController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace MiniShop3\Controllers\Api\Manager;
+
+use MiniShop3\Controllers\Api\Manager\Concerns\RunsMs3Processors;
+use MiniShop3\Router\Response;
+use MODX\Revolution\modX;
+
+/**
+ * Manager REST for CSV product import (processor bridge → Response envelope).
+ *
+ * @package MiniShop3\Controllers\Api\Manager
+ */
+class ImportController
+{
+    use RunsMs3Processors;
+
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * GET /api/mgr/import/fields
+     */
+    public function fields(array $params = []): Response
+    {
+        return $this->runMs3Processor('MiniShop3\\Processors\\Utilities\\Import\\Fields');
+    }
+
+    /**
+     * POST /api/mgr/import/upload
+     */
+    public function upload(array $params = []): Response
+    {
+        return $this->runMs3Processor(
+            'MiniShop3\\Processors\\Utilities\\Import\\Upload',
+            $_POST
+        );
+    }
+
+    /**
+     * POST /api/mgr/import/preview
+     */
+    public function preview(array $params = []): Response
+    {
+        return $this->runMs3Processor(
+            'MiniShop3\\Processors\\Utilities\\Import\\Preview',
+            $this->jsonBody()
+        );
+    }
+
+    /**
+     * POST /api/mgr/import/start
+     */
+    public function start(array $params = []): Response
+    {
+        return $this->runMs3Processor(
+            'MiniShop3\\Processors\\Utilities\\Import\\Import',
+            $this->jsonBody()
+        );
+    }
+
+    /**
+     * GET /api/mgr/import/progress/{import_id}
+     */
+    public function progress(array $params = []): Response
+    {
+        return $this->runMs3Processor(
+            'MiniShop3\\Processors\\Utilities\\Import\\Progress',
+            ['import_id' => $params['import_id'] ?? '']
+        );
+    }
+}

--- a/core/components/minishop3/src/Controllers/Api/Manager/UtilitiesGalleryController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/UtilitiesGalleryController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MiniShop3\Controllers\Api\Manager;
+
+use MiniShop3\Controllers\Api\Manager\Concerns\RunsMs3Processors;
+use MiniShop3\Router\Response;
+use MODX\Revolution\modX;
+
+/**
+ * Manager REST for gallery utilities (processor bridge → Response envelope).
+ *
+ * @package MiniShop3\Controllers\Api\Manager
+ */
+class UtilitiesGalleryController
+{
+    use RunsMs3Processors;
+
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * POST /api/mgr/utilities/gallery/update
+     */
+    public function update(array $params = []): Response
+    {
+        return $this->runMs3Processor(
+            'MiniShop3\\Processors\\Utilities\\Gallery\\Update',
+            $this->jsonBody()
+        );
+    }
+}

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -128,24 +128,15 @@ class CustomerAuthController
      */
     private function runProcessor(string $processorClass, array $properties): Response
     {
-        /** @var object $response */
         $response = $this->modx->runProcessor($processorClass, $properties);
 
-        return $this->toResponse($response);
-    }
-
-    private function toResponse(object $response): Response
-    {
-        if ($response->isError()) {
-            $payload = $response->getObject();
-            $status = HttpStatus::BAD_REQUEST;
-            if (is_array($payload) && isset($payload['code']) && is_numeric($payload['code'])) {
-                $status = (int) $payload['code'];
-            }
-
-            return Response::error($response->getMessage(), $status);
+        if (!is_object($response)) {
+            return Response::error(
+                'Processor failed',
+                HttpStatus::INTERNAL_SERVER_ERROR
+            );
         }
 
-        return Response::success($response->getObject(), $response->getMessage());
+        return Response::fromProcessor($response);
     }
 }

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -3,7 +3,17 @@
 namespace MiniShop3\Router;
 
 /**
- * JSON Response class
+ * JSON Response class — HTTP boundary envelope for Manager/Web API.
+ *
+ * | Layer | Contract | Notes |
+ * |-------|----------|-------|
+ * | HTTP boundary (Api controllers, route handlers, middleware) | `Response::success` / `error` / `fromProcessor` | Always this shape on the wire via Router |
+ * | Domain facades (Cart / Order / Customer) | MS2-array `{success,message,data}` | Snippet/plugin compatibility; do not re-wrap into Response inside domain |
+ * | Legacy `modProcessor` | `failure` / `success` | Bridge at HTTP edge with `Response::fromProcessor` — never return raw `getResponse()` from mgr/web routes |
+ *
+ * Do not nest `Response` inside `$ms3->utils->success` (or the reverse) without a concrete need.
+ *
+ * @see https://github.com/modx-pro/MiniShop3/issues/341
  */
 class Response
 {
@@ -65,8 +75,15 @@ class Response
     /**
      * Map a MODX processor response to an API Response.
      *
-     * Error processors may pass ['code' => HttpStatus::…] as the failure object
-     * (Login/Register rate-limit and auth failures).
+     * Do not return processor `getResponse()` from routes: connector Index unwraps
+     * `Response` as `$responseData['data'] ?? $responseData`, so a raw processor
+     * payload nests as `object.object.*`.
+     *
+     * Error shape:
+     * - `errors` — MODX field/validation map from `addFieldError` (when present)
+     * - `data` — processor object minus transport-only `code` (import stats, etc.)
+     * - HTTP/`code` — from object `code` when it is an allowed HttpStatus
+     *   (Login/Register rate-limit and auth failures)
      *
      * @param object $processorResponse modProcessorResponse (isError/getMessage/getObject)
      */
@@ -76,10 +93,85 @@ class Response
             return self::success($processorResponse->getObject(), $processorResponse->getMessage());
         }
 
-        return self::error(
-            (string) $processorResponse->getMessage(),
-            self::statusFromProcessorObject($processorResponse->getObject())
-        );
+        $object = $processorResponse->getObject();
+        $status = self::statusFromProcessorObject($object);
+        $fieldErrors = self::fieldErrorsFromProcessor($processorResponse);
+        $message = (string) $processorResponse->getMessage();
+        if ($message === '' && $fieldErrors !== null) {
+            $message = self::messageFromFieldErrors($fieldErrors);
+        }
+
+        $data = null;
+        if (is_array($object)) {
+            $data = $object;
+            unset($data['code']);
+            if ($data === []) {
+                $data = null;
+            }
+        }
+
+        $body = [
+            'success' => false,
+            'message' => $message,
+            'code' => $status,
+            'errors' => $fieldErrors,
+        ];
+        if ($data !== null) {
+            $body['data'] = $data;
+        }
+
+        return new self($body, $status);
+    }
+
+    /**
+     * Field errors from modProcessorResponse (addFieldError → getResponse()['errors']).
+     *
+     * @return array<int|string, mixed>|null
+     */
+    public static function fieldErrorsFromProcessor(object $processorResponse): ?array
+    {
+        if (method_exists($processorResponse, 'getResponse')) {
+            $raw = $processorResponse->getResponse();
+            if (is_string($raw) && $raw !== '') {
+                $decoded = json_decode($raw, true);
+                $raw = is_array($decoded) ? $decoded : null;
+            }
+            if (is_array($raw) && !empty($raw['errors']) && is_array($raw['errors'])) {
+                return $raw['errors'];
+            }
+        }
+
+        if (
+            method_exists($processorResponse, 'hasFieldErrors')
+            && method_exists($processorResponse, 'getFieldErrors')
+            && $processorResponse->hasFieldErrors()
+        ) {
+            $fieldErrors = $processorResponse->getFieldErrors();
+            if (is_array($fieldErrors) && $fieldErrors !== []) {
+                return $fieldErrors;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $fieldErrors
+     */
+    private static function messageFromFieldErrors(array $fieldErrors): string
+    {
+        $first = reset($fieldErrors);
+        if (is_array($first) && isset($first['msg'])) {
+            return (string) $first['msg'];
+        }
+        if (is_object($first) && isset($first->msg)) {
+            return (string) $first->msg;
+        }
+        if (is_string($first) && $first !== '') {
+            return $first;
+        }
+
+        return '';
     }
 
     /**

--- a/core/components/minishop3/tests/ImportGalleryConnectorEnvelopeTest.php
+++ b/core/components/minishop3/tests/ImportGalleryConnectorEnvelopeTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Import/gallery manager HTTP boundary must use Response envelope (#341 / #419).
+ *
+ * Processors\Api\Index unwraps Response as:
+ *   $this->success('', $responseData['data'] ?? $responseData);
+ * Raw getResponse() → no `data` key → nested object.object.*.
+ *
+ * Run: php tests/ImportGalleryConnectorEnvelopeTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Router\Response;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$processor = new class {
+    public function isError(): bool
+    {
+        return false;
+    }
+
+    public function getMessage(): string
+    {
+        return 'scheduled';
+    }
+
+    public function getObject(): array
+    {
+        return [
+            'import_id' => 'imp-1',
+            'scheduled' => true,
+        ];
+    }
+};
+
+$fixedData = Response::fromProcessor($processor)->getData();
+$fixedObject = $fixedData['data'] ?? $fixedData;
+
+if (!is_array($fixedObject) || ($fixedObject['scheduled'] ?? null) !== true) {
+    $fail('fromProcessor + Index unwrap must yield connector object with scheduled=true');
+}
+if (($fixedObject['import_id'] ?? null) !== 'imp-1') {
+    $fail('expected connector object.import_id === imp-1');
+}
+if (isset($fixedObject['object'])) {
+    $fail('connector object must not nest another processor object key');
+}
+if (($fixedData['message'] ?? null) !== 'scheduled') {
+    $fail('processor message must survive in API Response');
+}
+
+$errorProcessor = new class {
+    public function isError(): bool
+    {
+        return true;
+    }
+
+    public function getMessage(): string
+    {
+        return 'import failed';
+    }
+
+    public function getObject(): array
+    {
+        return [
+            'import_id' => 'imp-err',
+            'errors' => 3,
+        ];
+    }
+};
+
+$error = Response::fromProcessor($errorProcessor);
+$errorData = $error->getData();
+if ($error->getStatusCode() !== 400) {
+    $fail('fromProcessor error must use HTTP 400');
+}
+if (($errorData['success'] ?? true) !== false || ($errorData['message'] ?? null) !== 'import failed') {
+    $fail('fromProcessor error must keep success=false and processor message');
+}
+if (($errorData['data']['import_id'] ?? null) !== 'imp-err') {
+    $fail('fromProcessor error must keep processor object under data');
+}
+if (($errorData['data']['errors'] ?? null) !== 3) {
+    $fail('fromProcessor error must keep import error count in data.errors');
+}
+
+$routeFiles = [
+    __DIR__ . '/../config/routes/manager.php',
+    __DIR__ . '/../config/routes/web.php',
+];
+
+foreach ($routeFiles as $routeFile) {
+    $contents = file_get_contents($routeFile);
+    if ($contents === false) {
+        $fail('unable to read ' . $routeFile);
+    }
+    if (str_contains($contents, '->getResponse()')) {
+        $fail(basename($routeFile) . ' must not return raw processor getResponse()');
+    }
+}
+
+$trait = file_get_contents(
+    __DIR__ . '/../src/Controllers/Api/Manager/Concerns/RunsMs3Processors.php'
+);
+if ($trait === false || !str_contains($trait, 'Response::fromProcessor(')) {
+    $fail('RunsMs3Processors must map processors via Response::fromProcessor');
+}
+
+foreach ([
+    'ImportController.php',
+    'UtilitiesGalleryController.php',
+] as $controllerFile) {
+    $path = __DIR__ . '/../src/Controllers/Api/Manager/' . $controllerFile;
+    $src = file_get_contents($path);
+    if ($src === false) {
+        $fail('missing controller ' . $controllerFile);
+    }
+    if (!str_contains($src, 'RunsMs3Processors')) {
+        $fail($controllerFile . ' must use RunsMs3Processors');
+    }
+}
+
+$managerRoutes = file_get_contents(__DIR__ . '/../config/routes/manager.php');
+if ($managerRoutes === false) {
+    $fail('unable to read manager.php');
+}
+if (!str_contains($managerRoutes, 'UtilitiesGalleryController')) {
+    $fail('gallery routes must dispatch UtilitiesGalleryController');
+}
+if (!str_contains($managerRoutes, 'ImportController')) {
+    $fail('import routes must dispatch ImportController');
+}
+
+fwrite(STDOUT, "OK ImportGalleryConnectorEnvelopeTest\n");
+exit(0);

--- a/core/components/minishop3/tests/ResponseFromProcessorTest.php
+++ b/core/components/minishop3/tests/ResponseFromProcessorTest.php
@@ -3,7 +3,7 @@
 /**
  * Response::fromProcessor / statusFromProcessorObject (no MODX).
  *
- * Запуск: php tests/ProcessorErrorHttpStatusTest.php
+ * Run: php tests/ResponseFromProcessorTest.php
  */
 
 declare(strict_types=1);
@@ -83,6 +83,63 @@ if ($invalid->getStatusCode() !== HttpStatus::UNAUTHORIZED) {
 $ok = Response::fromProcessor($makeProcessor(false, 'ok', ['id' => 1]));
 if ($ok->getStatusCode() !== HttpStatus::OK || ($ok->getData()['success'] ?? false) !== true) {
     $fail('fromProcessor success path broken');
+}
+
+$withData = Response::fromProcessor(
+    $makeProcessor(true, 'import failed', ['import_id' => 'imp-1', 'errors' => 2])
+);
+if (($withData->getData()['data']['import_id'] ?? null) !== 'imp-1') {
+    $fail('fromProcessor error must expose processor object under data');
+}
+if (($withData->getData()['data']['errors'] ?? null) !== 2) {
+    $fail('fromProcessor must keep import error count in data.errors');
+}
+if (($withData->getData()['errors'] ?? null) !== null) {
+    $fail('fromProcessor must not put processor object into validation errors slot');
+}
+
+$fieldProcessor = new class {
+    public function isError(): bool
+    {
+        return true;
+    }
+
+    public function getMessage(): string
+    {
+        return '';
+    }
+
+    public function getObject(): array
+    {
+        return [];
+    }
+
+    public function getResponse(): array
+    {
+        return [
+            'success' => false,
+            'message' => '',
+            'errors' => [
+                ['id' => 'fields', 'msg' => 'This field is required'],
+            ],
+            'object' => [],
+        ];
+    }
+};
+
+$fieldError = Response::fromProcessor($fieldProcessor);
+if (($fieldError->getData()['errors'][0]['id'] ?? null) !== 'fields') {
+    $fail('fromProcessor must preserve MODX field errors under errors');
+}
+if (($fieldError->getData()['message'] ?? null) !== 'This field is required') {
+    $fail('fromProcessor must derive message from field errors when empty');
+}
+
+$authThrottle = Response::fromProcessor(
+    $makeProcessor(true, 'rate limited', ['code' => HttpStatus::TOO_MANY_REQUESTS])
+);
+if (array_key_exists('data', $authThrottle->getData())) {
+    $fail('auth-only code object must not add empty data key');
 }
 
 // Profile/email unauth envelope (AddressController pattern)


### PR DESCRIPTION
## Описание

Сводит Manager/Web API к одному контракту на HTTP boundary: `MiniShop3\Router\Response` + `HttpStatus`.

Import/gallery вынесены из fat closures `manager.php` в контроллеры с `Response::fromProcessor`. Customer auth на Web использует тот же bridge. В `Response.php` зафиксирована таблица слоёв (domain MS2-array vs HTTP envelope vs legacy processors).

Перекрывает подход [#437](https://github.com/modx-pro/MiniShop3/pull/437) (raw `getResponse()` → envelope). Extra-fields CRUD остаётся в [#491](https://github.com/modx-pro/MiniShop3/pull/491) / #355.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #341

## Как это было протестировано?

Локальный CI-гейт (без полной установки MODX/MySQL), PHP lint + smoke + PHPUnit из `.github/workflows/ci.yml`:

```bash
cd core/components/minishop3
composer install
composer ci:php
# exit 0 — php -l 455 files, smoke 42 OK, PHPUnit 109 OK (4 deprecations pre-existing)
php tests/ImportGalleryConnectorEnvelopeTest.php   # exit 0
php tests/ResponseFromProcessorTest.php            # exit 0
php tests/CustomerAuthEndpointsTest.php            # exit 0
```

Vue не трогали. PHPStan локально не гоняли (нет `.phpstan-deps`); ожидается job CI.

- [x] Автоматические тесты (`composer ci:php`)
- [ ] Ручное тестирование
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-341-response-envelope`
- MODX: n/a (smoke без MODX)
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы не требуются
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint n/a (Vue не менялся)
- [ ] CHANGELOG.md — не трогали (релизный maintainer)

## Дополнительные заметки

### Контракты (кратко)

| Слой | Контракт |
|------|----------|
| HTTP (Api controllers, routes, middleware) | `Response::*` / `fromProcessor` |
| Domain (Cart/Order/Customer) | MS2 `{success,message,data}` |
| Legacy processors | bridge только через `fromProcessor`, не `getResponse()` в routes |

### AC #341

| Критерий | Статус |
|----------|--------|
| Тронутые mgr+web REST отдают `Response` | да (import/gallery + CustomerAuth) |
| Zero `getResponse()` в `config/routes/{manager,web}.php` | да (smoke) |
| Таблица контрактов | docblock `Router/Response.php` + эта таблица |

### Follow-up

- Extra-fields fat closures → [#491](https://github.com/modx-pro/MiniShop3/pull/491)
- После merge можно закрыть [#437](https://github.com/modx-pro/MiniShop3/pull/437) как superseded