### PR TITLE
feat(order): публичный sessionless API программного создания заказов

### DIFF
--- a/core/components/minishop3/lexicon/en/order.inc.php
+++ b/core/components/minishop3/lexicon/en/order.inc.php
@@ -49,3 +49,10 @@ $_lang['ms3_order_err_products'] = 'Order has no products';
 $_lang['ms3_order_err_delivery_id'] = 'Delivery method is not selected';
 $_lang['ms3_order_err_payment_id'] = 'Payment method is not selected';
 $_lang['ms3_order_err_customer_id'] = 'Customer is not specified';
+
+// Programmatic / sessionless order API (#507)
+$_lang['ms3_order_err_idempotency_key_required'] = 'Idempotency key is required';
+$_lang['ms3_order_err_products_required'] = 'At least one product snapshot is required';
+$_lang['ms3_order_err_programmatic_create'] = 'Failed to create programmatic order';
+$_lang['ms3_order_programmatic_created'] = 'Order created programmatically';
+$_lang['ms3_order_programmatic_idempotent'] = 'Existing order returned for idempotency key';

--- a/core/components/minishop3/lexicon/ru/order.inc.php
+++ b/core/components/minishop3/lexicon/ru/order.inc.php
@@ -49,3 +49,10 @@ $_lang['ms3_order_err_products'] = 'В заказе нет товаров';
 $_lang['ms3_order_err_delivery_id'] = 'Не выбран способ доставки';
 $_lang['ms3_order_err_payment_id'] = 'Не выбран способ оплаты';
 $_lang['ms3_order_err_customer_id'] = 'Не указан покупатель';
+
+// Программное / sessionless API заказа (#507)
+$_lang['ms3_order_err_idempotency_key_required'] = 'Требуется ключ идемпотентности';
+$_lang['ms3_order_err_products_required'] = 'Нужен хотя бы один снимок товара';
+$_lang['ms3_order_err_programmatic_create'] = 'Не удалось создать заказ программно';
+$_lang['ms3_order_programmatic_created'] = 'Заказ создан программно';
+$_lang['ms3_order_programmatic_idempotent'] = 'Возвращён существующий заказ по ключу идемпотентности';

--- a/core/components/minishop3/migrations/20260809140000_add_order_idempotency_key.php
+++ b/core/components/minishop3/migrations/20260809140000_add_order_idempotency_key.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Unique nullable idempotency_key on ms3_orders for programmatic create (#507).
+ */
+final class AddOrderIdempotencyKey extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('ms3_orders');
+
+        if (!$table->hasColumn('idempotency_key')) {
+            $table->addColumn('idempotency_key', 'string', [
+                'limit' => 128,
+                'null' => true,
+                'default' => null,
+                'after' => 'uuid',
+            ])->update();
+        }
+
+        if (!$table->hasIndexByName('idempotency_key')) {
+            $table->addIndex(['idempotency_key'], [
+                'unique' => true,
+                'name' => 'idempotency_key',
+            ])->update();
+        }
+    }
+
+    public function down(): void
+    {
+        $table = $this->table('ms3_orders');
+
+        if ($table->hasIndexByName('idempotency_key')) {
+            $table->removeIndexByName('idempotency_key')->update();
+        }
+
+        if ($table->hasColumn('idempotency_key')) {
+            $table->removeColumn('idempotency_key')->update();
+        }
+    }
+}

--- a/core/components/minishop3/src/Model/msOrder.php
+++ b/core/components/minishop3/src/Model/msOrder.php
@@ -14,6 +14,7 @@ use xPDO\Om\xPDOSimpleObject;
  * @property integer $customer_id
  * @property string $token
  * @property string $uuid
+ * @property string|null $idempotency_key
  * @property string $createdon
  * @property string $updatedon
  * @property string $num

--- a/core/components/minishop3/src/Model/mysql/msOrder.php
+++ b/core/components/minishop3/src/Model/mysql/msOrder.php
@@ -19,6 +19,7 @@ class msOrder extends \MiniShop3\Model\msOrder
                 'customer_id' => 0,
                 'token' => '',
                 'uuid' => '',
+                'idempotency_key' => null,
                 'createdon' => null,
                 'updatedon' => null,
                 'num' => null,
@@ -66,6 +67,14 @@ class msOrder extends \MiniShop3\Model\msOrder
                         'precision' => '36',
                         'phptype' => 'string',
                         'null' => false,
+                    ],
+                'idempotency_key' =>
+                    [
+                        'dbtype' => 'varchar',
+                        'precision' => '128',
+                        'phptype' => 'string',
+                        'null' => true,
+                        'default' => null,
                     ],
                 'createdon' =>
                     [
@@ -230,6 +239,22 @@ class msOrder extends \MiniShop3\Model\msOrder
                                         'length' => '',
                                         'collation' => 'A',
                                         'null' => false,
+                                    ],
+                            ],
+                    ],
+                'idempotency_key' =>
+                    [
+                        'alias' => 'idempotency_key',
+                        'primary' => false,
+                        'unique' => true,
+                        'type' => 'BTREE',
+                        'columns' =>
+                            [
+                                'idempotency_key' =>
+                                    [
+                                        'length' => '',
+                                        'collation' => 'A',
+                                        'null' => true,
                                     ],
                             ],
                     ],

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -277,9 +277,9 @@ class Router
      */
     public function addRoute($method, string $pattern, $handler, array $middlewares = []): Route
     {
-        $fullPattern = ($this->currentPrefix ?? '') . $pattern;
+        $fullPattern = $this->currentPrefix . $pattern;
 
-        $allMiddlewares = array_merge($this->currentMiddlewares ?? [], $middlewares);
+        $allMiddlewares = array_merge($this->currentMiddlewares, $middlewares);
 
         $route = new Route($method, $fullPattern, $handler, $allMiddlewares);
 
@@ -345,8 +345,8 @@ class Router
      */
     public function group(string $prefix, callable $callback, array $middlewares = []): void
     {
-        $previousPrefix = $this->currentPrefix ?? '';
-        $previousMiddlewares = $this->currentMiddlewares ?? [];
+        $previousPrefix = $this->currentPrefix;
+        $previousMiddlewares = $this->currentMiddlewares;
 
         $this->currentPrefix = $previousPrefix . $prefix;
         $this->currentMiddlewares = array_merge($previousMiddlewares, $middlewares);

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -26,6 +26,12 @@ class Router
     /** @var array */
     protected $middlewares = [];
 
+    /** @var string */
+    protected $currentPrefix = '';
+
+    /** @var array */
+    protected $currentMiddlewares = [];
+
     /**
      * @param modX $modx
      */

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -82,6 +82,7 @@ class ServiceRegistry
         'ms3_cart_mutation_handler',
         'ms3_customer_order_resolver',
         'ms3_model_field_service',
+        'ms3_programmatic_order',
     ];
 
     /**
@@ -114,6 +115,7 @@ class ServiceRegistry
         ],
         'ms3_customer_order_resolver' => ['ms3_customer_field_manager'],
         'ms3_model_field_service' => ['ms3_model_field_section_service'],
+        'ms3_programmatic_order' => ['ms3_order_finalize', 'ms3_order_draft_manager'],
     ];
 
     /**
@@ -232,6 +234,10 @@ class ServiceRegistry
         ],
         'ms3_order_finalize' => [
             'class' => \MiniShop3\Services\Order\OrderFinalizeService::class,
+            'interface' => null,
+        ],
+        'ms3_programmatic_order' => [
+            'class' => \MiniShop3\Services\Order\ProgrammaticOrderService::class,
             'interface' => null,
         ],
         // Cart services
@@ -669,6 +675,16 @@ class ServiceRegistry
                     $ms3 = $modx->getService('MiniShop3', \MiniShop3\MiniShop3::class);
                     $numberGenerator = $modx->services->get('ms3_order_number_generator');
                     return new $validatedClass($modx, $ms3, $numberGenerator);
+                });
+                break;
+
+            case 'ms3_programmatic_order':
+                // ProgrammaticOrderService(modX, MiniShop3, OrderFinalizeService, OrderDraftManager)
+                $this->modx->services->add($serviceKey, function () use ($validatedClass, $modx) {
+                    $ms3 = $modx->getService('MiniShop3', \MiniShop3\MiniShop3::class);
+                    $finalize = $modx->services->get('ms3_order_finalize');
+                    $draftManager = $modx->services->get('ms3_order_draft_manager');
+                    return new $validatedClass($modx, $ms3, $finalize, $draftManager);
                 });
                 break;
 

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -5,7 +5,12 @@ namespace MiniShop3\Services\Order;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msOrder;
 use MiniShop3\Model\msOrderAddress;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msProduct;
+use MiniShop3\Model\msProductData;
+use MODX\Revolution\modSystemEvent;
 use MODX\Revolution\modX;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Order Draft Manager
@@ -596,5 +601,174 @@ class OrderDraftManager
         );
 
         return true;
+    }
+
+    /**
+     * Create a sessionless draft for programmatic / integration callers (#507).
+     *
+     * Does not read PHP session or cart tokens.
+     *
+     * @param array{
+     *     context?: string,
+     *     customer_id?: int,
+     *     delivery_id?: int,
+     *     payment_id?: int,
+     *     delivery_cost?: float|int,
+     *     order_comment?: string,
+     *     idempotency_key?: string,
+     *     origin?: string,
+     *     properties?: array<string, mixed>
+     * } $data
+     */
+    public function createSessionlessDraft(array $data): msOrder
+    {
+        $ctx = trim((string) ($data['context'] ?? 'web')) ?: 'web';
+        $deliveryCost = (float) ($data['delivery_cost'] ?? 0);
+        $origin = OrderOrigin::normalize(
+            $data['origin'] ?? OrderOrigin::INTEGRATION,
+            OrderOrigin::INTEGRATION
+        );
+        $idempotencyKey = trim((string) ($data['idempotency_key'] ?? ''));
+
+        /** @var msOrder $order */
+        $order = $this->modx->newObject(msOrder::class);
+        $order->set('uuid', Uuid::uuid4()->toString());
+        $order->set('token', md5(uniqid('ms3_int_', true)));
+        $order->set('status_id', (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1);
+        $order->set('context', $ctx);
+        $order->set('createdon', time());
+        $order->set('updatedon', time());
+        $order->set('user_id', 0);
+        $order->set('customer_id', (int) ($data['customer_id'] ?? 0));
+        $order->set('delivery_id', (int) ($data['delivery_id'] ?? 0));
+        $order->set('payment_id', (int) ($data['payment_id'] ?? 0));
+        $order->set('order_comment', (string) ($data['order_comment'] ?? ''));
+        $order->set('num', null);
+        $order->set('cart_cost', 0);
+        $order->set('delivery_cost', $deliveryCost);
+        $order->set('weight', 0);
+        $order->set('idempotency_key', $idempotencyKey !== '' ? $idempotencyKey : null);
+
+        /** @var OrderService $orderService */
+        $orderService = $this->modx->services->get('ms3_order_service');
+        $order->set('cost', $orderService->clampComputedTotal(null, 0.0, $deliveryCost, 0.0));
+
+        $properties = is_array($data['properties'] ?? null) ? $data['properties'] : [];
+        if ($idempotencyKey !== '') {
+            $properties[OrderOrigin::PROPERTY_IDEMPOTENCY_KEY] = $idempotencyKey;
+        }
+        $properties[OrderOrigin::PROPERTY_ORIGIN] = $origin;
+        $order->set('properties', $properties);
+
+        if (!$order->save()) {
+            throw new \RuntimeException('ms3_order_err_save');
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param array<string, mixed> $addressData
+     */
+    public function fillAddressFromArray(msOrder $order, array $addressData): void
+    {
+        /** @var msOrderAddress $address */
+        $address = $this->modx->newObject(msOrderAddress::class);
+        $address->set('order_id', $order->get('id'));
+        $address->set('createdon', time());
+
+        foreach ([
+            'first_name', 'last_name', 'phone', 'email',
+            'country', 'index', 'region', 'city', 'metro',
+            'street', 'building', 'entrance', 'floor', 'room',
+            'comment', 'text_address',
+        ] as $field) {
+            if (array_key_exists($field, $addressData)) {
+                $address->set($field, $addressData[$field]);
+            }
+        }
+
+        if (!$address->save()) {
+            throw new \RuntimeException('ms3_order_err_address_save');
+        }
+    }
+
+    /**
+     * Persist an order product from a caller-supplied snapshot (catalog id and/or price).
+     *
+     * @param array<string, mixed> $snapshot
+     */
+    public function addProductFromSnapshot(msOrder $order, array $snapshot, string $origin = OrderOrigin::INTEGRATION): void
+    {
+        $productId = (int) ($snapshot['product_id'] ?? 0);
+        $count = max(1, (int) ($snapshot['count'] ?? 1));
+        $name = isset($snapshot['name']) ? (string) $snapshot['name'] : '';
+        $price = array_key_exists('price', $snapshot) ? (float) $snapshot['price'] : null;
+        $weight = array_key_exists('weight', $snapshot) ? (float) $snapshot['weight'] : null;
+        $options = $snapshot['options'] ?? null;
+        if (is_string($options) && $options !== '') {
+            $decoded = json_decode($options, true);
+            $options = is_array($decoded) ? $decoded : [];
+        }
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        if ($productId > 0) {
+            $product = $this->modx->getObject(msProduct::class, $productId);
+            if (!$product) {
+                throw new \InvalidArgumentException('ms3_order_err_product_nf');
+            }
+            if ($name === '') {
+                $name = (string) $product->get('pagetitle');
+            }
+            /** @var msProductData|null $productData */
+            $productData = $this->modx->getObject(msProductData::class, $productId);
+            if ($price === null) {
+                $price = $productData ? (float) $productData->get('price') : 0.0;
+            }
+            if ($weight === null) {
+                $weight = $productData ? (float) $productData->get('weight') : 0.0;
+            }
+        } elseif ($name === '' || $price === null) {
+            throw new \InvalidArgumentException('ms3_order_err_product_snapshot');
+        } else {
+            $weight = $weight ?? 0.0;
+        }
+
+        /** @var msOrderProduct $orderProduct */
+        $orderProduct = $this->modx->newObject(msOrderProduct::class);
+        $orderProduct->set('order_id', $order->get('id'));
+        $orderProduct->set('product_id', $productId > 0 ? $productId : null);
+        $orderProduct->set('product_key', md5($productId . json_encode($options)));
+        $orderProduct->set('name', $name);
+        $orderProduct->set('count', $count);
+        $orderProduct->set('price', $price);
+        $orderProduct->set('weight', $weight);
+        $orderProduct->set('cost', $count * $price);
+        $orderProduct->set('options', $options !== [] ? json_encode($options) : null);
+
+        $modeNew = defined(modSystemEvent::class . '::MODE_NEW')
+            ? modSystemEvent::MODE_NEW
+            : 'new';
+
+        $eventContext = [
+            'mode' => $modeNew,
+            'object' => $orderProduct,
+            'msOrderProduct' => $orderProduct,
+            'msOrder' => $order,
+            'origin' => OrderOrigin::normalize($origin, OrderOrigin::INTEGRATION),
+        ];
+
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeCreateOrderProduct', $eventContext);
+        if (!$response['success']) {
+            throw new \RuntimeException((string) $response['message']);
+        }
+
+        if (!$orderProduct->save()) {
+            throw new \RuntimeException('ms3_order_err_product_save');
+        }
+
+        $this->ms3->utils->invokeEvent('msOnCreateOrderProduct', $eventContext);
     }
 }

--- a/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
+++ b/core/components/minishop3/src/Services/Order/OrderFinalizeService.php
@@ -21,6 +21,13 @@ use MODX\Revolution\modX;
  */
 class OrderFinalizeService
 {
+    /** @deprecated Use OrderOrigin::MANAGER */
+    public const ORIGIN_MANAGER = OrderOrigin::MANAGER;
+    /** @deprecated Use OrderOrigin::STOREFRONT */
+    public const ORIGIN_STOREFRONT = OrderOrigin::STOREFRONT;
+    /** @deprecated Use OrderOrigin::INTEGRATION */
+    public const ORIGIN_INTEGRATION = OrderOrigin::INTEGRATION;
+
     protected modX $modx;
     protected MiniShop3 $ms3;
     protected OrderNumberGenerator $numberGenerator;
@@ -42,6 +49,7 @@ class OrderFinalizeService
      *   - skip_payment: bool - Skip payment gateway call
      *   - create_customer: bool - Create customer from order address data
      *   - force_create_customer: bool - Create customer even if duplicate found
+     *   - origin: string - Event context origin (`manager` default, `integration`, `storefront`)
      * @return array Response with success/error
      */
     public function finalize(int $orderId, array $options = []): array
@@ -50,6 +58,8 @@ class OrderFinalizeService
         $skipNotifications = $options['skip_notifications'] ?? false;
         $createCustomer = $options['create_customer'] ?? false;
         $forceCreateCustomer = $options['force_create_customer'] ?? false;
+        $origin = OrderOrigin::normalize($options['origin'] ?? OrderOrigin::MANAGER);
+        $fromManager = OrderOrigin::isManager($origin);
 
         // Get order
         /** @var msOrder $order */
@@ -72,16 +82,18 @@ class OrderFinalizeService
             }
         }
 
-        // Event: before manager-side order creation (finalize = draft → real order).
-        // Sibling of msOnSubmitOrder but fires in the manager finalize flow.
-        $response = $this->ms3->utils->invokeEvent('msOnBeforeMgrCreateOrder', [
-            'service' => $this,
-            'msOrder' => $order,
-            'from_manager' => true,
-        ]);
+        // Manager-only sibling of msOnSubmitOrder (draft → real order in mgr UI).
+        if ($fromManager) {
+            $response = $this->ms3->utils->invokeEvent('msOnBeforeMgrCreateOrder', [
+                'service' => $this,
+                'msOrder' => $order,
+                'origin' => $origin,
+                'from_manager' => true,
+            ]);
 
-        if (!$response['success']) {
-            return $this->error($response['message']);
+            if (!$response['success']) {
+                return $this->error($response['message']);
+            }
         }
 
         // Create customer if requested and no customer linked yet
@@ -103,7 +115,7 @@ class OrderFinalizeService
         }
 
         // Calculate costs
-        $costResult = $this->calculateCosts($order);
+        $costResult = $this->calculateCosts($order, $options);
         if (!$costResult['success']) {
             return $costResult;
         }
@@ -141,24 +153,19 @@ class OrderFinalizeService
             return $this->error('ms3_err_order_num_save');
         }
 
-        // Event: before create order (same as frontend)
-        $response = $this->ms3->utils->invokeEvent('msOnBeforeCreateOrder', [
+        $createEventParams = [
             'service' => $this,
             'msOrder' => $order,
-            'from_manager' => true,
-        ]);
+            'origin' => $origin,
+            'from_manager' => $fromManager,
+        ];
 
+        $response = $this->ms3->utils->invokeEvent('msOnBeforeCreateOrder', $createEventParams);
         if (!$response['success']) {
             return $this->error($response['message']);
         }
 
-        // Event: on create order (same as frontend)
-        $response = $this->ms3->utils->invokeEvent('msOnCreateOrder', [
-            'service' => $this,
-            'msOrder' => $order,
-            'from_manager' => true,
-        ]);
-
+        $response = $this->ms3->utils->invokeEvent('msOnCreateOrder', $createEventParams);
         if (!$response['success']) {
             return $this->error($response['message']);
         }
@@ -181,17 +188,21 @@ class OrderFinalizeService
         // Reload order after status change
         $order = $this->modx->getObject(msOrder::class, $orderId);
 
-        // Event: manager-side order creation finished (draft finalized).
-        $this->ms3->utils->invokeEvent('msOnMgrCreateOrder', [
-            'service' => $this,
-            'msOrder' => $order,
-            'from_manager' => true,
-        ]);
+        if ($fromManager) {
+            $this->ms3->utils->invokeEvent('msOnMgrCreateOrder', [
+                'service' => $this,
+                'msOrder' => $order,
+                'origin' => $origin,
+                'from_manager' => true,
+            ]);
+        }
 
         return $this->success('ms3_order_finalized', [
             'order_id' => $order->get('id'),
             'order_num' => $order->get('num'),
             'status_id' => $order->get('status_id'),
+            'uuid' => $order->get('uuid'),
+            'num' => $order->get('num'),
         ]);
     }
 
@@ -407,12 +418,20 @@ class OrderFinalizeService
      * Calculate order costs
      *
      * @param msOrder $order
+     * @param array<string, mixed> $options Forward cost_mode / manual_delivery_cost to recalculator
      * @return array
      */
-    protected function calculateCosts(msOrder $order): array
+    protected function calculateCosts(msOrder $order, array $options = []): array
     {
         $recalculator = new ManagerOrderCostRecalculator($this->modx, $this->ms3);
-        $result = $recalculator->calculateBreakdown($order);
+        $costOptions = [];
+        if (isset($options['cost_mode'])) {
+            $costOptions['mode'] = $options['cost_mode'];
+        }
+        if (array_key_exists('manual_delivery_cost', $options)) {
+            $costOptions['manual_delivery_cost'] = $options['manual_delivery_cost'];
+        }
+        $result = $recalculator->calculateBreakdown($order, $costOptions);
 
         if (!$result['success']) {
             return $result;

--- a/core/components/minishop3/src/Services/Order/OrderOrigin.php
+++ b/core/components/minishop3/src/Services/Order/OrderOrigin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MiniShop3\Services\Order;
+
+/**
+ * Documented order creation origin for event context (#507).
+ */
+final class OrderOrigin
+{
+    public const MANAGER = 'manager';
+    public const STOREFRONT = 'storefront';
+    public const INTEGRATION = 'integration';
+
+    /** Stored on msOrder.properties for integrations */
+    public const PROPERTY_IDEMPOTENCY_KEY = 'idempotency_key';
+    public const PROPERTY_ORIGIN = 'origin';
+
+    /**
+     * @param mixed $origin
+     */
+    public static function normalize($origin, string $default = self::MANAGER): string
+    {
+        $value = is_string($origin) ? strtolower(trim($origin)) : '';
+
+        return match ($value) {
+            self::MANAGER, self::STOREFRONT, self::INTEGRATION => $value,
+            default => match ($default) {
+                self::MANAGER, self::STOREFRONT, self::INTEGRATION => $default,
+                default => self::MANAGER,
+            },
+        };
+    }
+
+    public static function isManager(string $origin): bool
+    {
+        return $origin === self::MANAGER;
+    }
+}

--- a/core/components/minishop3/src/Services/Order/ProgrammaticOrderService.php
+++ b/core/components/minishop3/src/Services/Order/ProgrammaticOrderService.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace MiniShop3\Services\Order;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msOrder;
+use MODX\Revolution\modX;
+use Throwable;
+
+/**
+ * Sessionless programmatic order creation for Extras / cron / integrations (#507).
+ *
+ * Thin orchestrator: draft graph via {@see OrderDraftManager}, finalize via
+ * {@see OrderFinalizeService} with `origin=integration`.
+ */
+class ProgrammaticOrderService
+{
+    public const PROPERTY_IDEMPOTENCY_KEY = OrderOrigin::PROPERTY_IDEMPOTENCY_KEY;
+    public const PROPERTY_ORIGIN = OrderOrigin::PROPERTY_ORIGIN;
+
+    public function __construct(
+        protected modX $modx,
+        protected MiniShop3 $ms3,
+        protected OrderFinalizeService $finalizeService,
+        protected OrderDraftManager $draftManager,
+    ) {
+    }
+
+    /**
+     * Create (or return/resume idempotent) finalized order.
+     *
+     * @param array<string, mixed> $input
+     * @return array{success: bool, message: string, data: array}
+     */
+    public function create(array $input): array
+    {
+        $idempotencyKey = trim((string) ($input['idempotency_key'] ?? ''));
+        if ($idempotencyKey === '') {
+            return $this->error('ms3_order_err_idempotency_key_required');
+        }
+
+        $origin = OrderOrigin::normalize(
+            $input['origin'] ?? OrderOrigin::INTEGRATION,
+            OrderOrigin::INTEGRATION
+        );
+
+        $finalizeOptions = [
+            'skip_notifications' => !empty($input['skip_notifications']),
+            'skip_validation' => !empty($input['skip_validation']),
+            'origin' => $origin,
+        ];
+        if (array_key_exists('delivery_cost', $input)) {
+            $finalizeOptions['cost_mode'] = ManagerOrderCostRecalculator::MODE_MANUAL;
+            $finalizeOptions['manual_delivery_cost'] = (float) $input['delivery_cost'];
+        }
+
+        $existing = $this->findByIdempotencyKey($idempotencyKey);
+        if ($existing instanceof msOrder) {
+            return $this->resumeOrReturnExisting($existing, $finalizeOptions);
+        }
+
+        $products = $input['products'] ?? null;
+        if (!is_array($products) || $products === []) {
+            return $this->error('ms3_order_err_products_required', ['products']);
+        }
+
+        try {
+            $order = $this->buildDraftGraph($input, $idempotencyKey, $origin, $products);
+        } catch (Throwable $e) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[ProgrammaticOrderService] Draft build failed: ' . $e->getMessage()
+            );
+
+            return $this->error('ms3_order_err_programmatic_create');
+        }
+
+        return $this->finalizeBuiltOrder($order, $finalizeOptions, 'ms3_order_programmatic_created');
+    }
+
+    /**
+     * @param array<string, mixed> $finalizeOptions
+     */
+    protected function resumeOrReturnExisting(msOrder $existing, array $finalizeOptions): array
+    {
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+        if ((int) $existing->get('status_id') === $statusDraft) {
+            return $this->finalizeBuiltOrder(
+                $existing,
+                $finalizeOptions,
+                'ms3_order_programmatic_created'
+            );
+        }
+
+        return $this->success('ms3_order_programmatic_idempotent', $this->resultPayload($existing));
+    }
+
+    /**
+     * @param array<string, mixed> $finalizeOptions
+     */
+    protected function finalizeBuiltOrder(msOrder $order, array $finalizeOptions, string $successMessage): array
+    {
+        $finalize = $this->finalizeService->finalize((int) $order->get('id'), $finalizeOptions);
+        if (!$finalize['success']) {
+            // Keep draft for idempotent resume; do not delete after mid-finalize failures.
+            return $finalize;
+        }
+
+        $reloaded = $this->modx->getObject(msOrder::class, (int) $order->get('id'));
+        if (!$reloaded instanceof msOrder) {
+            return $this->error('ms3_order_err_nf');
+        }
+
+        return $this->success($successMessage, $this->resultPayload($reloaded));
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param list<array<string, mixed>> $products
+     */
+    protected function buildDraftGraph(
+        array $input,
+        string $idempotencyKey,
+        string $origin,
+        array $products
+    ): msOrder {
+        $order = $this->draftManager->createSessionlessDraft([
+            'context' => $input['context'] ?? 'web',
+            'customer_id' => (int) ($input['customer_id'] ?? 0),
+            'delivery_id' => (int) ($input['delivery_id'] ?? 0),
+            'payment_id' => (int) ($input['payment_id'] ?? 0),
+            'delivery_cost' => (float) ($input['delivery_cost'] ?? 0),
+            'order_comment' => (string) ($input['order_comment'] ?? ''),
+            'idempotency_key' => $idempotencyKey,
+            'origin' => $origin,
+            'properties' => is_array($input['properties'] ?? null) ? $input['properties'] : [],
+        ]);
+
+        try {
+            $this->draftManager->fillAddressFromArray(
+                $order,
+                is_array($input['address'] ?? null) ? $input['address'] : []
+            );
+            foreach ($products as $snapshot) {
+                if (!is_array($snapshot)) {
+                    throw new \InvalidArgumentException('ms3_order_err_product_snapshot');
+                }
+                $this->draftManager->addProductFromSnapshot($order, $snapshot, $origin);
+            }
+            $this->draftManager->recalculate($order);
+        } catch (Throwable $e) {
+            $this->cleanupDraft($order);
+            throw $e;
+        }
+
+        return $order;
+    }
+
+    protected function findByIdempotencyKey(string $key): ?msOrder
+    {
+        /** @var msOrder|null $order */
+        $order = $this->modx->getObject(msOrder::class, [
+            'idempotency_key' => $key,
+        ]);
+
+        return $order instanceof msOrder ? $order : null;
+    }
+
+    /**
+     * @return array{order_id: int, uuid: string|null, num: string|null, status_id: int}
+     */
+    protected function resultPayload(msOrder $order): array
+    {
+        return [
+            'order_id' => (int) $order->get('id'),
+            'uuid' => $order->get('uuid'),
+            'num' => $order->get('num'),
+            'status_id' => (int) $order->get('status_id'),
+        ];
+    }
+
+    protected function cleanupDraft(msOrder $order): void
+    {
+        try {
+            if (!$this->draftManager->deleteDraft($order)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    '[ProgrammaticOrderService] deleteDraft returned false for #'
+                    . $order->get('id')
+                );
+            }
+        } catch (Throwable $e) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[ProgrammaticOrderService] Failed to cleanup draft #'
+                . $order->get('id')
+                . ': '
+                . $e->getMessage()
+            );
+        }
+    }
+
+    protected function success(string $message = '', array $data = []): array
+    {
+        return $this->ms3->utils->success($message, $data);
+    }
+
+    protected function error(string $message, array $data = []): array
+    {
+        return $this->ms3->utils->error($message, $data);
+    }
+}

--- a/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
@@ -317,7 +317,7 @@ final class ProgrammaticOrderServiceTest extends TestCase
                 return 0;
             }
 
-            public function lexicon($key, $params = [], $language = '')
+            public function lexicon(string $key, array $params = []): string
             {
                 return (string) $key;
             }
@@ -410,10 +410,17 @@ final class ProgrammaticOrderServiceTest extends TestCase
                             if (!empty($this->world['fail_product_save'])) {
                                 return false;
                             }
-                            $this->world['products'][] = $this->fields;
-                            $orderId = (int) ($this->fields['order_id'] ?? 0);
-                            if (isset($this->world['orders'][$orderId])) {
-                                $this->world['orders'][$orderId]->products[] = $this;
+                            // Assign id on first persist so RecordingMsOrder::save() skips re-saves.
+                            if (empty($this->fields['id'])) {
+                                $this->fields['id'] = $this->world['next_product_id']++;
+                                $this->world['products'][] = $this->fields;
+                                $orderId = (int) ($this->fields['order_id'] ?? 0);
+                                if (isset($this->world['orders'][$orderId])) {
+                                    $attached = $this->world['orders'][$orderId]->products;
+                                    if (!in_array($this, $attached, true)) {
+                                        $this->world['orders'][$orderId]->products[] = $this;
+                                    }
+                                }
                             }
 
                             return true;
@@ -595,6 +602,7 @@ final class ProgrammaticOrderServiceTest extends TestCase
     {
         return [
             'next_order_id' => 1,
+            'next_product_id' => 1,
             'orders' => [],
             'products' => [],
             'addresses' => [],

--- a/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
@@ -1,0 +1,604 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\Order;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderAddress;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\Order\OrderFinalizeService;
+use MiniShop3\Services\Order\OrderNumberGenerator;
+use MiniShop3\Services\Order\OrderService;
+use MiniShop3\Services\Order\ProgrammaticOrderService;
+use MiniShop3\Tests\RecordingMsOrder;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+/**
+ * Level-2: sessionless ProgrammaticOrderService (#507).
+ *
+ * CI has no MySQL; this suite covers idempotency, origin events, cleanup, and empty session.
+ */
+final class ProgrammaticOrderServiceTest extends TestCase
+{
+    /** @var list<array{name: string, params: array}> */
+    private array $events = [];
+
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
+        }
+        $this->events = [];
+        $_SESSION = [];
+    }
+
+    public function testCreateRequiresIdempotencyKey(): void
+    {
+        $service = $this->makeService();
+        $result = $service->create([
+            'products' => [['name' => 'Widget', 'price' => 10, 'count' => 1]],
+        ]);
+
+        self::assertFalse($result['success']);
+        self::assertSame('ms3_order_err_idempotency_key_required', $result['message']);
+    }
+
+    public function testCreateRequiresProducts(): void
+    {
+        $service = $this->makeService();
+        $result = $service->create([
+            'idempotency_key' => 'cycle-1',
+            'products' => [],
+        ]);
+
+        self::assertFalse($result['success']);
+        self::assertSame('ms3_order_err_products_required', $result['message']);
+    }
+
+    public function testIdempotentCreateReturnsSameOrderWithoutDuplicatingProducts(): void
+    {
+        $world = $this->makeWorld();
+        $service = $this->makeService($world);
+
+        $input = [
+            'idempotency_key' => 'cycle-42',
+            'origin' => 'integration',
+            'customer_id' => 7,
+            'delivery_id' => 3,
+            'payment_id' => 4,
+            'address' => ['email' => 'a@example.com'],
+            'products' => [
+                ['name' => 'Widget', 'price' => 50.0, 'count' => 2, 'weight' => 1.0],
+            ],
+            'skip_validation' => true,
+            'skip_notifications' => true,
+        ];
+
+        $first = $service->create($input);
+        self::assertTrue($first['success'], (string) ($first['message'] ?? ''));
+        self::assertSame(1, $first['data']['order_id']);
+        self::assertSame(2, $first['data']['status_id']);
+        self::assertCount(1, $world['products']);
+
+        $second = $service->create($input);
+        self::assertTrue($second['success']);
+        self::assertSame('ms3_order_programmatic_idempotent', $second['message']);
+        self::assertSame(1, $second['data']['order_id']);
+        self::assertCount(1, $world['products'], 'idempotent retry must not add products again');
+    }
+
+    public function testCreateWorksWithEmptySessionAndSetsIntegrationOrigin(): void
+    {
+        $_SESSION = [];
+        $world = $this->makeWorld();
+        $service = $this->makeService($world);
+
+        $result = $service->create([
+            'idempotency_key' => 'no-session',
+            'delivery_id' => 3,
+            'payment_id' => 4,
+            'products' => [
+                ['name' => 'Widget', 'price' => 10.0, 'count' => 1],
+            ],
+            'skip_validation' => true,
+            'skip_notifications' => true,
+        ]);
+
+        self::assertTrue($result['success'], (string) ($result['message'] ?? ''));
+        self::assertSame([], $_SESSION);
+
+        $createEvents = array_values(array_filter(
+            $this->events,
+            static fn(array $e): bool => in_array($e['name'], ['msOnBeforeCreateOrder', 'msOnCreateOrder'], true)
+        ));
+        self::assertNotEmpty($createEvents);
+        foreach ($createEvents as $event) {
+            self::assertSame('integration', $event['params']['origin'] ?? null);
+            self::assertFalse($event['params']['from_manager'] ?? true);
+        }
+
+        $mgrEvents = array_filter(
+            $this->events,
+            static fn(array $e): bool => str_contains($e['name'], 'MgrCreateOrder')
+        );
+        self::assertCount(0, $mgrEvents, 'integration must not fire manager-only events');
+    }
+
+    public function testIdempotentRetryResumesUnfinishedDraft(): void
+    {
+        $world = $this->makeWorld();
+        $service = $this->makeService($world);
+
+        $order = new RecordingMsOrder([
+            'id' => 9,
+            'status_id' => 1,
+            'delivery_id' => 3,
+            'payment_id' => 4,
+            'num' => null,
+            'uuid' => 'u-9',
+            'idempotency_key' => 'resume-me',
+            'properties' => ['idempotency_key' => 'resume-me'],
+            'cart_cost' => 10,
+            'delivery_cost' => 0,
+            'cost' => 10,
+            'weight' => 0,
+        ]);
+        $order->products = [
+            new class {
+                public function get(string $field): float|int
+                {
+                    return match ($field) {
+                        'cost' => 10.0,
+                        'weight' => 0.0,
+                        'count' => 1,
+                        default => 0,
+                    };
+                }
+            },
+        ];
+        $world['orders'][9] = $order;
+        $world['products'][] = ['order_id' => 9, 'name' => 'Widget', 'cost' => 10];
+        $world['next_order_id'] = 10;
+
+        $result = $service->create([
+            'idempotency_key' => 'resume-me',
+            'products' => [['name' => 'ignored', 'price' => 1, 'count' => 1]],
+            'skip_validation' => true,
+            'skip_notifications' => true,
+        ]);
+
+        self::assertTrue($result['success'], (string) ($result['message'] ?? ''));
+        self::assertSame('ms3_order_programmatic_created', $result['message']);
+        self::assertSame(9, $result['data']['order_id']);
+        self::assertSame(2, $result['data']['status_id']);
+        self::assertCount(1, $world['orders'], 'resume must not create a second order');
+    }
+
+    public function testProductFailureCleansPartialDraft(): void
+    {
+        $world = $this->makeWorld();
+        $world['fail_product_save'] = true;
+        $service = $this->makeService($world);
+
+        $result = $service->create([
+            'idempotency_key' => 'boom',
+            'delivery_id' => 3,
+            'payment_id' => 4,
+            'products' => [
+                ['name' => 'Widget', 'price' => 10.0, 'count' => 1],
+            ],
+            'skip_validation' => true,
+        ]);
+
+        self::assertFalse($result['success']);
+        self::assertSame([], $world['orders'], 'failed create must not leave draft order');
+        self::assertSame([], $world['products']);
+        self::assertSame([], $world['addresses']);
+    }
+
+    /**
+     * @param array<string, mixed>|null $world
+     */
+    private function makeService(?array &$world = null): ProgrammaticOrderService
+    {
+        $world ??= $this->makeWorld();
+        $events = &$this->events;
+
+        $utils = new class ($events) {
+            /** @param list<array{name: string, params: array}> $events */
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function success(string $message = '', array $data = [], array $placeholders = []): array
+            {
+                return ['success' => true, 'message' => $message, 'data' => $data];
+            }
+
+            public function error(string $message = '', array $data = [], array $placeholders = []): array
+            {
+                return ['success' => false, 'message' => $message, 'data' => $data];
+            }
+
+            public function invokeEvent(string $eventName, array $params = []): array
+            {
+                $this->events[] = ['name' => $eventName, 'params' => $params];
+
+                return ['success' => true, 'message' => '', 'data' => $params];
+            }
+        };
+
+        $ms3 = $this->createStub(MiniShop3::class);
+        $ms3->utils = $utils;
+
+        $orderService = new OrderService(new modX());
+        $statusCalls = [];
+        $statusService = new class ($statusCalls, $world) {
+            public function __construct(private array &$statusCalls, private array &$world)
+            {
+            }
+
+            public function change(int $orderId, int $statusId, bool $writeLog = true): true|string
+            {
+                $this->statusCalls[] = compact('orderId', 'statusId', 'writeLog');
+                if (isset($this->world['orders'][$orderId])) {
+                    $this->world['orders'][$orderId]->set('status_id', $statusId);
+                }
+
+                return true;
+            }
+        };
+
+        $delivery = $this->createStub(\MiniShop3\Model\msDelivery::class);
+        $delivery->method('get')->willReturnCallback(static function (string $k) {
+            return match ($k) {
+                'price' => 0.0,
+                'weight_price' => 0.0,
+                'active' => 1,
+                'validation_rules' => null,
+                default => null,
+            };
+        });
+        $payment = $this->createStub(\MiniShop3\Model\msPayment::class);
+        $payment->method('get')->willReturnCallback(static fn(string $k) => $k === 'active' ? 1 : null);
+
+        $modx = new class ($world, $orderService, $statusService, $delivery, $payment) extends modX {
+            public function __construct(
+                public array &$world,
+                OrderService $orderService,
+                object $statusService,
+                private object $delivery,
+                private object $payment,
+            ) {
+                parent::__construct();
+                $this->services = new class ($orderService, $statusService) {
+                    public function __construct(
+                        private OrderService $orderService,
+                        private object $statusService,
+                    ) {
+                    }
+
+                    public function has(string $key): bool
+                    {
+                        return in_array($key, ['ms3_order_service', 'ms3_order_status', 'ms3_delivery_service'], true);
+                    }
+
+                    public function get(string $key): mixed
+                    {
+                        return match ($key) {
+                            'ms3_order_service' => $this->orderService,
+                            'ms3_order_status' => $this->statusService,
+                            'ms3_delivery_service' => new class {
+                                public function getDeliveryPaymentPairError(int $d, int $p): ?string
+                                {
+                                    return null;
+                                }
+                            },
+                            default => null,
+                        };
+                    }
+                };
+            }
+
+            public function getOption($key, $options = null, $default = null, $skipEmpty = false)
+            {
+                return match ((string) $key) {
+                    'ms3_status_draft' => 1,
+                    'ms3_status_new' => 2,
+                    default => $default,
+                };
+            }
+
+            public function getLoginUserID($context = '')
+            {
+                return 0;
+            }
+
+            public function lexicon(string $key, array $params = []): string
+            {
+                return (string) $key;
+            }
+
+            public function log($level, $message): void
+            {
+            }
+
+            public function newObject($className, $fields = [])
+            {
+                if ($className === msOrder::class) {
+                    $id = $this->world['next_order_id']++;
+                    $order = new RecordingMsOrder(array_merge([
+                        'id' => $id,
+                        'status_id' => 1,
+                        'properties' => [],
+                        'num' => null,
+                        'uuid' => null,
+                        'cart_cost' => 0,
+                        'delivery_cost' => 0,
+                        'cost' => 0,
+                        'weight' => 0,
+                    ], is_array($fields) ? $fields : []));
+                    $order->set('id', $id);
+                    $this->world['orders'][$id] = $order;
+
+                    return $order;
+                }
+
+                if ($className === msOrderAddress::class) {
+                    $address = new class ($this->world) {
+                        /** @var array<string, mixed> */
+                        private array $fields = [];
+
+                        public function __construct(private array &$world)
+                        {
+                        }
+
+                        public function set($k, $v)
+                        {
+                            $this->fields[$k] = $v;
+
+                            return true;
+                        }
+
+                        public function get($k)
+                        {
+                            return $this->fields[$k] ?? null;
+                        }
+
+                        public function save($cacheFlag = null): bool
+                        {
+                            $this->world['addresses'][] = $this->fields;
+
+                            return true;
+                        }
+
+                        public function remove(): bool
+                        {
+                            return true;
+                        }
+                    };
+
+                    return $address;
+                }
+
+                if ($className === msOrderProduct::class) {
+                    $product = new class ($this->world) {
+                        /** @var array<string, mixed> */
+                        private array $fields = [];
+
+                        public function __construct(private array &$world)
+                        {
+                        }
+
+                        public function set($k, $v)
+                        {
+                            $this->fields[$k] = $v;
+
+                            return true;
+                        }
+
+                        public function get($k)
+                        {
+                            return $this->fields[$k] ?? null;
+                        }
+
+                        public function save($cacheFlag = null): bool
+                        {
+                            if (!empty($this->world['fail_product_save'])) {
+                                return false;
+                            }
+                            $this->world['products'][] = $this->fields;
+                            $orderId = (int) ($this->fields['order_id'] ?? 0);
+                            if (isset($this->world['orders'][$orderId])) {
+                                $this->world['orders'][$orderId]->products[] = $this;
+                            }
+
+                            return true;
+                        }
+
+                        public function remove(): bool
+                        {
+                            $this->world['products'] = array_values(array_filter(
+                                $this->world['products'],
+                                fn(array $row): bool => ($row['order_id'] ?? null) !== ($this->fields['order_id'] ?? null)
+                                    || ($row['name'] ?? null) !== ($this->fields['name'] ?? null)
+                            ));
+
+                            return true;
+                        }
+                    };
+
+                    return $product;
+                }
+
+                return parent::newObject($className, $fields);
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className === msOrder::class) {
+                    if (is_array($criteria) && isset($criteria['idempotency_key'])) {
+                        $key = (string) $criteria['idempotency_key'];
+                        foreach ($this->world['orders'] as $order) {
+                            if ((string) $order->get('idempotency_key') === $key) {
+                                return $order;
+                            }
+                        }
+
+                        return null;
+                    }
+
+                    $id = is_array($criteria) ? (int) ($criteria['id'] ?? 0) : (int) $criteria;
+
+                    return $this->world['orders'][$id] ?? null;
+                }
+
+                if ($className === \MiniShop3\Model\msDelivery::class) {
+                    return $this->delivery;
+                }
+                if ($className === \MiniShop3\Model\msPayment::class) {
+                    return $this->payment;
+                }
+
+                return null;
+            }
+
+            public function getCollection($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className === msOrder::class) {
+                    return $this->world['orders'];
+                }
+
+                return [];
+            }
+
+            public function getCount($className, $criteria = null)
+            {
+                if ($className === msOrderProduct::class) {
+                    $orderId = is_array($criteria) ? (int) ($criteria['order_id'] ?? 0) : 0;
+
+                    return count(array_filter(
+                        $this->world['products'],
+                        static fn(array $row): bool => (int) ($row['order_id'] ?? 0) === $orderId
+                    ));
+                }
+
+                return 0;
+            }
+
+            public function getIterator($className, $criteria = null, $cacheFlag = true): \ArrayIterator
+            {
+                if ($className === msOrderProduct::class) {
+                    $orderId = is_array($criteria) ? (int) ($criteria['order_id'] ?? 0) : 0;
+                    $rows = array_filter(
+                        $this->world['products'],
+                        static fn(array $row): bool => $orderId === 0 || (int) ($row['order_id'] ?? 0) === $orderId
+                    );
+
+                    return new \ArrayIterator(array_map(static function (array $row) {
+                        return new class ($row) {
+                            public function __construct(private array $row)
+                            {
+                            }
+
+                            public function get(string $field): mixed
+                            {
+                                return $this->row[$field] ?? null;
+                            }
+                        };
+                    }, $rows));
+                }
+
+                return new \ArrayIterator([]);
+            }
+
+            public function newQuery($className, $criteria = null, $cacheFlag = true)
+            {
+                return new class {
+                    public function where($criteria, $conjunction = 'AND'): self
+                    {
+                        return $this;
+                    }
+
+                    public function sortby($column, $direction = 'ASC'): self
+                    {
+                        return $this;
+                    }
+
+                    public function limit($limit, $offset = 0): self
+                    {
+                        return $this;
+                    }
+                };
+            }
+        };
+
+        $numberGenerator = $this->createStub(OrderNumberGenerator::class);
+        $numberGenerator->method('runWithNextNumber')->willReturnCallback(
+            static function (callable $persist): string {
+                $persist('2501/7');
+
+                return '2501/7';
+            }
+        );
+
+        $finalize = new OrderFinalizeService($modx, $ms3, $numberGenerator);
+
+        $draftManager = new class ($modx, $ms3, $world) extends OrderDraftManager {
+            public function __construct(
+                modX $modx,
+                MiniShop3 $ms3,
+                private array &$world,
+            ) {
+                parent::__construct($modx, $ms3);
+            }
+
+            public function recalculate(msOrder $draft): void
+            {
+                $totals = OrderService::aggregateProductsTotals($draft->getMany('Products') ?? []);
+                $draft->set('cart_cost', $totals['cart_cost']);
+                $draft->set('weight', $totals['weight']);
+                $draft->set(
+                    'cost',
+                    (float) $totals['cart_cost'] + (float) $draft->get('delivery_cost')
+                );
+                $draft->save();
+            }
+
+            public function deleteDraft(msOrder $draft): bool
+            {
+                $id = (int) $draft->get('id');
+                unset($this->world['orders'][$id]);
+                $this->world['products'] = array_values(array_filter(
+                    $this->world['products'],
+                    static fn(array $row): bool => (int) ($row['order_id'] ?? 0) !== $id
+                ));
+                $this->world['addresses'] = array_values(array_filter(
+                    $this->world['addresses'],
+                    static fn(array $row): bool => (int) ($row['order_id'] ?? 0) !== $id
+                ));
+
+                return true;
+            }
+        };
+
+        return new ProgrammaticOrderService($modx, $ms3, $finalize, $draftManager);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function makeWorld(): array
+    {
+        return [
+            'next_order_id' => 1,
+            'orders' => [],
+            'products' => [],
+            'addresses' => [],
+            'fail_product_save' => false,
+        ];
+    }
+}

--- a/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
+++ b/core/components/minishop3/tests/Integration/Order/ProgrammaticOrderServiceTest.php
@@ -317,7 +317,7 @@ final class ProgrammaticOrderServiceTest extends TestCase
                 return 0;
             }
 
-            public function lexicon(string $key, array $params = []): string
+            public function lexicon($key, $params = [], $language = '')
             {
                 return (string) $key;
             }

--- a/core/components/minishop3/tests/Integration/Product/ProductDataPayloadTraitTest.php
+++ b/core/components/minishop3/tests/Integration/Product/ProductDataPayloadTraitTest.php
@@ -64,6 +64,8 @@ final class ProductDataPayloadTraitTest extends TestCase
     private function xpdoWithoutMs3(): xPDO
     {
         return new class extends xPDO {
+            /** @var object|null */
+            public $services;
 
             public function __construct()
             {
@@ -125,6 +127,8 @@ final class PayloadHarness
         $this->properties = $properties;
         $this->object = $object ?? new LightweightProduct(
             new RecordingProductData(new class extends xPDO {
+                /** @var object|null */
+                public $services;
 
                 public function __construct()
                 {

--- a/core/components/minishop3/tests/Integration/Product/UpdateProductDataPermissionsTest.php
+++ b/core/components/minishop3/tests/Integration/Product/UpdateProductDataPermissionsTest.php
@@ -130,6 +130,8 @@ final class UpdateProductDataPermissionsTest extends TestCase
     private function xpdo(): xPDO
     {
         return new class extends xPDO {
+            /** @var object|null */
+            public $services;
 
             public function __construct()
             {


### PR DESCRIPTION
## Описание

Extras и cron создают и финализируют обычный `msOrder` через DI-сервис `ms3_programmatic_order` (`ProgrammaticOrderService`): без storefront session, cart token, manager HTTP и payment redirect.

`OrderDraftManager` собирает draft, address и products (sessionless helpers). `OrderFinalizeService` финализирует с `origin=integration` и не ставит `from_manager=true`. Идемпотентность держит UNIQUE-колонка `ms3_orders.idempotency_key` (migration).

HTTP endpoint в этот PR не входит. Вызов идёт из PHP Extra / cron через `ServiceRegistry`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #507

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php
# exit 0 — php -l, smoke 41 OK, PHPUnit 115 OK, без deprecations

./vendor/bin/phpunit tests/Integration/Order/ProgrammaticOrderServiceTest.php \
  tests/Integration/Order/OrderFinalizeServiceTest.php
# exit 0 — 10 tests

composer stan
# exit 0
```

Level-2 stub suite закрывает AC по idempotency, empty session, cleanup и origin. UNIQUE `idempotency_key` проверяет migration. Concurrent create под MySQL — follow-up.

CI на head (`7039a10`): PHP lint + smoke, PHPStan, vueManager lint — green.

- [x] Автоматические тесты (`composer ci:php` / `composer stan` / GitHub Actions CI)
- [ ] Ручное тестирование на установленном MODX
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-507-programmatic-order`
- MODX: n/a (Level-2 stubs)
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Storefront submit / manager finalize без смены default-поведения (`origin` default = manager)
- [x] Лексиконы ru+en (`order.inc.php`)
- [x] PHPStan проходит без новых ошибок (CI job `PHPStan`)
- [x] ESLint n/a
- [ ] CHANGELOG.md — на релизе maintainer

## Дополнительные заметки

### Контракт

```php
$modx->services->get('ms3_programmatic_order')->create([
    'idempotency_key' => $cycleUuid,
    'origin' => 'integration',
    'context' => 'web',
    'customer_id' => $customerId,
    'delivery_id' => $deliveryId,
    'payment_id' => $paymentId,
    'delivery_cost' => 0, // optional → finalize cost MODE_MANUAL
    'address' => [...],
    'products' => [['product_id' => 1, 'count' => 2] /* or name+price */],
    'properties' => ['source' => 'mssubscription'],
    'skip_notifications' => true,
]);
// → order_id, uuid, num, status_id
```

### AC #507

| Критерий | Статус |
|----------|--------|
| Повтор с тем же key → тот же order, без дубля products | Level-2 + UNIQUE column |
| Пустой `$_SESSION`, без cart | Level-2 |
| Ошибка address/products → cleanup draft | Level-2 |
| Cost/number/status через канонику | `OrderFinalizeService` / recalculator / number / status |
| Events `origin=integration`, не Mgr* | Level-2 |
| `ServiceRegistry` | `ms3_programmatic_order` |
| Storefront/manager BC | default finalize origin=manager |

### Follow-up

- MySQL integration / concurrent create under load
- После merge: `phinx migrate` на стендах
