### PR TITLE
refactor(mgr-api): общий CRUD deliveries ↔ payments

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/DeliveriesController.php
@@ -3,19 +3,13 @@
 namespace MiniShop3\Controllers\Api\Manager;
 
 use MiniShop3\Model\msDelivery;
-use MiniShop3\Model\msDeliveryMember;
-use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
-use MiniShop3\Services\Grid\ManagerListFilterPolicy;
-use MiniShop3\Utils\PriceAdjustment;
+use MiniShop3\Services\Reference\Ms3ReferenceCrudService;
+use MiniShop3\Services\Reference\ReferenceResourceConfig;
 use MODX\Revolution\modX;
 
 /**
- * API controller for delivery management (Manager API)
- *
- * Handles CRUD operations for deliveries in admin panel.
- *
- * @package MiniShop3\Controllers\Api\Manager
+ * Manager API: deliveries CRUD + payment links (thin HTTP mapping).
  */
 class DeliveriesController
 {
@@ -33,10 +27,12 @@ class DeliveriesController
     ];
 
     protected modX $modx;
+    protected Ms3ReferenceCrudService $crud;
 
-    public function __construct(modX $modx)
+    public function __construct(modX $modx, ?Ms3ReferenceCrudService $crud = null)
     {
         $this->modx = $modx;
+        $this->crud = $crud ?? new Ms3ReferenceCrudService($modx, ReferenceResourceConfig::forDeliveries());
     }
 
     /**
@@ -69,356 +65,59 @@ class DeliveriesController
         return array_intersect_key($data, array_flip(self::ACTIVE_DROPDOWN_FIELDS));
     }
 
-    /**
-     * Get list of deliveries with pagination and search
-     * GET /api/mgr/deliveries
-     *
-     * @param array $params URL parameters (start, limit, query)
-     * @return array Response
-     */
     public function getList(array $params = []): array
     {
-        $start = (int)($params['start'] ?? 0);
-        $limit = (int)($params['limit'] ?? 20);
-        $query = trim($params['query'] ?? '');
-
-        $gridConfig = $this->modx->services->get('ms3_grid_config');
-        $gridFields = $gridConfig ? $gridConfig->getGridConfig('deliveries') : [];
-
-        $criteria = [];
-
-        if (!empty($query)) {
-            $criteria[] = [
-                'name:LIKE' => "%{$query}%",
-                'OR:description:LIKE' => "%{$query}%",
-            ];
-        }
-
-        // Filter by active status
-        foreach ($params as $key => $value) {
-            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
-                $fieldName = substr($key, 7);
-                ManagerListFilterPolicy::applyCriteriaFilter(
-                    $criteria,
-                    $fieldName,
-                    $value,
-                    ManagerListFilterPolicy::DELIVERY_FILTER_MAP
-                );
-            }
-        }
-
-        $total = $this->modx->getCount(msDelivery::class, $criteria);
-
-        $q = $this->modx->newQuery(msDelivery::class, $criteria);
-        $q->limit($limit, $start);
-        $q->sortby('position', 'ASC');
-
-        $results = [];
-        foreach ($this->modx->getIterator(msDelivery::class, $q) as $delivery) {
-            $results[] = $this->formatDelivery($delivery);
-        }
-
-        return Response::success([
-            'results' => $results,
-            'total' => $total
-        ])->getData();
+        return $this->crud->getList($params);
     }
 
-    /**
-     * Get specific delivery
-     * GET /api/mgr/deliveries/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
     public function get(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Delivery ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $delivery = $this->modx->getObject(msDelivery::class, $id);
-
-        if (!$delivery) {
-            return Response::error('Delivery not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        $data = $this->formatDelivery($delivery);
-
-        // Add payments for this delivery
-        $payments = [];
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['delivery_id' => $id]) as $member) {
-            $payments[] = $member->get('payment_id');
-        }
-        $data['payments'] = $payments;
-
-        return Response::success($data)->getData();
+        return $this->crud->get($params);
     }
 
-    /**
-     * Create new delivery
-     * POST /api/mgr/deliveries
-     *
-     * @param array $data Request data
-     * @return array Response
-     */
     public function create(array $data = []): array
     {
-        if (empty($data['name'])) {
-            return Response::error('Delivery name is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $delivery = $this->modx->newObject(msDelivery::class);
-
-        $allowedFields = ['name', 'description', 'price', 'weight_price', 'distance_price',
-                          'logo', 'position', 'active', 'class', 'properties',
-                          'validation_rules', 'free_delivery_amount'];
-
-        foreach ($allowedFields as $field) {
-            if (array_key_exists($field, $data)) {
-                $delivery->set($field, $this->prepareFieldValue($field, $data[$field]));
-            }
-        }
-
-        // Set defaults
-        if (!isset($data['position'])) {
-            $maxPosition = 0;
-            $last = $this->modx->getObject(msDelivery::class, [], ['sortby' => 'position', 'sortdir' => 'DESC', 'limit' => 1]);
-            if ($last) {
-                $maxPosition = (int)$last->get('position');
-            }
-            $delivery->set('position', $maxPosition + 1);
-        }
-
-        if (!$delivery->save()) {
-            return Response::error('Failed to create delivery', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        // Handle payments assignment
-        if (isset($data['payments']) && is_array($data['payments'])) {
-            $this->updateDeliveryPayments($delivery->get('id'), $data['payments']);
-        }
-
-        return Response::success($this->formatDelivery($delivery), 'Delivery created successfully')->getData();
+        return $this->crud->create($data);
     }
 
-    /**
-     * Update delivery
-     * PUT /api/mgr/deliveries/{id}
-     *
-     * @param array $data Update data
-     * @return array Response
-     */
     public function update(array $data = []): array
     {
-        $id = (int)($data['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Delivery ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $delivery = $this->modx->getObject(msDelivery::class, $id);
-
-        if (!$delivery) {
-            return Response::error('Delivery not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        $allowedFields = ['name', 'description', 'price', 'weight_price', 'distance_price',
-                          'logo', 'position', 'active', 'class', 'properties',
-                          'validation_rules', 'free_delivery_amount'];
-
-        foreach ($allowedFields as $field) {
-            if (array_key_exists($field, $data)) {
-                $delivery->set($field, $this->prepareFieldValue($field, $data[$field]));
-            }
-        }
-
-        if (!$delivery->save()) {
-            return Response::error('Failed to save delivery', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        // Handle payments assignment
-        if (isset($data['payments']) && is_array($data['payments'])) {
-            $this->updateDeliveryPayments($id, $data['payments']);
-        }
-
-        return Response::success($this->formatDelivery($delivery), 'Delivery updated successfully')->getData();
+        return $this->crud->update($data);
     }
 
-    /**
-     * Delete delivery
-     * DELETE /api/mgr/deliveries/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
     public function delete(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Delivery ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $delivery = $this->modx->getObject(msDelivery::class, $id);
-
-        if (!$delivery) {
-            return Response::error('Delivery not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        // Delete related payment members
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['delivery_id' => $id]) as $member) {
-            $member->remove();
-        }
-
-        if (!$delivery->remove()) {
-            return Response::error('Failed to delete delivery', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Delivery deleted successfully')->getData();
+        return $this->crud->delete($params);
     }
 
-    /**
-     * Reorder deliveries (drag-drop sort)
-     * POST /api/mgr/deliveries/sort
-     *
-     * @param array $data Request data (ids - array of delivery IDs in new order)
-     * @return array Response
-     */
     public function sort(array $data = []): array
     {
-        $ids = $data['ids'] ?? [];
-
-        if (empty($ids) || !is_array($ids)) {
-            return Response::error('Delivery IDs array is required for sorting', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $position = 0;
-        foreach ($ids as $id) {
-            $id = (int)$id;
-            if ($id > 0) {
-                $delivery = $this->modx->getObject(msDelivery::class, $id);
-                if ($delivery) {
-                    $delivery->set('position', $position);
-                    $delivery->save();
-                    $position++;
-                }
-            }
-        }
-
-        return Response::success([], 'Deliveries reordered successfully')->getData();
+        return $this->crud->sort($data);
     }
 
-    /**
-     * Bulk delete deliveries
-     * DELETE /api/mgr/deliveries/bulk
-     *
-     * @param array $data Request data (ids)
-     * @return array Response
-     */
     public function bulkDelete(array $data = []): array
     {
-        $ids = $data['ids'] ?? [];
-
-        if (empty($ids) || !is_array($ids)) {
-            return Response::error('Delivery IDs array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $ids = array_filter(array_map('intval', $ids), function ($id) {
-            return $id > 0;
-        });
-
-        if (empty($ids)) {
-            return Response::error('No valid delivery IDs provided', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $deleted = 0;
-        $failed = 0;
-
-        foreach ($ids as $id) {
-            $delivery = $this->modx->getObject(msDelivery::class, $id);
-
-            if (!$delivery) {
-                $failed++;
-                continue;
-            }
-
-            // Delete related payment members
-            foreach ($this->modx->getIterator(msDeliveryMember::class, ['delivery_id' => $id]) as $member) {
-                $member->remove();
-            }
-
-            if ($delivery->remove()) {
-                $deleted++;
-            } else {
-                $failed++;
-            }
-        }
-
-        if ($deleted === 0) {
-            return Response::error('Failed to delete deliveries', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([
-            'deleted' => $deleted,
-            'failed' => $failed
-        ], "Deleted {$deleted} deliveries")->getData();
+        return $this->crud->bulkDelete($data);
     }
 
-    /**
-     * Update positions (drag-n-drop reorder)
-     * PUT /api/mgr/deliveries/positions
-     *
-     * @param array $data Request data (positions: [id => position])
-     * @return array Response
-     */
     public function updatePositions(array $data = []): array
     {
-        $positions = $data['positions'] ?? [];
-
-        if (empty($positions) || !is_array($positions)) {
-            return Response::error('Positions array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $updated = 0;
-        foreach ($positions as $id => $position) {
-            $delivery = $this->modx->getObject(msDelivery::class, (int)$id);
-            if ($delivery) {
-                $delivery->set('position', (int)$position);
-                if ($delivery->save()) {
-                    $updated++;
-                }
-            }
-        }
-
-        return Response::success(['updated' => $updated], "Updated {$updated} positions")->getData();
+        return $this->crud->updatePositions($data);
     }
 
-    /**
-     * Format delivery object for API response
-     *
-     * @param msDelivery $delivery
-     * @return array
-     */
-    protected function formatDelivery(msDelivery $delivery): array
+    public function getPayments(array $params = []): array
     {
-        return [
-            'id' => $delivery->get('id'),
-            'name' => $delivery->get('name'),
-            'description' => $delivery->get('description'),
-            'price' => $delivery->get('price'),
-            'weight_price' => (float)$delivery->get('weight_price'),
-            'distance_price' => (float)$delivery->get('distance_price'),
-            'logo' => $delivery->get('logo'),
-            'position' => (int)$delivery->get('position'),
-            'active' => (bool)$delivery->get('active'),
-            'class' => $delivery->get('class'),
-            'properties' => $delivery->get('properties'),
-            'validation_rules' => $delivery->get('validation_rules'),
-            'free_delivery_amount' => (float)$delivery->get('free_delivery_amount'),
-        ];
+        return $this->crud->listLinks($params);
+    }
+
+    public function addPayment(array $data = []): array
+    {
+        return $this->crud->addLink($data);
+    }
+
+    public function removePayment(array $params = []): array
+    {
+        return $this->crud->removeLink($params);
     }
 
     /**
@@ -445,127 +144,5 @@ class DeliveriesController
         }
 
         return $data;
-    }
-
-    /**
-     * Get payments for specific delivery
-     * GET /api/mgr/deliveries/{id}/payments
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
-    public function getPayments(array $params = []): array
-    {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Delivery ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $results = [];
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['delivery_id' => $id]) as $member) {
-            $results[] = [
-                'delivery_id' => $member->get('delivery_id'),
-                'payment_id' => $member->get('payment_id'),
-            ];
-        }
-
-        return Response::success(['results' => $results])->getData();
-    }
-
-    /**
-     * Add payment to delivery
-     * POST /api/mgr/deliveries/{id}/payments
-     *
-     * @param array $data Request data (delivery_id, payment_id)
-     * @return array Response
-     */
-    public function addPayment(array $data = []): array
-    {
-        $deliveryId = (int)($data['delivery_id'] ?? 0);
-        $paymentId = (int)($data['payment_id'] ?? 0);
-
-        if (!$deliveryId || !$paymentId) {
-            return Response::error('Delivery ID and Payment ID are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Check if relationship already exists
-        $existing = $this->modx->getObject(msDeliveryMember::class, [
-            'delivery_id' => $deliveryId,
-            'payment_id' => $paymentId
-        ]);
-
-        if ($existing) {
-            return Response::success([], 'Payment already linked to delivery')->getData();
-        }
-
-        $member = $this->modx->newObject(msDeliveryMember::class);
-        $member->set('delivery_id', $deliveryId);
-        $member->set('payment_id', $paymentId);
-
-        if (!$member->save()) {
-            return Response::error('Failed to add payment to delivery', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Payment added to delivery')->getData();
-    }
-
-    /**
-     * Remove payment from delivery
-     * DELETE /api/mgr/deliveries/{id}/payments/{payment_id}
-     *
-     * @param array $params URL parameters (id, payment_id)
-     * @return array Response
-     */
-    public function removePayment(array $params = []): array
-    {
-        $deliveryId = (int)($params['id'] ?? 0);
-        $paymentId = (int)($params['payment_id'] ?? 0);
-
-        if (!$deliveryId || !$paymentId) {
-            return Response::error('Delivery ID and Payment ID are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $member = $this->modx->getObject(msDeliveryMember::class, [
-            'delivery_id' => $deliveryId,
-            'payment_id' => $paymentId
-        ]);
-
-        if (!$member) {
-            return Response::error('Payment link not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        if (!$member->remove()) {
-            return Response::error('Failed to remove payment from delivery', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Payment removed from delivery')->getData();
-    }
-
-    /**
-     * Update delivery-payment relationships
-     *
-     * @param int $deliveryId
-     * @param array $paymentIds
-     */
-    protected function updateDeliveryPayments(int $deliveryId, array $paymentIds): void
-    {
-        // Remove existing relationships
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['delivery_id' => $deliveryId]) as $member) {
-            $member->remove();
-        }
-
-        // Add new relationships
-        foreach ($paymentIds as $paymentId) {
-            $member = $this->modx->newObject(msDeliveryMember::class);
-            $member->set('delivery_id', $deliveryId);
-            $member->set('payment_id', (int)$paymentId);
-            $member->save();
-        }
-    }
-
-    protected function prepareFieldValue(string $field, $value)
-    {
-        return $field === 'price' ? PriceAdjustment::normalize($value) : $value;
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/PaymentsController.php
@@ -2,457 +2,74 @@
 
 namespace MiniShop3\Controllers\Api\Manager;
 
-use MiniShop3\Model\msPayment;
-use MiniShop3\Model\msDeliveryMember;
-use MiniShop3\Router\HttpStatus;
-use MiniShop3\Router\Response;
-use MiniShop3\Services\Grid\ManagerListFilterPolicy;
-use MiniShop3\Utils\PriceAdjustment;
+use MiniShop3\Services\Reference\Ms3ReferenceCrudService;
+use MiniShop3\Services\Reference\ReferenceResourceConfig;
 use MODX\Revolution\modX;
 
 /**
- * API controller for payment management (Manager API)
- *
- * Handles CRUD operations for payments in admin panel.
- *
- * @package MiniShop3\Controllers\Api\Manager
+ * Manager API: payments CRUD + delivery links (thin HTTP mapping).
  */
 class PaymentsController
 {
-    protected modX $modx;
+    protected Ms3ReferenceCrudService $crud;
 
-    public function __construct(modX $modx)
+    public function __construct(modX $modx, ?Ms3ReferenceCrudService $crud = null)
     {
-        $this->modx = $modx;
+        $this->crud = $crud ?? new Ms3ReferenceCrudService($modx, ReferenceResourceConfig::forPayments());
     }
 
-    /**
-     * Get list of payments with pagination and search
-     * GET /api/mgr/payments
-     *
-     * @param array $params URL parameters (start, limit, query)
-     * @return array Response
-     */
     public function getList(array $params = []): array
     {
-        $start = (int)($params['start'] ?? 0);
-        $limit = (int)($params['limit'] ?? 20);
-        $query = trim($params['query'] ?? '');
-
-        // If limit=0, return all payments (for delivery settings)
-        $returnAll = $limit === 0;
-
-        $criteria = [];
-
-        if (!empty($query)) {
-            $criteria[] = [
-                'name:LIKE' => "%{$query}%",
-                'OR:description:LIKE' => "%{$query}%",
-            ];
-        }
-
-        // Filter by active status
-        foreach ($params as $key => $value) {
-            if (str_starts_with($key, 'filter_') && $value !== '' && $value !== null) {
-                $fieldName = substr($key, 7);
-                ManagerListFilterPolicy::applyCriteriaFilter(
-                    $criteria,
-                    $fieldName,
-                    $value,
-                    ManagerListFilterPolicy::PAYMENT_FILTER_MAP
-                );
-            }
-        }
-
-        $total = $this->modx->getCount(msPayment::class, $criteria);
-
-        $q = $this->modx->newQuery(msPayment::class, $criteria);
-        if (!$returnAll) {
-            $q->limit($limit, $start);
-        }
-        $q->sortby('position', 'ASC');
-
-        $results = [];
-        foreach ($this->modx->getIterator(msPayment::class, $q) as $payment) {
-            $results[] = $this->formatPayment($payment);
-        }
-
-        return Response::success([
-            'results' => $results,
-            'total' => $total
-        ])->getData();
+        return $this->crud->getList($params);
     }
 
-    /**
-     * Get specific payment
-     * GET /api/mgr/payments/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
     public function get(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Payment ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $payment = $this->modx->getObject(msPayment::class, $id);
-
-        if (!$payment) {
-            return Response::error('Payment not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        return Response::success($this->formatPayment($payment))->getData();
+        return $this->crud->get($params);
     }
 
-    /**
-     * Create new payment
-     * POST /api/mgr/payments
-     *
-     * @param array $data Request data
-     * @return array Response
-     */
     public function create(array $data = []): array
     {
-        if (empty($data['name'])) {
-            return Response::error('Payment name is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $payment = $this->modx->newObject(msPayment::class);
-
-        $allowedFields = ['name', 'description', 'price', 'logo', 'position', 'active', 'class', 'properties'];
-
-        foreach ($allowedFields as $field) {
-            if (array_key_exists($field, $data)) {
-                $payment->set($field, $this->prepareFieldValue($field, $data[$field]));
-            }
-        }
-
-        // Set defaults
-        if (!isset($data['position'])) {
-            $maxPosition = 0;
-            $q = $this->modx->newQuery(msPayment::class);
-            $q->sortby('position', 'DESC');
-            $q->limit(1);
-            $last = $this->modx->getObject(msPayment::class, $q);
-            if ($last) {
-                $maxPosition = (int)$last->get('position');
-            }
-            $payment->set('position', $maxPosition + 1);
-        }
-
-        if (!$payment->save()) {
-            return Response::error('Failed to create payment', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success($this->formatPayment($payment), 'Payment created successfully')->getData();
+        return $this->crud->create($data);
     }
 
-    /**
-     * Update payment
-     * PUT /api/mgr/payments/{id}
-     *
-     * @param array $data Update data
-     * @return array Response
-     */
     public function update(array $data = []): array
     {
-        $id = (int)($data['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Payment ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $payment = $this->modx->getObject(msPayment::class, $id);
-
-        if (!$payment) {
-            return Response::error('Payment not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        $allowedFields = ['name', 'description', 'price', 'logo', 'position', 'active', 'class', 'properties'];
-
-        foreach ($allowedFields as $field) {
-            if (array_key_exists($field, $data)) {
-                $payment->set($field, $this->prepareFieldValue($field, $data[$field]));
-            }
-        }
-
-        if (!$payment->save()) {
-            return Response::error('Failed to save payment', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success($this->formatPayment($payment), 'Payment updated successfully')->getData();
+        return $this->crud->update($data);
     }
 
-    /**
-     * Delete payment
-     * DELETE /api/mgr/payments/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
     public function delete(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Payment ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $payment = $this->modx->getObject(msPayment::class, $id);
-
-        if (!$payment) {
-            return Response::error('Payment not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        // Delete related delivery members
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['payment_id' => $id]) as $member) {
-            $member->remove();
-        }
-
-        if (!$payment->remove()) {
-            return Response::error('Failed to delete payment', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Payment deleted successfully')->getData();
+        return $this->crud->delete($params);
     }
 
-    /**
-     * Reorder payments (drag-drop sort)
-     * POST /api/mgr/payments/sort
-     *
-     * @param array $data Request data (ids - array of payment IDs in new order)
-     * @return array Response
-     */
     public function sort(array $data = []): array
     {
-        $ids = $data['ids'] ?? [];
-
-        if (empty($ids) || !is_array($ids)) {
-            return Response::error('Payment IDs array is required for sorting', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $position = 0;
-        foreach ($ids as $id) {
-            $id = (int)$id;
-            if ($id > 0) {
-                $payment = $this->modx->getObject(msPayment::class, $id);
-                if ($payment) {
-                    $payment->set('position', $position);
-                    $payment->save();
-                    $position++;
-                }
-            }
-        }
-
-        return Response::success([], 'Payments reordered successfully')->getData();
+        return $this->crud->sort($data);
     }
 
-    /**
-     * Bulk delete payments
-     * DELETE /api/mgr/payments/bulk
-     *
-     * @param array $data Request data (ids)
-     * @return array Response
-     */
     public function bulkDelete(array $data = []): array
     {
-        $ids = $data['ids'] ?? [];
-
-        if (empty($ids) || !is_array($ids)) {
-            return Response::error('Payment IDs array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $ids = array_filter(array_map('intval', $ids), function ($id) {
-            return $id > 0;
-        });
-
-        if (empty($ids)) {
-            return Response::error('No valid payment IDs provided', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $deleted = 0;
-        $failed = 0;
-
-        foreach ($ids as $id) {
-            $payment = $this->modx->getObject(msPayment::class, $id);
-
-            if (!$payment) {
-                $failed++;
-                continue;
-            }
-
-            // Delete related delivery members
-            foreach ($this->modx->getIterator(msDeliveryMember::class, ['payment_id' => $id]) as $member) {
-                $member->remove();
-            }
-
-            if ($payment->remove()) {
-                $deleted++;
-            } else {
-                $failed++;
-            }
-        }
-
-        if ($deleted === 0) {
-            return Response::error('Failed to delete payments', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([
-            'deleted' => $deleted,
-            'failed' => $failed
-        ], "Deleted {$deleted} payments")->getData();
+        return $this->crud->bulkDelete($data);
     }
 
-    /**
-     * Update positions (drag-n-drop reorder)
-     * PUT /api/mgr/payments/positions
-     *
-     * @param array $data Request data (positions: [id => position])
-     * @return array Response
-     */
     public function updatePositions(array $data = []): array
     {
-        $positions = $data['positions'] ?? [];
-
-        if (empty($positions) || !is_array($positions)) {
-            return Response::error('Positions array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $updated = 0;
-        foreach ($positions as $id => $position) {
-            $payment = $this->modx->getObject(msPayment::class, (int)$id);
-            if ($payment) {
-                $payment->set('position', (int)$position);
-                if ($payment->save()) {
-                    $updated++;
-                }
-            }
-        }
-
-        return Response::success(['updated' => $updated], "Updated {$updated} positions")->getData();
+        return $this->crud->updatePositions($data);
     }
 
-    /**
-     * Format payment object for API response
-     *
-     * @param msPayment $payment
-     * @return array
-     */
-    protected function formatPayment(msPayment $payment): array
-    {
-        return [
-            'id' => $payment->get('id'),
-            'name' => $payment->get('name'),
-            'description' => $payment->get('description'),
-            'price' => $payment->get('price'),
-            'logo' => $payment->get('logo'),
-            'position' => (int)$payment->get('position'),
-            'active' => (bool)$payment->get('active'),
-            'class' => $payment->get('class'),
-            'properties' => $payment->get('properties'),
-        ];
-    }
-
-    /**
-     * Get deliveries for specific payment
-     * GET /api/mgr/payments/{id}/deliveries
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
-     */
     public function getDeliveries(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Payment ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $results = [];
-        foreach ($this->modx->getIterator(msDeliveryMember::class, ['payment_id' => $id]) as $member) {
-            $results[] = [
-                'delivery_id' => $member->get('delivery_id'),
-                'payment_id' => $member->get('payment_id'),
-            ];
-        }
-
-        return Response::success(['results' => $results])->getData();
+        return $this->crud->listLinks($params);
     }
 
-    /**
-     * Add delivery to payment
-     * POST /api/mgr/payments/{id}/deliveries
-     *
-     * @param array $data Request data (payment_id, delivery_id)
-     * @return array Response
-     */
     public function addDelivery(array $data = []): array
     {
-        $paymentId = (int)($data['payment_id'] ?? 0);
-        $deliveryId = (int)($data['delivery_id'] ?? 0);
-
-        if (!$paymentId || !$deliveryId) {
-            return Response::error('Payment ID and Delivery ID are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Check if relationship already exists
-        $existing = $this->modx->getObject(msDeliveryMember::class, [
-            'delivery_id' => $deliveryId,
-            'payment_id' => $paymentId
-        ]);
-
-        if ($existing) {
-            return Response::success([], 'Delivery already linked to payment')->getData();
-        }
-
-        $member = $this->modx->newObject(msDeliveryMember::class);
-        $member->set('delivery_id', $deliveryId);
-        $member->set('payment_id', $paymentId);
-
-        if (!$member->save()) {
-            return Response::error('Failed to add delivery to payment', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Delivery added to payment')->getData();
+        return $this->crud->addLink($data);
     }
 
-    /**
-     * Remove delivery from payment
-     * DELETE /api/mgr/payments/{id}/deliveries/{delivery_id}
-     *
-     * @param array $params URL parameters (id, delivery_id)
-     * @return array Response
-     */
     public function removeDelivery(array $params = []): array
     {
-        $paymentId = (int)($params['id'] ?? 0);
-        $deliveryId = (int)($params['delivery_id'] ?? 0);
-
-        if (!$paymentId || !$deliveryId) {
-            return Response::error('Payment ID and Delivery ID are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $member = $this->modx->getObject(msDeliveryMember::class, [
-            'delivery_id' => $deliveryId,
-            'payment_id' => $paymentId
-        ]);
-
-        if (!$member) {
-            return Response::error('Delivery link not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        if (!$member->remove()) {
-            return Response::error('Failed to remove delivery from payment', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success([], 'Delivery removed from payment')->getData();
-    }
-
-    protected function prepareFieldValue(string $field, $value)
-    {
-        return $field === 'price' ? PriceAdjustment::normalize($value) : $value;
+        return $this->crud->removeLink($params);
     }
 }

--- a/core/components/minishop3/src/Services/Reference/Ms3ReferenceCrudService.php
+++ b/core/components/minishop3/src/Services/Reference/Ms3ReferenceCrudService.php
@@ -1,0 +1,520 @@
+<?php
+
+namespace MiniShop3\Services\Reference;
+
+use MiniShop3\Model\msDeliveryMember;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
+use MiniShop3\Utils\PriceAdjustment;
+use MODX\Revolution\modX;
+use xPDO\Om\xPDOObject;
+
+/**
+ * Shared Manager API CRUD + M2M linking for delivery/payment references.
+ */
+class Ms3ReferenceCrudService
+{
+    public function __construct(
+        protected modX $modx,
+        protected ReferenceResourceConfig $config,
+    ) {
+    }
+
+    public function getList(array $params = []): array
+    {
+        $start = (int) ($params['start'] ?? 0);
+        $limit = (int) ($params['limit'] ?? 20);
+        $query = trim((string) ($params['query'] ?? ''));
+        // limit=0 means "all rows" (PaymentsGrid loads deliveries with limit:0).
+        $returnAll = $limit === 0;
+
+        $criteria = [];
+        if ($query !== '') {
+            $criteria[] = [
+                'name:LIKE' => "%{$query}%",
+                'OR:description:LIKE' => "%{$query}%",
+            ];
+        }
+
+        foreach ($params as $key => $value) {
+            if (!str_starts_with((string) $key, 'filter_') || $value === '' || $value === null) {
+                continue;
+            }
+            ManagerListFilterPolicy::applyCriteriaFilter(
+                $criteria,
+                substr((string) $key, 7),
+                $value,
+                $this->config->filterMap
+            );
+        }
+
+        $model = $this->config->modelClass;
+        $total = $this->modx->getCount($model, $criteria);
+
+        $q = $this->modx->newQuery($model, $criteria);
+        if (!$returnAll) {
+            $q->limit($limit, $start);
+        }
+        $q->sortby('position', 'ASC');
+
+        $results = [];
+        foreach ($this->modx->getIterator($model, $q) as $object) {
+            $results[] = $this->formatItem($object);
+        }
+
+        return Response::success([
+            'results' => $results,
+            'total' => $total,
+        ])->getData();
+    }
+
+    public function get(array $params = []): array
+    {
+        $id = (int) ($params['id'] ?? 0);
+        if (!$id) {
+            return $this->errorRequiredId();
+        }
+
+        $object = $this->modx->getObject($this->config->modelClass, $id);
+        if (!$object) {
+            return $this->errorNotFound();
+        }
+
+        $data = $this->formatItem($object);
+        if ($this->config->embedLinksKey !== null) {
+            $data[$this->config->embedLinksKey] = $this->collectPeerIds($id);
+        }
+
+        return Response::success($data)->getData();
+    }
+
+    public function create(array $data = []): array
+    {
+        if (empty($data['name'])) {
+            return Response::error(
+                "{$this->config->labelSingular} name is required",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $object = $this->modx->newObject($this->config->modelClass);
+        $this->applyAllowedFields($object, $data);
+
+        if (!isset($data['position'])) {
+            $object->set('position', $this->nextPosition());
+        }
+
+        if (!$object->save()) {
+            return Response::error(
+                "Failed to create {$this->labelLower()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        $this->maybeReplaceEmbeddedLinks((int) $object->get('id'), $data);
+
+        return Response::success(
+            $this->formatItem($object),
+            "{$this->config->labelSingular} created successfully"
+        )->getData();
+    }
+
+    public function update(array $data = []): array
+    {
+        $id = (int) ($data['id'] ?? 0);
+        if (!$id) {
+            return $this->errorRequiredId();
+        }
+
+        $object = $this->modx->getObject($this->config->modelClass, $id);
+        if (!$object) {
+            return $this->errorNotFound();
+        }
+
+        $this->applyAllowedFields($object, $data);
+
+        if (!$object->save()) {
+            return Response::error(
+                "Failed to save {$this->labelLower()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        $this->maybeReplaceEmbeddedLinks($id, $data);
+
+        return Response::success(
+            $this->formatItem($object),
+            "{$this->config->labelSingular} updated successfully"
+        )->getData();
+    }
+
+    public function delete(array $params = []): array
+    {
+        $id = (int) ($params['id'] ?? 0);
+        if (!$id) {
+            return $this->errorRequiredId();
+        }
+
+        $object = $this->modx->getObject($this->config->modelClass, $id);
+        if (!$object) {
+            return $this->errorNotFound();
+        }
+
+        $this->removeMembersForOwnId($id);
+
+        if (!$object->remove()) {
+            return Response::error(
+                "Failed to delete {$this->labelLower()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        return Response::success([], "{$this->config->labelSingular} deleted successfully")->getData();
+    }
+
+    public function sort(array $data = []): array
+    {
+        $ids = $data['ids'] ?? [];
+        if ($ids === [] || !is_array($ids)) {
+            return Response::error(
+                "{$this->config->labelSingular} IDs array is required for sorting",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $position = 0;
+        foreach ($ids as $id) {
+            $id = (int) $id;
+            if ($id <= 0) {
+                continue;
+            }
+            $object = $this->modx->getObject($this->config->modelClass, $id);
+            if ($object) {
+                $object->set('position', $position);
+                $object->save();
+                $position++;
+            }
+        }
+
+        return Response::success(
+            [],
+            "{$this->config->labelPlural} reordered successfully"
+        )->getData();
+    }
+
+    public function bulkDelete(array $data = []): array
+    {
+        $ids = $data['ids'] ?? [];
+        if ($ids === [] || !is_array($ids)) {
+            return Response::error(
+                "{$this->config->labelSingular} IDs array is required",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $ids = array_values(array_filter(array_map('intval', $ids), static fn(int $id): bool => $id > 0));
+        if ($ids === []) {
+            return Response::error(
+                "No valid {$this->labelLower()} IDs provided",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $deleted = 0;
+        $failed = 0;
+        foreach ($ids as $id) {
+            $object = $this->modx->getObject($this->config->modelClass, $id);
+            if (!$object) {
+                $failed++;
+                continue;
+            }
+            $this->removeMembersForOwnId($id);
+            if ($object->remove()) {
+                $deleted++;
+            } else {
+                $failed++;
+            }
+        }
+
+        if ($deleted === 0) {
+            return Response::error(
+                "Failed to delete {$this->labelLowerPlural()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        return Response::success(
+            ['deleted' => $deleted, 'failed' => $failed],
+            "Deleted {$deleted} {$this->labelLowerPlural()}"
+        )->getData();
+    }
+
+    public function updatePositions(array $data = []): array
+    {
+        $positions = $data['positions'] ?? [];
+        if ($positions === [] || !is_array($positions)) {
+            return Response::error('Positions array is required', HttpStatus::BAD_REQUEST)->getData();
+        }
+
+        $updated = 0;
+        foreach ($positions as $id => $position) {
+            $object = $this->modx->getObject($this->config->modelClass, (int) $id);
+            if (!$object) {
+                continue;
+            }
+            $object->set('position', (int) $position);
+            if ($object->save()) {
+                $updated++;
+            }
+        }
+
+        return Response::success(
+            ['updated' => $updated],
+            "Updated {$updated} positions"
+        )->getData();
+    }
+
+    public function listLinks(array $params = []): array
+    {
+        $id = (int) ($params['id'] ?? 0);
+        if (!$id) {
+            return $this->errorRequiredId();
+        }
+
+        $results = [];
+        foreach ($this->iterateMembersForOwnId($id) as $member) {
+            $results[] = [
+                'delivery_id' => (int) $member->get('delivery_id'),
+                'payment_id' => (int) $member->get('payment_id'),
+            ];
+        }
+
+        return Response::success(['results' => $results])->getData();
+    }
+
+    public function addLink(array $data = []): array
+    {
+        $ownId = (int) ($data[$this->config->memberOwnFk] ?? 0);
+        $peerId = (int) ($data[$this->config->memberPeerFk] ?? 0);
+
+        if (!$ownId || !$peerId) {
+            return Response::error(
+                "{$this->config->labelSingular} ID and {$this->config->peerLabelSingular} ID are required",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $criteria = $this->memberLinkCriteria($ownId, $peerId);
+
+        if ($this->modx->getObject(msDeliveryMember::class, $criteria)) {
+            return Response::success(
+                [],
+                "{$this->config->peerLabelSingular} already linked to {$this->labelLower()}"
+            )->getData();
+        }
+
+        $member = $this->modx->newObject(msDeliveryMember::class);
+        $member->fromArray($criteria);
+
+        if (!$member->save()) {
+            return Response::error(
+                "Failed to add {$this->peerLabelLower()} to {$this->labelLower()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        return Response::success(
+            [],
+            "{$this->config->peerLabelSingular} added to {$this->labelLower()}"
+        )->getData();
+    }
+
+    public function removeLink(array $params = []): array
+    {
+        $ownId = (int) ($params['id'] ?? 0);
+        $peerId = (int) ($params[$this->config->memberPeerFk] ?? 0);
+
+        if (!$ownId || !$peerId) {
+            return Response::error(
+                "{$this->config->labelSingular} ID and {$this->config->peerLabelSingular} ID are required",
+                HttpStatus::BAD_REQUEST
+            )->getData();
+        }
+
+        $member = $this->modx->getObject(
+            msDeliveryMember::class,
+            $this->memberLinkCriteria($ownId, $peerId)
+        );
+        if (!$member) {
+            return Response::error(
+                "{$this->config->peerLabelSingular} link not found",
+                HttpStatus::NOT_FOUND
+            )->getData();
+        }
+
+        if (!$member->remove()) {
+            return Response::error(
+                "Failed to remove {$this->peerLabelLower()} from {$this->labelLower()}",
+                HttpStatus::INTERNAL_SERVER_ERROR
+            )->getData();
+        }
+
+        return Response::success(
+            [],
+            "{$this->config->peerLabelSingular} removed from {$this->labelLower()}"
+        )->getData();
+    }
+
+    /**
+     * Replace all peer links for an own-side id (delivery write path).
+     *
+     * @param list<int|string> $peerIds
+     */
+    public function replaceLinks(int $ownId, array $peerIds): void
+    {
+        $this->removeMembersForOwnId($ownId);
+
+        foreach ($peerIds as $peerId) {
+            $peerId = (int) $peerId;
+            if ($peerId <= 0) {
+                continue;
+            }
+            $member = $this->modx->newObject(msDeliveryMember::class);
+            $member->set($this->config->memberOwnFk, $ownId);
+            $member->set($this->config->memberPeerFk, $peerId);
+            $member->save();
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function collectPeerIds(int $ownId): array
+    {
+        $ids = [];
+        foreach ($this->iterateMembersForOwnId($ownId) as $member) {
+            $ids[] = (int) $member->get($this->config->memberPeerFk);
+        }
+
+        return $ids;
+    }
+
+    public function formatItem(xPDOObject $object): array
+    {
+        $data = [
+            'id' => (int) $object->get('id'),
+        ];
+        $floatFields = array_fill_keys($this->config->floatFields, true);
+
+        foreach ($this->config->allowedFields as $field) {
+            $raw = $object->get($field);
+            if ($field === 'position') {
+                $data[$field] = (int) $raw;
+            } elseif ($field === 'active') {
+                $data[$field] = (bool) $raw;
+            } elseif (isset($floatFields[$field])) {
+                $data[$field] = (float) $raw;
+            } else {
+                $data[$field] = $raw;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function applyAllowedFields(xPDOObject $object, array $data): void
+    {
+        foreach ($this->config->allowedFields as $field) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+            $object->set($field, $this->prepareFieldValue($field, $data[$field]));
+        }
+    }
+
+    protected function prepareFieldValue(string $field, mixed $value): mixed
+    {
+        return $field === 'price' ? PriceAdjustment::normalize($value) : $value;
+    }
+
+    protected function nextPosition(): int
+    {
+        $q = $this->modx->newQuery($this->config->modelClass);
+        $q->sortby('position', 'DESC');
+        $q->limit(1);
+        $last = $this->modx->getObject($this->config->modelClass, $q);
+
+        return $last ? ((int) $last->get('position') + 1) : 1;
+    }
+
+    protected function maybeReplaceEmbeddedLinks(int $ownId, array $data): void
+    {
+        $key = $this->config->embedLinksKey;
+        if ($key === null || !isset($data[$key]) || !is_array($data[$key])) {
+            return;
+        }
+
+        $this->replaceLinks($ownId, $data[$key]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function memberLinkCriteria(int $ownId, int $peerId): array
+    {
+        return [
+            $this->config->memberOwnFk => $ownId,
+            $this->config->memberPeerFk => $peerId,
+        ];
+    }
+
+    /**
+     * @return iterable<object>
+     */
+    protected function iterateMembersForOwnId(int $ownId): iterable
+    {
+        return $this->modx->getIterator(
+            msDeliveryMember::class,
+            [$this->config->memberOwnFk => $ownId]
+        );
+    }
+
+    protected function removeMembersForOwnId(int $ownId): void
+    {
+        foreach ($this->iterateMembersForOwnId($ownId) as $member) {
+            $member->remove();
+        }
+    }
+
+    protected function errorRequiredId(): array
+    {
+        return Response::error(
+            "{$this->config->labelSingular} ID is required",
+            HttpStatus::BAD_REQUEST
+        )->getData();
+    }
+
+    protected function errorNotFound(): array
+    {
+        return Response::error(
+            "{$this->config->labelSingular} not found",
+            HttpStatus::NOT_FOUND
+        )->getData();
+    }
+
+    protected function labelLower(): string
+    {
+        return strtolower($this->config->labelSingular);
+    }
+
+    protected function labelLowerPlural(): string
+    {
+        return strtolower($this->config->labelPlural);
+    }
+
+    protected function peerLabelLower(): string
+    {
+        return strtolower($this->config->peerLabelSingular);
+    }
+}

--- a/core/components/minishop3/src/Services/Reference/ReferenceResourceConfig.php
+++ b/core/components/minishop3/src/Services/Reference/ReferenceResourceConfig.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MiniShop3\Services\Reference;
+
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
+
+/**
+ * Resource parameters for {@see Ms3ReferenceCrudService} (deliveries / payments).
+ *
+ * Not a generic REST-for-any-table framework — only the two mirrored mgr references.
+ */
+final class ReferenceResourceConfig
+{
+    /**
+     * @param class-string $modelClass
+     * @param list<string> $allowedFields
+     * @param array<string, string> $filterMap
+     * @param list<string> $floatFields
+     */
+    public function __construct(
+        public readonly string $modelClass,
+        public readonly string $labelSingular,
+        public readonly string $labelPlural,
+        public readonly array $allowedFields,
+        public readonly array $filterMap,
+        public readonly string $memberOwnFk,
+        public readonly string $memberPeerFk,
+        public readonly string $peerLabelSingular,
+        public readonly array $floatFields = [],
+        /** When set: embed peer ids on get and replace peer links on create/update. */
+        public readonly ?string $embedLinksKey = null,
+    ) {
+    }
+
+    public static function forDeliveries(): self
+    {
+        return new self(
+            modelClass: msDelivery::class,
+            labelSingular: 'Delivery',
+            labelPlural: 'Deliveries',
+            allowedFields: [
+                'name',
+                'description',
+                'price',
+                'weight_price',
+                'distance_price',
+                'logo',
+                'position',
+                'active',
+                'class',
+                'properties',
+                'validation_rules',
+                'free_delivery_amount',
+            ],
+            filterMap: ManagerListFilterPolicy::DELIVERY_FILTER_MAP,
+            memberOwnFk: 'delivery_id',
+            memberPeerFk: 'payment_id',
+            peerLabelSingular: 'Payment',
+            floatFields: ['weight_price', 'distance_price', 'free_delivery_amount'],
+            embedLinksKey: 'payments',
+        );
+    }
+
+    public static function forPayments(): self
+    {
+        return new self(
+            modelClass: msPayment::class,
+            labelSingular: 'Payment',
+            labelPlural: 'Payments',
+            allowedFields: [
+                'name',
+                'description',
+                'price',
+                'logo',
+                'position',
+                'active',
+                'class',
+                'properties',
+            ],
+            filterMap: ManagerListFilterPolicy::PAYMENT_FILTER_MAP,
+            memberOwnFk: 'payment_id',
+            memberPeerFk: 'delivery_id',
+            peerLabelSingular: 'Delivery',
+            floatFields: [],
+            embedLinksKey: null,
+        );
+    }
+}

--- a/core/components/minishop3/tests/ReferenceResourceCrudConfigTest.php
+++ b/core/components/minishop3/tests/ReferenceResourceCrudConfigTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Unit checks for shared deliveries/payments reference CRUD config (#356).
+ *
+ * Run: php tests/ReferenceResourceCrudConfigTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Services\Grid\ManagerListFilterPolicy;
+use MiniShop3\Services\Reference\Ms3ReferenceCrudService;
+use MiniShop3\Services\Reference\ReferenceResourceConfig;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertTrue = static function (bool $value, string $case) use ($fail): void {
+    if (!$value) {
+        $fail($case . ': expected true');
+    }
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$deliveries = ReferenceResourceConfig::forDeliveries();
+$payments = ReferenceResourceConfig::forPayments();
+
+$assertSame(msDelivery::class, $deliveries->modelClass, 'deliveries model');
+$assertSame(msPayment::class, $payments->modelClass, 'payments model');
+
+$assertTrue(
+    in_array('validation_rules', $deliveries->allowedFields, true),
+    'deliveries keep validation_rules'
+);
+$assertTrue(
+    in_array('free_delivery_amount', $deliveries->allowedFields, true),
+    'deliveries keep free_delivery_amount'
+);
+$assertTrue(
+    !in_array('validation_rules', $payments->allowedFields, true),
+    'payments must not expose validation_rules'
+);
+$assertTrue(
+    !in_array('free_delivery_amount', $payments->allowedFields, true),
+    'payments must not expose free_delivery_amount'
+);
+
+$assertSame('payments', $deliveries->embedLinksKey, 'deliveries embed payments on get');
+$assertSame(null, $payments->embedLinksKey, 'payments do not embed deliveries on get');
+$assertTrue(
+    in_array('weight_price', $deliveries->floatFields, true),
+    'deliveries cast weight_price'
+);
+$assertSame([], $payments->floatFields, 'payments have no float casts');
+
+$assertSame(
+    ManagerListFilterPolicy::DELIVERY_FILTER_MAP,
+    $deliveries->filterMap,
+    'delivery filter map'
+);
+$assertSame(
+    ManagerListFilterPolicy::PAYMENT_FILTER_MAP,
+    $payments->filterMap,
+    'payment filter map'
+);
+
+// Controllers stay thin and keep public method names (route BC).
+$assertHasMethods = static function (string $class, array $methods) use ($assertTrue): void {
+    $available = get_class_methods($class);
+    foreach ($methods as $method) {
+        $assertTrue(in_array($method, $available, true), "{$class}::{$method}");
+    }
+};
+
+$assertHasMethods(\MiniShop3\Controllers\Api\Manager\DeliveriesController::class, [
+    'getList',
+    'get',
+    'create',
+    'update',
+    'delete',
+    'sort',
+    'bulkDelete',
+    'updatePositions',
+    'getPayments',
+    'addPayment',
+    'removePayment',
+    'getActiveDropdown',
+]);
+
+$assertHasMethods(\MiniShop3\Controllers\Api\Manager\PaymentsController::class, [
+    'getList',
+    'get',
+    'create',
+    'update',
+    'delete',
+    'sort',
+    'bulkDelete',
+    'updatePositions',
+    'getDeliveries',
+    'addDelivery',
+    'removeDelivery',
+]);
+
+$assertTrue(
+    class_exists(Ms3ReferenceCrudService::class),
+    'Ms3ReferenceCrudService exists'
+);
+
+// Controllers should not re-implement CRUD bodies (source size / shared service usage).
+$deliverySrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Manager/DeliveriesController.php');
+$paymentSrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Manager/PaymentsController.php');
+$serviceSrc = file_get_contents(__DIR__ . '/../src/Services/Reference/Ms3ReferenceCrudService.php');
+if ($deliverySrc === false || $paymentSrc === false || $serviceSrc === false) {
+    $fail('cannot read source files');
+}
+
+$assertTrue(
+    str_contains($deliverySrc, 'Ms3ReferenceCrudService'),
+    'DeliveriesController uses Ms3ReferenceCrudService'
+);
+$assertTrue(
+    str_contains($paymentSrc, 'Ms3ReferenceCrudService'),
+    'PaymentsController uses Ms3ReferenceCrudService'
+);
+$assertTrue(
+    str_contains($serviceSrc, '$returnAll = $limit === 0'),
+    'getList treats limit=0 as all rows (PaymentsGrid deliveries load)'
+);
+$assertTrue(
+    !str_contains($serviceSrc, 'allowLimitZero'),
+    'no allowLimitZero mode flag'
+);
+$assertTrue(
+    substr_count($deliverySrc, "\n") < 200,
+    'DeliveriesController stays thin (<200 lines)'
+);
+$assertTrue(
+    substr_count($paymentSrc, "\n") < 120,
+    'PaymentsController stays thin (<120 lines)'
+);
+
+fwrite(STDOUT, "OK ReferenceResourceCrudConfigTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Вынесен зеркальный Manager API CRUD/M2M доставок и оплат в `Ms3ReferenceCrudService` + `ReferenceResourceConfig`. Контроллеры стали тонкими HTTP-адаптерами. URL и имена методов без breaking changes. Whitelist `deliveries-active` и delivery-only поля (`validation_rules`, `free_delivery_amount`) остаются у deliveries. `limit=0` означает все строки (нужно для `PaymentsGrid`).

## Тип изменений

- [x] Рефакторинг (без изменения функциональности)
- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #356

## Как это было протестировано?

Gate E (локально, exit 0):

```bash
cd core/components/minishop3
php -l src/Services/Reference/ReferenceResourceConfig.php
php -l src/Services/Reference/Ms3ReferenceCrudService.php
php -l src/Controllers/Api/Manager/DeliveriesController.php
php -l src/Controllers/Api/Manager/PaymentsController.php
php tests/DeliveriesActiveDropdownFieldsTest.php
php tests/ReferenceResourceCrudConfigTest.php
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`php -l`, `DeliveriesActiveDropdownFieldsTest`, `ReferenceResourceCrudConfigTest`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-356-reference-crud-service`
- MODX: n/a (unit/syntax)
- PHP: 8.x local

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы — не требуется (сообщения API без изменений)
- [ ] PHPStan — CI
- [ ] ESLint — Vue не трогали
- [ ] CHANGELOG — по политике релиза не редактировался

## Дополнительные заметки

**Gate A**

| AC | Code | Test |
|----|------|------|
| Общий CRUD/M2M, тонкие контроллеры | yes | yes (`ReferenceResourceCrudConfigTest`) |
| URL `/deliveries*` `/payments*` без breaking | yes | yes (публичные методы) |
| ValidationRules только у deliveries | yes | yes (allowedFields) |
| Контракт с Vue (#354) | yes | `limit=0` all-rows для PaymentsGrid |

**Review:** code-reviewer — BLOCK нет. Thermo-nuclear — SOFT: HTTP envelope ещё в сервисе (как у соседних fat controllers); полный вынос Response в контроллеры можно отдельным PR. Убраны флаги `allowLimitZero` / `replaceLinksOnWrite`.