### PR TITLE
docs: граница Domain facades vs Controllers/Api

### DIFF
--- a/core/components/minishop3/src/Controllers/Cart/Cart.php
+++ b/core/components/minishop3/src/Controllers/Cart/Cart.php
@@ -11,7 +11,11 @@ use MiniShop3\Services\Order\OrderLogService;
 use MODX\Revolution\modX;
 
 /**
- * Shopping Cart Controller (Facade)
+ * Domain facade for the shopping cart (not an HTTP controller).
+ *
+ * Lives under Controllers\ for MS2-style compatibility, but does not handle
+ * FastRoute requests. HTTP entry points are Controllers\Api\Web\CartController
+ * (and similar). Registered as DI key `ms3_cart`; typically reached via `$ms3->cart`.
  *
  * Manages customer cart: adding, changing, removing products.
  * Cart is stored in DB as draft order (msOrder with draft status).
@@ -24,9 +28,12 @@ use MODX\Revolution\modX;
  * To override logic:
  * 1. Create your class extending Cart
  * 2. Override required methods (add, remove, change, etc.)
- * 3. Set your class in system setting: ms3_cart_class = Your\Namespace\MyCart
+ * 3. Register it for DI key `ms3_cart` via `core/config/ms3.services.php`
+ *    or `core/config/ms3.services.d/*.php` (see ms3.services.example.php)
  *
  * @package MiniShop3\Controllers\Cart
+ * @see \MiniShop3\Controllers\Api\Web\CartController
+ * @see \MiniShop3\ServiceRegistry
  */
 class Cart
 {

--- a/core/components/minishop3/src/Controllers/Customer/Customer.php
+++ b/core/components/minishop3/src/Controllers/Customer/Customer.php
@@ -14,6 +14,17 @@ use MODX\Revolution\modX;
 
 use Rakit\Validation\Validator;
 
+/**
+ * Domain facade for the customer profile/session (not an HTTP controller).
+ *
+ * Lives under Controllers\ for MS2-style compatibility, but does not handle
+ * FastRoute requests. HTTP entry points live under Controllers\Api\Web\*
+ * (auth, profile, etc.). Registered as DI key `ms3_customer`; typically
+ * reached via `$ms3->customer`.
+ *
+ * @see \MiniShop3\Controllers\Api\Web\CustomerProfileController
+ * @see \MiniShop3\ServiceRegistry
+ */
 class Customer
 {
     /** @var modX $modx */
@@ -27,8 +38,6 @@ class Customer
     protected $validationMessages = [];
 
     /**
-     * Cart constructor.
-     *
      * @param MiniShop3 $ms3
      * @param array $config
      */

--- a/core/components/minishop3/src/Controllers/Order/Order.php
+++ b/core/components/minishop3/src/Controllers/Order/Order.php
@@ -15,13 +15,21 @@ use MiniShop3\Services\Order\OrderUserResolver;
 use MODX\Revolution\modX;
 
 /**
- * Order Controller (Facade)
+ * Domain facade for the order workflow (not an HTTP controller).
+ *
+ * Lives under Controllers\ for MS2-style compatibility, but does not handle
+ * FastRoute requests. HTTP entry points live under Controllers\Api\Web\*
+ * (and Manager API where applicable). Registered as DI key `ms3_order`;
+ * typically reached via `$ms3->order`.
  *
  * Manages order workflow: draft creation, field updates, cost calculation,
  * and order submission. Delegates business logic to specialized services.
  *
  * This class maintains backward compatibility while internally using
  * the new service-based architecture.
+ *
+ * @see \MiniShop3\Controllers\Api\Web\OrderController
+ * @see \MiniShop3\ServiceRegistry
  */
 class Order
 {

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -17,6 +17,14 @@ use MODX\Revolution\modX;
  *
  * Each next level overrides the previous one.
  *
+ * Layer boundary (naming under Controllers\):
+ * - Controllers\Api\* — HTTP (FastRoute): Manager/*, Web/*, plus other Api\* on manager routes.
+ * - Controllers\Cart|Order|Customer — domain facades (MS2-style), not HTTP controllers.
+ *   DI keys: ms3_cart, ms3_order, ms3_customer.
+ * - Controllers\Delivery|Payment — provider plugin bases (not ms3_* DI facades).
+ * - Services\* — canonical business logic used by facades and API controllers.
+ * See repository readme.md section «Слои под src/Controllers/».
+ *
  * Architecture for addons:
  * - Each addon creates its file in ms3.services.d/
  * - Files are loaded in alphabetical order

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,27 @@ MiniShop3/
 └── vueManager/             # Vue 3 исходники админки
 ```
 
+### Слои под `src/Controllers/` (HTTP vs domain facade)
+
+Оба живут в namespace `MiniShop3\Controllers\…`, но это **разные роли**. Не кладите HTTP-парсинг в domain facade и не тащите бизнес-логику корзины/заказа в API-класс.
+
+| Слой | Путь | Роль |
+|------|------|------|
+| HTTP API | `Controllers/Api/Manager/*`, `Controllers/Api/Web/*` (+ соседние `Controllers/Api/*` на manager routes) | Маршруты FastRoute: request → Response / HttpStatus |
+| Domain facade (MS2-style) | `Controllers/Cart`, `Order`, `Customer` | Публичный фасад для `$ms3->cart` / `$ms3->order` / `$ms3->customer` и DI; делегирует в `Services/` |
+| Provider plugins | `Controllers/Delivery`, `Payment` | Abstract base для методов доставки/оплаты (не DI-фасады `ms3_*`) |
+| Services | `Services/*` | Каноническая бизнес-логика |
+
+Ключевые DI-ключи фасадов (см. также `ServiceRegistry`):
+
+| DI key | Класс | Роль |
+|--------|-------|------|
+| `ms3_cart` | `MiniShop3\Controllers\Cart\Cart` | Domain facade корзины (не HTTP) |
+| `ms3_order` | `MiniShop3\Controllers\Order\Order` | Domain facade заказа (не HTTP) |
+| `ms3_customer` | `MiniShop3\Controllers\Customer\Customer` | Domain facade покупателя (не HTTP) |
+
+Переименование namespace (`Domain\` / `Facades\`) — отдельный major с bc-aliases; этот репозиторий пока фиксирует границу документацией и PHPDoc.
+
 ## 🤝 Участие в разработке
 
 Мы приветствуем вклад в развитие проекта!


### PR DESCRIPTION
## Описание

Docs-only фиксация naming boundary под `src/Controllers/`: HTTP API (`Controllers/Api/*`) отдельно от domain facades `Cart` / `Order` / `Customer` (DI `ms3_cart|order|customer`). Delivery/Payment описаны как provider plugins, не как DI-фасады.

Rename namespace (`Domain\` / `Facades\`) не делался — отдельный major с bc-aliases, как в #367.

## Тип изменений

- [x] Документация
- [x] Рефакторинг (без изменения функциональности) — только PHPDoc

## Связанные Issues

Closes #367

## Как это было протестировано?

```bash
php -l core/components/minishop3/src/Controllers/Cart/Cart.php
php -l core/components/minishop3/src/Controllers/Order/Order.php
php -l core/components/minishop3/src/Controllers/Customer/Customer.php
php -l core/components/minishop3/src/ServiceRegistry.php
# EXIT:0
```

Автотесты поведения не применимы (docs/PHPDoc).

- [x] Синтаксис PHP (`php -l`)
- [ ] Ручное тестирование — n/a

**Конфигурация тестирования:**
- MiniShop3: ветка `docs/issue-367-domain-facades-boundary`
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Лексиконы — n/a
- [x] ESLint — n/a
- [ ] CHANGELOG.md — на релизе (docs-only)

## Дополнительные заметки

**Review:** исправлены замечания — Delivery/Payment вынесены из строки domain facade; override Cart через `ms3.services.php`, не устаревший `ms3_cart_class`; `@see` на Web API для Order/Customer.