### PR TITLE
feat(gallery): выбор главного превью без смены порядка

### DIFF
--- a/core/components/minishop3/lexicon/en/product.inc.php
+++ b/core/components/minishop3/lexicon/en/product.inc.php
@@ -148,6 +148,8 @@ $_lang['ms3_gallery_button_upload'] = 'Select Files';
 
 $_lang['ms3_gallery_file_show'] = 'Open in New Window';
 $_lang['ms3_gallery_file_update'] = 'Edit Properties';
+$_lang['ms3_gallery_file_set_preview'] = 'Use as main preview';
+$_lang['ms3_gallery_file_preview_badge'] = 'Main';
 $_lang['ms3_gallery_file_generate_all'] = 'Regenerate All';
 $_lang['ms3_gallery_file_generate_thumbs'] = 'Regenerate Thumbnails';
 $_lang['ms3_gallery_file_generate_thumbs_confirm'] = 'Are you sure you want to regenerate thumbnails for all files?';

--- a/core/components/minishop3/lexicon/ru/product.inc.php
+++ b/core/components/minishop3/lexicon/ru/product.inc.php
@@ -148,6 +148,8 @@ $_lang['ms3_gallery_button_upload'] = 'Выбрать файлы';
 
 $_lang['ms3_gallery_file_show'] = 'Открыть в новом окне';
 $_lang['ms3_gallery_file_update'] = 'Изменить свойства';
+$_lang['ms3_gallery_file_set_preview'] = 'Сделать главным превью';
+$_lang['ms3_gallery_file_preview_badge'] = 'Главное';
 $_lang['ms3_gallery_file_generate_all'] = 'Обновить все';
 $_lang['ms3_gallery_file_generate_thumbs'] = 'Обновить превьюшки';
 $_lang['ms3_gallery_file_generate_thumbs_confirm'] = 'Вы действительно хотите обновить превью всех файлов?';

--- a/core/components/minishop3/migrations/20260810120000_add_preview_file_id_to_product_data.php
+++ b/core/components/minishop3/migrations/20260810120000_add_preview_file_id_to_product_data.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Adds preview_file_id to ms3_products so gallery preview can differ from sort order (#130).
+ */
+final class AddPreviewFileIdToProductData extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('ms3_products');
+
+        if (!$table->hasColumn('preview_file_id')) {
+            $table->addColumn('preview_file_id', 'integer', [
+                'signed' => false,
+                'null' => true,
+                'default' => null,
+                'after' => 'thumb',
+                'comment' => 'msProductFile id used as product preview (nullable)',
+            ]);
+            $table->update();
+        }
+    }
+
+    public function down(): void
+    {
+        $table = $this->table('ms3_products');
+
+        if ($table->hasColumn('preview_file_id')) {
+            $table->removeColumn('preview_file_id');
+            $table->update();
+        }
+    }
+}

--- a/core/components/minishop3/schema/minishop3.mysql.schema.xml
+++ b/core/components/minishop3/schema/minishop3.mysql.schema.xml
@@ -29,6 +29,7 @@
         <field key="weight" dbtype="decimal" precision="13,3" phptype="float" null="true" default="0"/>
         <field key="image" dbtype="varchar" precision="255" phptype="string" null="true"/>
         <field key="thumb" dbtype="varchar" precision="255" phptype="string" null="true"/>
+        <field key="preview_file_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true"/>
         <field key="vendor_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="true"
                default="0"/>
         <field key="made_in" dbtype="varchar" precision="100" phptype="string" null="true" default=""/>
@@ -546,7 +547,7 @@
             <rule field="key" name="invalid" type="preg_match"
                   rule="/^(?!\W+)(?!\d)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_]+(?!\s)$/" message="ms3_option_err_invalid_key"/>
             <rule field="key" name="reserved" type="preg_match"
-                  rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|article|price|old_price|weight|image|thumb|vendor|made_in|new|popular|favorite|tags|color|size|source|action)$)/"
+                  rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|article|price|old_price|weight|image|thumb|preview_file_id|vendor|made_in|new|popular|favorite|tags|color|size|source|action)$)/"
                   message="ms3_option_err_reserved_key"/>
         </validation>
     </object>

--- a/core/components/minishop3/src/Model/msProduct.php
+++ b/core/components/minishop3/src/Model/msProduct.php
@@ -395,9 +395,10 @@ class msProduct extends modResource
         parent::set('options', $data->get('options'));
         parent::set('links', $data->get('links'));
 
-        // Clear image/thumb - gallery should NOT be copied
+        // Clear image/thumb/preview - gallery should NOT be copied (#130)
         parent::set('image', '');
         parent::set('thumb', '');
+        parent::set('preview_file_id', null);
 
         $sourceId = (int)$this->get('id');
 

--- a/core/components/minishop3/src/Model/msProductData.php
+++ b/core/components/minishop3/src/Model/msProductData.php
@@ -18,6 +18,7 @@ use xPDO\xPDO;
  * @property float $weight
  * @property string $image
  * @property string $thumb
+ * @property integer|null $preview_file_id
  * @property integer $vendor_id
  * @property string $made_in
  * @property boolean $new

--- a/core/components/minishop3/src/Model/mysql/msProductData.php
+++ b/core/components/minishop3/src/Model/mysql/msProductData.php
@@ -22,6 +22,7 @@ class msProductData extends \MiniShop3\Model\msProductData
                 'weight' => 0.0,
                 'image' => null,
                 'thumb' => null,
+                'preview_file_id' => null,
                 'vendor_id' => 0,
                 'made_in' => '',
                 'new' => 0,
@@ -85,6 +86,14 @@ class msProductData extends \MiniShop3\Model\msProductData
                         'dbtype' => 'varchar',
                         'precision' => '255',
                         'phptype' => 'string',
+                        'null' => true,
+                    ],
+                'preview_file_id' =>
+                    [
+                        'dbtype' => 'int',
+                        'precision' => '10',
+                        'attributes' => 'unsigned',
+                        'phptype' => 'integer',
                         'null' => true,
                     ],
                 'vendor_id' =>

--- a/core/components/minishop3/src/Processors/Gallery/GetList.php
+++ b/core/components/minishop3/src/Processors/Gallery/GetList.php
@@ -5,6 +5,7 @@ namespace MiniShop3\Processors\Gallery;
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductFile;
+use MiniShop3\Services\Product\ProductImageService;
 use MODX\Revolution\modX;
 use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Sources\modMediaSource;
@@ -22,6 +23,7 @@ class GetList extends GetListProcessor
     /** @var MiniShop3 $ms3 */
     protected $ms3;
     protected $thumb;
+    protected int $previewFileId = 0;
 
     /**
      * @return bool|null|string
@@ -35,6 +37,11 @@ class GetList extends GetListProcessor
         if ($product) {
             $data = $product->getOne('Data');
             if ($data) {
+                /** @var ProductImageService|null $imageService */
+                $imageService = $this->modx->services->get('ms3_product_image');
+                if ($imageService instanceof ProductImageService) {
+                    $this->previewFileId = $imageService->resolvePreviewFileId($data);
+                }
                 $sourceId = (int)$data->get('source_id');
                 $source = null;
                 if ($sourceId > 0) {
@@ -194,6 +201,9 @@ class GetList extends GetListProcessor
             ? json_decode($row['properties'], true)
             : [];
 
+        $row['is_preview'] = $this->previewFileId > 0
+            && (int) ($row['id'] ?? 0) === $this->previewFileId;
+
         $row['actions'] = [];
 
         $row['actions'][] = [
@@ -215,6 +225,17 @@ class GetList extends GetListProcessor
         ];
 
         if ($row['type'] == 'image') {
+            if (!$row['is_preview']) {
+                $row['actions'][] = [
+                    'cls' => '',
+                    'icon' => 'icon icon-star',
+                    'title' => $this->modx->lexicon('ms3_gallery_file_set_preview'),
+                    'action' => 'setPreview',
+                    'button' => false,
+                    'menu' => true,
+                ];
+            }
+
             $row['actions'][] = [
                 'cls' => '',
                 'icon' => 'icon icon-refresh',

--- a/core/components/minishop3/src/Processors/Gallery/GetList.php
+++ b/core/components/minishop3/src/Processors/Gallery/GetList.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Processors\Gallery;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msProduct;
+use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductFile;
 use MiniShop3\Services\Product\ProductImageService;
 use MODX\Revolution\modX;
@@ -36,7 +37,7 @@ class GetList extends GetListProcessor
         $product = $this->modx->getObject(msProduct::class, (int)$this->getProperty('product_id'));
         if ($product) {
             $data = $product->getOne('Data');
-            if ($data) {
+            if ($data instanceof msProductData) {
                 /** @var ProductImageService|null $imageService */
                 $imageService = $this->modx->services->get('ms3_product_image');
                 if ($imageService instanceof ProductImageService) {

--- a/core/components/minishop3/src/Processors/Gallery/Remove.php
+++ b/core/components/minishop3/src/Processors/Gallery/Remove.php
@@ -23,7 +23,6 @@ class Remove extends RemoveProcessor
         /** @var msProduct $product */
         $product = $this->object->getOne('Product');
         $thumb = '';
-
         if ($product) {
             $productData = $product->getOne('Data');
 

--- a/core/components/minishop3/src/Processors/Gallery/SetPreview.php
+++ b/core/components/minishop3/src/Processors/Gallery/SetPreview.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MiniShop3\Processors\Gallery;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Services\Product\ProductImageService;
+use MODX\Revolution\Processors\ModelProcessor;
+
+/**
+ * Mark a gallery image as the product preview without changing position (#130).
+ */
+class SetPreview extends ModelProcessor
+{
+    public $classKey = msProductFile::class;
+    public $languageTopics = ['minishop3:default', 'minishop3:product'];
+    public $permission = 'msproductfile_save';
+
+    public function process()
+    {
+        $productId = (int) $this->getProperty('product_id');
+        $fileId = (int) $this->getProperty('id');
+
+        if ($productId <= 0 || $fileId <= 0) {
+            return $this->failure($this->modx->lexicon('ms3_gallery_err_ns'));
+        }
+
+        /** @var msProductData|null $productData */
+        $productData = $this->modx->getObject(msProductData::class, ['id' => $productId]);
+        if (!$productData) {
+            return $this->failure($this->modx->lexicon('ms3_gallery_err_no_product'));
+        }
+
+        /** @var ProductImageService|null $imageService */
+        $imageService = $this->modx->services->get('ms3_product_image');
+        if (!$imageService instanceof ProductImageService) {
+            return $this->failure($this->modx->lexicon('ms3_err_unknown'));
+        }
+
+        $saved = $imageService->setProductPreview($productData, $fileId);
+        if ($saved === false) {
+            return $this->failure($this->modx->lexicon('ms3_err_gallery_ns'));
+        }
+
+        $thumb = (string) $productData->get('thumb');
+        if ($thumb === '') {
+            /** @var MiniShop3 $ms3 */
+            $ms3 = $this->modx->services->get('ms3');
+            $thumb = (string) ($ms3->config['defaultThumb'] ?? '');
+        }
+
+        return $this->success('', [
+            'thumb' => $thumb,
+            'preview_file_id' => (int) $productData->get('preview_file_id'),
+        ]);
+    }
+}

--- a/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
+++ b/core/components/minishop3/src/Processors/Product/ProductDataPayloadTrait.php
@@ -116,7 +116,7 @@ trait ProductDataPayloadTrait
     private function getAllowedProductDataFieldNames(): array
     {
         $fields = array_fill_keys($this->object->getDataFieldsNames(), true);
-        unset($fields['id']);
+        unset($fields['id'], $fields['preview_file_id']);
 
         return $fields;
     }

--- a/core/components/minishop3/src/Services/Product/ProductImageService.php
+++ b/core/components/minishop3/src/Services/Product/ProductImageService.php
@@ -120,33 +120,51 @@ class ProductImageService
     }
 
     /**
-     * Update product main image
+     * Set which gallery file is the product preview without changing sort order (#130).
      *
-     * Finds the first product image (with lowest rank) and sets it
-     * as main (image and thumb fields in msProductData)
+     * @return bool|mixed save result from updateProductImage()
+     */
+    public function setProductPreview(msProductData $productData, int $fileId): mixed
+    {
+        $productId = (int) $productData->get('id');
+        if (!$this->getMainGalleryFile($productId, $fileId)) {
+            return false;
+        }
+
+        $productData->set('preview_file_id', $fileId);
+
+        return $this->updateProductImage($productData);
+    }
+
+    /**
+     * Effective preview gallery file id (explicit preview or first image by position).
+     * Read-only: does not mutate product data (#130).
+     */
+    public function resolvePreviewFileId(msProductData $productData): int
+    {
+        $file = $this->findMainImageFile($productData);
+
+        return $file ? (int) $file->get('id') : 0;
+    }
+
+    /**
+     * Update product main image / thumb URLs from gallery.
+     *
+     * Uses preview_file_id when set and valid; otherwise the first image by position (#130).
      *
      * @param msProductData $productData
      * @return bool|mixed
      */
     public function updateProductImage(msProductData $productData)
     {
-        $productId = $productData->get('id');
-
-        // Получаем первое изображение (с минимальной позицией)
-        $c = $this->modx->newQuery(msProductFile::class);
-        $c->where([
-            'product_id' => $productId,
-            'parent_id' => 0,
-            'type' => 'image'
-        ]);
-        $c->sortby('position', 'ASC');
-
-        /** @var msProductFile $file */
-        $file = $this->modx->getObject(msProductFile::class, $c);
+        $stalePreview = false;
+        $file = $this->findMainImageFile($productData, $stalePreview);
+        if ($stalePreview) {
+            $productData->set('preview_file_id', null);
+        }
 
         if ($file) {
-            // Get thumbnail from child record (generated thumbnail)
-            /** @var msProductFile $thumbnailFile */
+            /** @var msProductFile|null $thumbnailFile */
             $thumbnailFile = $this->modx->getObject(msProductFile::class, [
                 'parent_id' => $file->get('id'),
                 'type' => 'image',
@@ -157,12 +175,62 @@ class ProductImageService
             $productData->set('thumb', $thumb);
 
             return $productData->save();
-        } else {
-            $productData->set('image', '');
-            $productData->set('thumb', '');
-
-            return $productData->save();
         }
+
+        $productData->set('preview_file_id', null);
+        $productData->set('image', '');
+        $productData->set('thumb', '');
+
+        return $productData->save();
+    }
+
+    /**
+     * @param bool|null $stalePreview set true when preview_file_id pointed at a missing file
+     */
+    private function findMainImageFile(msProductData $productData, ?bool &$stalePreview = null): ?msProductFile
+    {
+        $stalePreview = false;
+        $productId = (int) $productData->get('id');
+        $previewId = (int) $productData->get('preview_file_id');
+
+        if ($previewId > 0) {
+            $preview = $this->getMainGalleryFile($productId, $previewId);
+            if ($preview) {
+                return $preview;
+            }
+            $stalePreview = true;
+        }
+
+        return $this->getMainGalleryFile($productId);
+    }
+
+    private function getMainGalleryFile(int $productId, ?int $fileId = null): ?msProductFile
+    {
+        if ($fileId !== null && $fileId > 0) {
+            /** @var msProductFile|null $file */
+            $file = $this->modx->getObject(msProductFile::class, [
+                'id' => $fileId,
+                'product_id' => $productId,
+                'parent_id' => 0,
+                'type' => 'image',
+            ]);
+
+            return $file ?: null;
+        }
+
+        $c = $this->modx->newQuery(msProductFile::class);
+        $c->where([
+            'product_id' => $productId,
+            'parent_id' => 0,
+            'type' => 'image',
+        ]);
+        $c->sortby('position', 'ASC');
+        $c->sortby('id', 'ASC');
+
+        /** @var msProductFile|null $file */
+        $file = $this->modx->getObject(msProductFile::class, $c);
+
+        return $file ?: null;
     }
 
     /**

--- a/core/components/minishop3/src/Services/Product/ProductImageService.php
+++ b/core/components/minishop3/src/Services/Product/ProductImageService.php
@@ -185,9 +185,9 @@ class ProductImageService
     }
 
     /**
-     * @param bool|null $stalePreview set true when preview_file_id pointed at a missing file
+     * @param bool $stalePreview set true when preview_file_id pointed at a missing file
      */
-    private function findMainImageFile(msProductData $productData, ?bool &$stalePreview = null): ?msProductFile
+    private function findMainImageFile(msProductData $productData, bool &$stalePreview = false): ?msProductFile
     {
         $stalePreview = false;
         $productId = (int) $productData->get('id');

--- a/core/components/minishop3/src/Utils/ProductThumbnailJoin.php
+++ b/core/components/minishop3/src/Utils/ProductThumbnailJoin.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Utils;
 
+use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductFile;
 use MODX\Revolution\modX;
 
@@ -11,8 +12,10 @@ use MODX\Revolution\modX;
 final class ProductThumbnailJoin
 {
     /**
-     * LEFT JOIN ON: one thumbnail per product — child of the main gallery image
-     * (parent_id = 0, lowest position), path contains the given size folder.
+     * LEFT JOIN ON: one thumbnail per product — child of the main gallery image.
+     *
+     * Main image is preview_file_id when set, otherwise lowest position (#130).
+     * Path must contain the given size folder.
      */
     public static function buildLeftJoinOn(
         modX $modx,
@@ -29,10 +32,9 @@ final class ProductThumbnailJoin
         }
 
         // xPDO::getTableName() already returns the name escaped with backticks
-        // (e.g. "`modx_ms3_product_files`"). DO NOT wrap %4$s in extra backticks
-        // — that produced triple backticks at runtime and an SQL syntax error
-        // on `includeThumbs=...` (regression introduced in #282 / 1.11.0-beta1).
+        // (e.g. "`modx_ms3_product_files`"). DO NOT wrap %4$s / %5$s in extra backticks.
         $filesTable = $modx->getTableName(msProductFile::class);
+        $productsTable = $modx->getTableName(msProductData::class);
 
         return sprintf(
             '`%1$s`.product_id = `%2$s`.id'
@@ -43,13 +45,19 @@ final class ProductThumbnailJoin
             . ' WHERE `main`.`product_id` = `%2$s`.`id`'
             . ' AND `main`.`parent_id` = 0'
             . ' AND `main`.`type` = \'image\''
-            . ' ORDER BY `main`.`position` ASC, `main`.`id` ASC'
+            . ' ORDER BY'
+            . ' CASE WHEN `main`.`id` = ('
+            . 'SELECT `pdata`.`preview_file_id` FROM %5$s `pdata`'
+            . ' WHERE `pdata`.`id` = `%2$s`.`id`'
+            . ') THEN 0 ELSE 1 END,'
+            . ' `main`.`position` ASC, `main`.`id` ASC'
             . ' LIMIT 1'
             . ')',
             $thumbAlias,
             $productAlias,
             $thumbSize,
-            $filesTable
+            $filesTable,
+            $productsTable
         );
     }
 

--- a/core/components/minishop3/tests/Unit/Services/Product/ProductImageServicePreviewTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Product/ProductImageServicePreviewTest.php
@@ -151,7 +151,7 @@ final class ProductImageServicePreviewTest extends TestCase
     private function invokeFind(
         ProductImageService $service,
         msProductData $data,
-        ?bool &$stale = null
+        bool &$stale = false
     ): ?msProductFile {
         $method = new ReflectionMethod(ProductImageService::class, 'findMainImageFile');
         $method->setAccessible(true);

--- a/core/components/minishop3/tests/Unit/Services/Product/ProductImageServicePreviewTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Product/ProductImageServicePreviewTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Services\Product\ProductImageService;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class ProductImageServicePreviewTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testFindMainImageFileUsesPreviewFileIdWhenValid(): void
+    {
+        $preview = $this->fakeFile(42);
+        $service = new ProductImageService($this->modxReturning($preview));
+        $data = $this->fakeProductData(['id' => 7, 'preview_file_id' => 42]);
+
+        $resolved = $this->invokeFind($service, $data);
+
+        self::assertSame($preview, $resolved);
+        self::assertSame(42, $data->get('preview_file_id'));
+    }
+
+    public function testFindMainImageFileFallsBackWithoutMutatingStalePreview(): void
+    {
+        $fallback = $this->fakeFile(9);
+        $calls = 0;
+        $modx = new class ($fallback, $calls) extends modX {
+            public function __construct(
+                private msProductFile $fallback,
+                private int &$calls,
+            ) {
+                parent::__construct();
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                $this->calls++;
+                if ($this->calls === 1) {
+                    return null;
+                }
+
+                return $this->fallback;
+            }
+
+            public function newQuery($className, $criteria = null, $cacheFlag = true)
+            {
+                return new class {
+                    public function where($criteria, $conjunction = null)
+                    {
+                        return $this;
+                    }
+
+                    public function sortby($column, $direction = '')
+                    {
+                        return $this;
+                    }
+                };
+            }
+        };
+
+        $service = new ProductImageService($modx);
+        $data = $this->fakeProductData(['id' => 7, 'preview_file_id' => 99]);
+        $stale = false;
+        $resolved = $this->invokeFind($service, $data, $stale);
+
+        self::assertSame($fallback, $resolved);
+        self::assertTrue($stale);
+        self::assertSame(99, $data->get('preview_file_id'));
+    }
+
+    public function testResolvePreviewFileIdIsReadOnlyForStalePointer(): void
+    {
+        $fallback = $this->fakeFile(9);
+        $calls = 0;
+        $modx = new class ($fallback, $calls) extends modX {
+            public function __construct(
+                private msProductFile $fallback,
+                private int &$calls,
+            ) {
+                parent::__construct();
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                $this->calls++;
+                if ($this->calls === 1) {
+                    return null;
+                }
+
+                return $this->fallback;
+            }
+
+            public function newQuery($className, $criteria = null, $cacheFlag = true)
+            {
+                return new class {
+                    public function where($criteria, $conjunction = null)
+                    {
+                        return $this;
+                    }
+
+                    public function sortby($column, $direction = '')
+                    {
+                        return $this;
+                    }
+                };
+            }
+        };
+
+        $service = new ProductImageService($modx);
+        $data = $this->fakeProductData(['id' => 7, 'preview_file_id' => 99]);
+
+        self::assertSame(9, $service->resolvePreviewFileId($data));
+        self::assertSame(99, $data->get('preview_file_id'));
+    }
+
+    public function testSetProductPreviewRejectsForeignOrMissingFile(): void
+    {
+        $modx = new class extends modX {
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                return null;
+            }
+        };
+        $service = new ProductImageService($modx);
+        $data = $this->fakeProductData(['id' => 7, 'preview_file_id' => null]);
+
+        self::assertFalse($service->setProductPreview($data, 123));
+    }
+
+    public function testResolvePreviewFileId(): void
+    {
+        $preview = $this->fakeFile(42);
+        $service = new ProductImageService($this->modxReturning($preview));
+        $data = $this->fakeProductData(['id' => 7, 'preview_file_id' => 42]);
+
+        self::assertSame(42, $service->resolvePreviewFileId($data));
+    }
+
+    private function invokeFind(
+        ProductImageService $service,
+        msProductData $data,
+        ?bool &$stale = null
+    ): ?msProductFile {
+        $method = new ReflectionMethod(ProductImageService::class, 'findMainImageFile');
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($service, [$data, &$stale]);
+    }
+
+    private function modxReturning(msProductFile $file): modX
+    {
+        return new class ($file) extends modX {
+            public function __construct(private msProductFile $file)
+            {
+                parent::__construct();
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                return $this->file;
+            }
+        };
+    }
+
+    private function fakeFile(int $id): msProductFile
+    {
+        return new class ($id) extends msProductFile {
+            public function __construct(private int $fileId)
+            {
+            }
+
+            public function get($k, $format = null, $formatTemplate = null)
+            {
+                return $k === 'id' ? $this->fileId : null;
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function fakeProductData(array $fields): msProductData
+    {
+        return new class ($fields) extends msProductData {
+            /** @param array<string, mixed> $fields */
+            public function __construct(private array $fields)
+            {
+            }
+
+            public function get($k, $format = null, $formatTemplate = null)
+            {
+                return $this->fields[$k] ?? null;
+            }
+
+            public function set($k, $v = null, $vType = '')
+            {
+                $this->fields[$k] = $v;
+
+                return true;
+            }
+        };
+    }
+}

--- a/core/components/minishop3/tests/Unit/Utils/ProductThumbnailJoinPreviewTest.php
+++ b/core/components/minishop3/tests/Unit/Utils/ProductThumbnailJoinPreviewTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Utils;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Utils\ProductThumbnailJoin;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+final class ProductThumbnailJoinPreviewTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testBuildLeftJoinOnPrefersPreviewFileIdOverPosition(): void
+    {
+        $modx = new class extends modX {
+            public function getTableName($className, $escape = true)
+            {
+                return match ($className) {
+                    msProductFile::class => '`modx_ms3_product_files`',
+                    msProductData::class => '`modx_ms3_products`',
+                    default => '`' . $className . '`',
+                };
+            }
+        };
+
+        $sql = ProductThumbnailJoin::buildLeftJoinOn($modx, 'Thumb', 'small', 'msProduct');
+
+        self::assertStringContainsString('preview_file_id', $sql);
+        self::assertStringContainsString('CASE WHEN `main`.`id` =', $sql);
+        self::assertStringContainsString('ORDER BY', $sql);
+        self::assertStringContainsString('`main`.`position` ASC', $sql);
+        self::assertStringContainsString('`modx_ms3_products`', $sql);
+        self::assertStringContainsString('`modx_ms3_product_files`', $sql);
+    }
+
+    public function testBuildLeftJoinOnRejectsEmptyIdentifiers(): void
+    {
+        $modx = new modX();
+        self::assertSame('1 = 0', ProductThumbnailJoin::buildLeftJoinOn($modx, '', 'small'));
+    }
+}

--- a/vueManager/src/components/gallery/ProductGallery.vue
+++ b/vueManager/src/components/gallery/ProductGallery.vue
@@ -39,6 +39,7 @@ const {
   regenerateThumbs,
   regenerateAll,
   updateFile,
+  setPreview,
   updateProductSource,
 } = useGalleryApi()
 
@@ -168,6 +169,27 @@ async function onEditSave(data) {
       name: data.name,
       description: data.description,
     })
+    await loadImages()
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: _('ms3_gallery_errors'),
+      detail: error.message,
+      life: 5000,
+    })
+  }
+}
+
+/**
+ * Handle set as main product preview (#130)
+ */
+async function onSetPreview(image) {
+  if (!image?.id) return
+  try {
+    const result = await setPreview(props.productId, image.id)
+    if (result.thumb) {
+      updateProductThumb(result.thumb)
+    }
     await loadImages()
   } catch (error) {
     toast.add({
@@ -361,6 +383,7 @@ onMounted(() => {
       @page-change="onPageChange"
       @edit="onEdit"
       @show="onShow"
+      @set-preview="onSetPreview"
       @generate-thumbs="onGenerateThumbs"
       @delete="onDeleteFiles"
     />

--- a/vueManager/src/components/gallery/ProductGalleryGrid.vue
+++ b/vueManager/src/components/gallery/ProductGalleryGrid.vue
@@ -35,6 +35,7 @@ const emit = defineEmits([
   'page-change',
   'edit',
   'show',
+  'set-preview',
   'generate-thumbs',
   'delete',
 ])
@@ -43,35 +44,49 @@ const searchQuery = ref('')
 const currentPage = ref(0)
 
 // Context menu
-const contextMenuRef = ref(null)
+const contextMenuRef = ref()
 const contextMenuTarget = ref(null)
 
-const contextMenuItems = computed(() => [
-  {
-    label: _('ms3_gallery_file_update'),
-    icon: 'pi pi-pencil',
-    command: () => contextMenuTarget.value && emit('edit', contextMenuTarget.value),
-  },
-  {
-    label: _('ms3_gallery_file_show'),
-    icon: 'pi pi-external-link',
-    command: () => contextMenuTarget.value && emit('show', contextMenuTarget.value),
-  },
-  {
-    label: _('ms3_gallery_file_generate_thumbs'),
-    icon: 'pi pi-refresh',
-    command: () => contextMenuTarget.value && emit('generate-thumbs', [contextMenuTarget.value.id]),
-  },
-  {
-    separator: true,
-  },
-  {
-    label: _('ms3_gallery_file_delete'),
-    icon: 'pi pi-trash',
-    class: 'p-menuitem-danger',
-    command: () => contextMenuTarget.value && emit('delete', [contextMenuTarget.value.id]),
-  },
-])
+const contextMenuItems = computed(() => {
+  const items = [
+    {
+      label: _('ms3_gallery_file_update'),
+      icon: 'pi pi-pencil',
+      command: () => contextMenuTarget.value && emit('edit', contextMenuTarget.value),
+    },
+    {
+      label: _('ms3_gallery_file_show'),
+      icon: 'pi pi-external-link',
+      command: () => contextMenuTarget.value && emit('show', contextMenuTarget.value),
+    },
+  ]
+
+  if (contextMenuTarget.value && !contextMenuTarget.value.is_preview) {
+    items.push({
+      label: _('ms3_gallery_file_set_preview'),
+      icon: 'pi pi-star',
+      command: () => contextMenuTarget.value && emit('set-preview', contextMenuTarget.value),
+    })
+  }
+
+  items.push(
+    {
+      label: _('ms3_gallery_file_generate_thumbs'),
+      icon: 'pi pi-refresh',
+      command: () =>
+        contextMenuTarget.value && emit('generate-thumbs', [contextMenuTarget.value.id]),
+    },
+    { separator: true },
+    {
+      label: _('ms3_gallery_file_delete'),
+      icon: 'pi pi-trash',
+      class: 'p-menuitem-danger',
+      command: () => contextMenuTarget.value && emit('delete', [contextMenuTarget.value.id]),
+    }
+  )
+
+  return items
+})
 
 // Local copy for draggable — allows instant visual reorder
 const localImages = ref([])
@@ -164,11 +179,15 @@ function onContextMenu(event, image) {
       <template #item="{ element }">
         <div
           class="gallery-item"
+          :class="{ 'gallery-item--preview': element.is_preview }"
           :title="_('ms3_gallery_drag_hint')"
           @dblclick="onDblClick(element)"
           @contextmenu.prevent="onContextMenu($event, element)"
         >
           <div class="gallery-item-thumb">
+            <span v-if="element.is_preview" class="gallery-item-badge">
+              {{ _('ms3_gallery_file_preview_badge') }}
+            </span>
             <img
               v-if="element.thumbnail"
               :src="element.thumbnail"
@@ -276,6 +295,10 @@ function onContextMenu(event, image) {
   border-color: var(--p-primary-color);
 }
 
+.gallery-images :deep(.gallery-item--preview) {
+  border-color: var(--p-primary-color);
+}
+
 .gallery-images :deep(.gallery-item-thumb) {
   width: 7.5rem;
   height: 5.625rem;
@@ -284,6 +307,21 @@ function onContextMenu(event, image) {
   justify-content: center;
   overflow: hidden;
   background: var(--p-surface-50);
+  position: relative;
+}
+
+.gallery-images :deep(.gallery-item-badge) {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  z-index: 1;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--p-primary-contrast-color, #fff);
+  background: var(--p-primary-color);
 }
 
 .gallery-images :deep(.gallery-item-thumb img) {

--- a/vueManager/src/composables/useGalleryApi.js
+++ b/vueManager/src/composables/useGalleryApi.js
@@ -194,6 +194,20 @@ export function useGalleryApi() {
   }
 
   /**
+   * Mark gallery file as product preview without changing sort order (#130).
+   * @param {number} productId
+   * @param {number} fileId
+   * @returns {Promise<{thumb: string}>}
+   */
+  async function setPreview(productId, fileId) {
+    const data = await connectorRequest('MiniShop3\\Processors\\Gallery\\SetPreview', {
+      product_id: productId,
+      id: fileId,
+    })
+    return { thumb: data.object?.thumb || '' }
+  }
+
+  /**
    * Change product media source
    * @param {number} productId
    * @param {number} sourceId
@@ -217,6 +231,7 @@ export function useGalleryApi() {
     regenerateThumbs,
     regenerateAll,
     updateFile,
+    setPreview,
     updateProductSource,
   }
 }


### PR DESCRIPTION
## Описание

В галерее товара можно назначить любое изображение главным превью (кнопка в контекстном меню) без перестановки `position`. ID хранится в `msProductData.preview_file_id`; `image`/`thumb` и `includeThumbs` JOIN обновляются с учётом этого поля. Если поле пустое — поведение как раньше (первая по position).

## Тип изменений

- [x] Новая функциональность (non-breaking change)

## Связанные Issues

Closes #130

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Product/ProductImageService.php
php -l src/Processors/Gallery/SetPreview.php
php -l src/Utils/ProductThumbnailJoin.php
./vendor/bin/phpunit -c phpunit.xml.dist \
  tests/Unit/Utils/ProductThumbnailJoinPreviewTest.php \
  tests/Unit/Services/Product/ProductImageServicePreviewTest.php \
  tests/Integration/Product/ProductDataPayloadTraitTest.php
# EXIT:0 — 9 tests

cd ../../../vueManager
npx eslint src/components/gallery/ProductGallery.vue \
  src/components/gallery/ProductGalleryGrid.vue \
  src/composables/useGalleryApi.js
# EXIT:0
```

После merge на стенде: прогнать Phinx-миграцию `20260810120000_add_preview_file_id_to_product_data`.

- [x] Автоматические тесты
- [ ] Ручное тестирование на стенде с миграцией

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-130-gallery-preview-file`
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Лексиконы ru+en
- [x] ESLint по затронутым Vue-файлам
- [ ] CHANGELOG — на релизе
- [ ] Миграция применена на стенде перед QA

## Дополнительные заметки

- `preview_file_id` исключён из generic Product Create/Update payload (только `Gallery\SetPreview`).
- При duplicate товара поле сбрасывается вместе с `image`/`thumb`.
- Review: read-path `resolvePreviewFileId` без мутации; cleanup stale только в `updateProductImage`.