### PR TITLE
refactor(grid): разрез GridConfigService (Phase A #365)

### DIFF
--- a/core/components/minishop3/src/Services/Grid/GridColumnTypeValidator.php
+++ b/core/components/minishop3/src/Services/Grid/GridColumnTypeValidator.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Grid;
+
+use MiniShop3\Interfaces\ComputedFieldInterface;
+use MODX\Revolution\modX;
+
+/**
+ * Validates grid column JSON config by column type (template/relation/…).
+ *
+ * @phpstan-type ValidationResult array{success: bool, message?: string, config?: array<string, mixed>}
+ */
+final class GridColumnTypeValidator
+{
+    /** @var list<string> */
+    private const ALLOWED_AGGREGATIONS = ['COUNT', 'SUM', 'AVG', 'MIN', 'MAX'];
+
+    /** @var list<string> */
+    private const ALLOWED_ACTION_HANDLERS = [
+        'edit', 'delete', 'view', 'refresh', 'addresses', 'publish', 'duplicate',
+    ];
+
+    /** @var list<string> */
+    private const ALLOWED_SEVERITIES = ['secondary', 'success', 'info', 'warn', 'danger'];
+
+    /** @var array<string, string> */
+    private const RELATION_REQUIRED = [
+        'table' => 'relation.table is required',
+        'foreignKey' => 'relation.foreignKey is required',
+        'displayField' => 'relation.displayField is required',
+    ];
+
+    public function __construct(private modX $modx)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateForType(string $type, array $config, string $fieldName = ''): array
+    {
+        return match ($type) {
+            'template' => $this->validateTemplateConfig($config),
+            'relation' => $this->validateRelationConfig($config),
+            'computed' => $this->validateComputedConfig($config),
+            'actions' => $this->validateActionsConfig($config),
+            'option' => $this->validateOptionConfig($config, $fieldName),
+            default => ['success' => true],
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateTemplateConfig(array $config): array
+    {
+        if (empty($config['template'])) {
+            return ['success' => false, 'message' => 'template is required for template field'];
+        }
+
+        if (!is_string($config['template'])) {
+            return ['success' => false, 'message' => 'template must be a string'];
+        }
+
+        return ['success' => true];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateRelationConfig(array $config): array
+    {
+        $relation = $config['relation'] ?? [];
+
+        foreach (self::RELATION_REQUIRED as $key => $message) {
+            if (empty($relation[$key])) {
+                return ['success' => false, 'message' => $message];
+            }
+        }
+
+        $aggregation = $relation['aggregation'] ?? null;
+        if ($aggregation !== null && !in_array($aggregation, self::ALLOWED_AGGREGATIONS, true)) {
+            return [
+                'success' => false,
+                'message' => 'Invalid aggregation type. Allowed: ' . implode(', ', self::ALLOWED_AGGREGATIONS),
+            ];
+        }
+
+        $tableOrModel = $relation['table'];
+        $isModel = str_contains($tableOrModel, '\\') || str_contains($tableOrModel, '::');
+
+        if ($isModel) {
+            try {
+                $tableName = $this->modx->getTableName($tableOrModel);
+
+                if (empty($tableName)) {
+                    return ['success' => false, 'message' => "Unable to get table name for model: {$tableOrModel}"];
+                }
+
+                $config['relation']['resolvedTableName'] = $tableName;
+            } catch (\Exception $e) {
+                return [
+                    'success' => false,
+                    'message' => "Invalid model class: {$tableOrModel}. " . $e->getMessage(),
+                ];
+            }
+        } else {
+            $tablePrefix = $this->modx->config['table_prefix'] ?? '';
+            if ($tablePrefix !== '' && !str_starts_with($tableOrModel, $tablePrefix)) {
+                $tableOrModel = $tablePrefix . $tableOrModel;
+            }
+            $config['relation']['resolvedTableName'] = $tableOrModel;
+        }
+
+        return ['success' => true, 'config' => $config];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateComputedConfig(array $config): array
+    {
+        $computed = $config['computed'] ?? [];
+
+        if (empty($computed['className'])) {
+            return ['success' => false, 'message' => 'computed.className is required'];
+        }
+
+        if (!class_exists($computed['className'])) {
+            return ['success' => false, 'message' => "Class {$computed['className']} not found"];
+        }
+
+        $interfaces = class_implements($computed['className']) ?: [];
+        if (!isset($interfaces[ComputedFieldInterface::class])) {
+            return ['success' => false, 'message' => 'Class must implement ComputedFieldInterface'];
+        }
+
+        return ['success' => true];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateActionsConfig(array $config): array
+    {
+        $actions = $config['actions'] ?? [];
+
+        if (!is_array($actions)) {
+            return ['success' => false, 'message' => 'actions must be an array'];
+        }
+
+        $actionNames = [];
+
+        foreach ($actions as $index => $action) {
+            if (empty($action['name'])) {
+                return ['success' => false, 'message' => "actions[{$index}].name is required"];
+            }
+
+            if (in_array($action['name'], $actionNames, true)) {
+                return ['success' => false, 'message' => "Duplicate action name: {$action['name']}"];
+            }
+            $actionNames[] = $action['name'];
+
+            if (empty($action['handler'])) {
+                return ['success' => false, 'message' => "actions[{$index}].handler is required"];
+            }
+
+            $handler = $action['handler'];
+            if (
+                !in_array($handler, self::ALLOWED_ACTION_HANDLERS, true)
+                && !str_starts_with($handler, 'custom:')
+            ) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_INFO,
+                    "[GridColumnTypeValidator] Custom handler used: {$handler} in action {$action['name']}"
+                );
+            }
+
+            if (!empty($action['severity']) && !in_array($action['severity'], self::ALLOWED_SEVERITIES, true)) {
+                return [
+                    'success' => false,
+                    'message' => "Invalid severity for action {$action['name']}. Allowed: "
+                        . implode(', ', self::ALLOWED_SEVERITIES),
+                ];
+            }
+        }
+
+        return ['success' => true];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ValidationResult
+     */
+    public function validateOptionConfig(array $config, string $fieldName = ''): array
+    {
+        $option = $config['option'] ?? [];
+
+        if (empty($option['key'])) {
+            return ['success' => false, 'message' => 'option.key is required for option field'];
+        }
+
+        $key = (string) $option['key'];
+        if (!OptionColumnSpec::isValidOptionKey($key)) {
+            return ['success' => false, 'message' => 'option.key must contain only letters, numbers and underscores'];
+        }
+
+        if ($fieldName !== '' && !OptionColumnSpec::isValidFieldName($fieldName)) {
+            return [
+                'success' => false,
+                'message' => "Field name '{$fieldName}' is not allowed for option columns: "
+                    . 'it collides with a builtin product column or contains invalid characters. '
+                    . "Use a name like 'option_{$key}' instead.",
+            ];
+        }
+
+        return ['success' => true];
+    }
+}

--- a/core/components/minishop3/src/Services/Grid/GridConfigRepository.php
+++ b/core/components/minishop3/src/Services/Grid/GridConfigRepository.php
@@ -100,11 +100,13 @@ final class GridConfigRepository
         }
 
         /** @var list<msGridField> $fields */
-        return array_values($this->modx->getCollection(msGridField::class, [
+        $fields = array_values($this->modx->getCollection(msGridField::class, [
             'grid_key' => $gridKey,
             'is_system' => false,
             'field_name:NOT IN' => $fieldNamesToKeep,
         ]) ?: []);
+
+        return $fields;
     }
 
     /**
@@ -140,6 +142,8 @@ final class GridConfigRepository
         $query->sortby('sort_order', 'ASC');
 
         /** @var list<msGridField> $fields */
-        return array_values($this->modx->getCollection(msGridField::class, $query) ?: []);
+        $fields = array_values($this->modx->getCollection(msGridField::class, $query) ?: []);
+
+        return $fields;
     }
 }

--- a/core/components/minishop3/src/Services/Grid/GridConfigRepository.php
+++ b/core/components/minishop3/src/Services/Grid/GridConfigRepository.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Grid;
+
+use MiniShop3\Model\msGridField;
+use MODX\Revolution\modX;
+
+/**
+ * Persistence for msGridField rows (grid column config).
+ */
+final class GridConfigRepository
+{
+    public function __construct(private modX $modx)
+    {
+    }
+
+    /**
+     * @return list<msGridField>
+     */
+    public function findByGridKey(string $gridKey, bool $includeHidden = false): array
+    {
+        $where = ['grid_key' => $gridKey];
+        if (!$includeHidden) {
+            $where['visible'] = true;
+        }
+
+        return $this->collectSorted($where);
+    }
+
+    /**
+     * @return list<msGridField>
+     */
+    public function findFilterableByGridKey(string $gridKey): array
+    {
+        return $this->collectSorted([
+            'grid_key' => $gridKey,
+            'filterable' => true,
+        ]);
+    }
+
+    public function findOne(string $gridKey, string $fieldName): ?msGridField
+    {
+        /** @var msGridField|null $field */
+        $field = $this->modx->getObject(msGridField::class, [
+            'grid_key' => $gridKey,
+            'field_name' => $fieldName,
+        ]);
+
+        return $field instanceof msGridField ? $field : null;
+    }
+
+    public function nextSortOrder(string $gridKey): int
+    {
+        $query = $this->modx->newQuery(msGridField::class);
+        $query->where(['grid_key' => $gridKey]);
+        $query->sortby('sort_order', 'DESC');
+        $query->limit(1);
+        $lastField = $this->modx->getObject(msGridField::class, $query);
+
+        return $lastField ? (int) $lastField->get('sort_order') + 1 : 1;
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function create(array $attributes): msGridField
+    {
+        /** @var msGridField $field */
+        $field = $this->modx->newObject(msGridField::class);
+        $field->fromArray($attributes);
+
+        return $field;
+    }
+
+    public function save(msGridField $field): bool
+    {
+        return (bool) $field->save();
+    }
+
+    public function remove(msGridField $field): bool
+    {
+        return (bool) $field->remove();
+    }
+
+    /**
+     * Non-system fields whose names are not in $fieldNamesToKeep (candidates for delete on save).
+     *
+     * Empty keep list returns [] — never wipe all non-system rows. Callers that omit every
+     * field name must not treat that as "delete everything" (xPDO `NOT IN ()` is also invalid).
+     *
+     * @param list<string> $fieldNamesToKeep
+     * @return list<msGridField>
+     */
+    public function findNonSystemNotIn(string $gridKey, array $fieldNamesToKeep): array
+    {
+        if ($fieldNamesToKeep === []) {
+            return [];
+        }
+
+        /** @var list<msGridField> $fields */
+        return array_values($this->modx->getCollection(msGridField::class, [
+            'grid_key' => $gridKey,
+            'is_system' => false,
+            'field_name:NOT IN' => $fieldNamesToKeep,
+        ]) ?: []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function decodeConfig(mixed $config): array
+    {
+        if (is_string($config)) {
+            $decoded = json_decode($config, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return is_array($config) ? $config : [];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function encodeConfig(array $config): string
+    {
+        return (string) json_encode($config, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @param array<string, mixed> $where
+     * @return list<msGridField>
+     */
+    private function collectSorted(array $where): array
+    {
+        $query = $this->modx->newQuery(msGridField::class);
+        $query->where($where);
+        $query->sortby('sort_order', 'ASC');
+
+        /** @var list<msGridField> $fields */
+        return array_values($this->modx->getCollection(msGridField::class, $query) ?: []);
+    }
+}

--- a/core/components/minishop3/src/Services/Grid/GridRelationFieldExtractor.php
+++ b/core/components/minishop3/src/Services/Grid/GridRelationFieldExtractor.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Grid;
+
+/**
+ * Groups relation-type grid columns for JOIN building.
+ */
+final class GridRelationFieldExtractor
+{
+    /** @var array<string, string> */
+    private const MODEL_MAP = [
+        'msOrder' => 'MiniShop3\\Model\\msOrder',
+        'msOrderStatus' => 'MiniShop3\\Model\\msOrderStatus',
+        'msOrderAddress' => 'MiniShop3\\Model\\msOrderAddress',
+        'msOrderProduct' => 'MiniShop3\\Model\\msOrderProduct',
+        'msDelivery' => 'MiniShop3\\Model\\msDelivery',
+        'msPayment' => 'MiniShop3\\Model\\msPayment',
+        'msProduct' => 'MiniShop3\\Model\\msProduct',
+        'msProductData' => 'MiniShop3\\Model\\msProductData',
+        'msCategory' => 'MiniShop3\\Model\\msCategory',
+        'msCategoryMember' => 'MiniShop3\\Model\\msCategoryMember',
+        'msVendor' => 'MiniShop3\\Model\\msVendor',
+        'msCustomer' => 'MiniShop3\\Model\\msCustomer',
+        'modUser' => 'MODX\\Revolution\\modUser',
+        'modUserProfile' => 'MODX\\Revolution\\modUserProfile',
+        'modResource' => 'MODX\\Revolution\\modResource',
+    ];
+
+    /**
+     * @param list<array<string, mixed>> $gridFields
+     * @return array<string, array{
+     *   table: string,
+     *   modelClass: ?string,
+     *   foreignKey: string,
+     *   alias: string,
+     *   fields: list<array{name: string, displayField: string}>
+     * }>
+     */
+    public function extract(array $gridFields): array
+    {
+        $relationGroups = [];
+
+        foreach ($gridFields as $field) {
+            if (($field['type'] ?? 'model') !== 'relation') {
+                continue;
+            }
+
+            $relation = $field['relation'] ?? null;
+            if (!$this->isCompleteRelation($relation)) {
+                continue;
+            }
+
+            $table = (string) $relation['table'];
+            $foreignKey = (string) $relation['foreignKey'];
+            $displayField = (string) $relation['displayField'];
+            $fieldName = (string) ($field['name'] ?? '');
+            $groupKey = "{$table}_{$foreignKey}";
+
+            if (!isset($relationGroups[$groupKey])) {
+                $relationGroups[$groupKey] = [
+                    'table' => $table,
+                    'modelClass' => self::MODEL_MAP[$table] ?? null,
+                    'foreignKey' => $foreignKey,
+                    'alias' => "rel_{$table}_{$foreignKey}",
+                    'fields' => [],
+                ];
+            }
+
+            $relationGroups[$groupKey]['fields'][] = [
+                'name' => $fieldName,
+                'displayField' => $displayField,
+            ];
+        }
+
+        return $relationGroups;
+    }
+
+    /**
+     * @param mixed $relation
+     * @phpstan-assert-if-true array{table: mixed, foreignKey: mixed, displayField: mixed} $relation
+     */
+    private function isCompleteRelation(mixed $relation): bool
+    {
+        return is_array($relation)
+            && !empty($relation['table'])
+            && !empty($relation['foreignKey'])
+            && !empty($relation['displayField']);
+    }
+}

--- a/core/components/minishop3/src/Services/Grid/OptionColumnSpec.php
+++ b/core/components/minishop3/src/Services/Grid/OptionColumnSpec.php
@@ -9,7 +9,7 @@ namespace MiniShop3\Services\Grid;
  */
 final readonly class OptionColumnSpec
 {
-    /** Same rule as {@see \MiniShop3\Services\GridConfigService::validateOptionConfig()} */
+    /** Same rule as {@see \MiniShop3\Services\Grid\GridColumnTypeValidator::validateOptionConfig()} */
     private const OPTION_KEY_PATTERN = '/^[a-z0-9_]+$/i';
 
     /** Same rule as OPTION_KEY_PATTERN; fieldName also lands in `SELECT … AS \`{name}\``. */

--- a/core/components/minishop3/src/Services/GridConfigService.php
+++ b/core/components/minishop3/src/Services/GridConfigService.php
@@ -1,70 +1,77 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MiniShop3\Services;
 
 use MiniShop3\Model\msGridField;
-use MiniShop3\Services\Grid\OptionColumnSpec;
+use MiniShop3\Services\Grid\GridColumnTypeValidator;
+use MiniShop3\Services\Grid\GridConfigRepository;
+use MiniShop3\Services\Grid\GridRelationFieldExtractor;
 use MODX\Revolution\modX;
 
 /**
- * Service for managing grid configurations
+ * Facade: grid column configuration for manager grids.
+ *
+ * Persistence → {@see GridConfigRepository}; type rules → {@see GridColumnTypeValidator}.
  */
 class GridConfigService
 {
-    /** @var modX */
-    protected $modx;
+    protected modX $modx;
 
-    /**
-     * @param modX $modx
-     */
-    public function __construct(modX $modx)
-    {
+    private GridConfigRepository $repository;
+
+    private GridColumnTypeValidator $typeValidator;
+
+    private GridRelationFieldExtractor $relationExtractor;
+
+    /** @var list<string> */
+    private const SAVE_CONFIG_KEYS = [
+        'template', 'type', 'format', 'actions',
+        'relation',
+        'computed',
+        'option',
+        'source_field', 'color_field',
+        'decimals', 'currency', 'currency_position', 'thousands_separator', 'decimal_separator',
+        'unit', 'unit_position',
+        'editable', 'editor_type', 'editor_options', 'editor_reference', 'editor_combo_endpoint',
+    ];
+
+    public function __construct(
+        modX $modx,
+        ?GridConfigRepository $repository = null,
+        ?GridColumnTypeValidator $typeValidator = null,
+        ?GridRelationFieldExtractor $relationExtractor = null,
+    ) {
         $this->modx = $modx;
+        $this->repository = $repository ?? new GridConfigRepository($modx);
+        $this->typeValidator = $typeValidator ?? new GridColumnTypeValidator($modx);
+        $this->relationExtractor = $relationExtractor ?? new GridRelationFieldExtractor();
     }
 
     /**
-     * Get grid columns configuration
-     *
-     * @param string $gridKey Grid key (customers, orders, products, etc.)
-     * @return array
+     * @return list<array<string, mixed>>
      */
     public function getGridConfig(string $gridKey, bool $includeHidden = false): array
     {
-        $query = $this->modx->newQuery(msGridField::class);
-        $where = ['grid_key' => $gridKey];
-        if (!$includeHidden) {
-            $where['visible'] = true;
-        }
-        $query->where($where);
-        $query->sortby('sort_order', 'ASC');
-
         $fields = [];
-        $collection = $this->modx->getCollection(msGridField::class, $query);
 
-        foreach ($collection as $field) {
-            $config = $field->get('config');
-
-            // xPDO 3 with phptype='json' automatically deserializes JSON to array
-            if (is_string($config)) {
-                $config = json_decode($config, true) ?: [];
-            } elseif (!is_array($config)) {
-                $config = [];
-            }
+        foreach ($this->repository->findByGridKey($gridKey, $includeHidden) as $field) {
+            $config = $this->repository->decodeConfig($field->get('config'));
 
             $fieldData = [
                 'name' => $field->get('field_name'),
                 'label' => $this->resolveLabel($field),
-                'visible' => (bool)$field->get('visible'),
-                'sortable' => (bool)$field->get('sortable'),
-                'filterable' => (bool)$field->get('filterable'),
-                'frozen' => (bool)$field->get('frozen'),
+                'visible' => (bool) $field->get('visible'),
+                'sortable' => (bool) $field->get('sortable'),
+                'filterable' => (bool) $field->get('filterable'),
+                'frozen' => (bool) $field->get('frozen'),
                 'width' => $field->get('width'),
                 'minWidth' => $field->get('min_width'),
-                'isSystem' => (bool)$field->get('is_system'),
+                'isSystem' => (bool) $field->get('is_system'),
             ];
 
-            // Merge additional configuration from JSON
-            if (!empty($config)) {
+            if ($config !== []) {
                 $fieldData = array_merge($fieldData, $config);
             }
 
@@ -74,15 +81,8 @@ class GridConfigService
         return $fields;
     }
 
-    /**
-     * Get label considering lexicon_key
-     *
-     * @param msGridField $field
-     * @return string
-     */
     protected function resolveLabel(msGridField $field): string
     {
-        // Priority: direct label > lexicon_key > field_name
         $label = $field->get('label');
         if (!empty($label)) {
             return $label;
@@ -92,316 +92,202 @@ class GridConfigService
         if (!empty($lexiconKey)) {
             $this->modx->lexicon->load('minishop3:vue');
             $translated = $this->modx->lexicon($lexiconKey);
-
-            // If translation found (key itself not returned)
             if ($translated !== $lexiconKey) {
                 return $translated;
             }
         }
 
-        // Fallback - field_name
         return $field->get('field_name');
     }
 
     /**
-     * Save grid configuration
-     *
-     * @param string $gridKey
-     * @param array $fields
-     * @return bool
+     * @param list<array<string, mixed>> $fields
      */
     public function saveGridConfig(string $gridKey, array $fields): bool
     {
         try {
-            // Get list of field names to keep
             $fieldNamesToKeep = [];
 
             foreach ($fields as $index => $fieldData) {
                 $fieldName = $fieldData['name'] ?? null;
-
                 if (!$fieldName) {
                     continue;
                 }
 
                 $fieldNamesToKeep[] = $fieldName;
-
-                $field = $this->modx->getObject(msGridField::class, [
-                    'grid_key' => $gridKey,
-                    'field_name' => $fieldName,
-                ]);
-
+                $field = $this->repository->findOne($gridKey, $fieldName);
                 if (!$field) {
-                    $this->modx->log(modX::LOG_LEVEL_WARN,
-                        "[GridConfigService] Field not found: {$gridKey}.{$fieldName}");
+                    $this->modx->log(
+                        modX::LOG_LEVEL_WARN,
+                        "[GridConfigService] Field not found: {$gridKey}.{$fieldName}"
+                    );
                     continue;
                 }
 
-                // Update basic parameters
-                if (isset($fieldData['label'])) {
-                    $field->set('label', $fieldData['label']);
-                }
-                if (isset($fieldData['visible'])) {
-                    $field->set('visible', (bool)$fieldData['visible']);
-                }
-                // Use array index as sort_order to preserve drag & drop order
-                $field->set('sort_order', $index);
+                $this->applySavePayload($field, $fieldData, $index);
 
-                if (isset($fieldData['sortable'])) {
-                    $field->set('sortable', (bool)$fieldData['sortable']);
-                }
-                if (isset($fieldData['filterable'])) {
-                    $field->set('filterable', (bool)$fieldData['filterable']);
-                }
-                if (isset($fieldData['frozen'])) {
-                    $field->set('frozen', (bool)$fieldData['frozen']);
-                }
-                if (isset($fieldData['width'])) {
-                    $field->set('width', $fieldData['width']);
-                }
-                if (isset($fieldData['minWidth'])) {
-                    $field->set('min_width', $fieldData['minWidth']);
-                }
-
-                // Update JSON config (additional parameters)
-                // Start with existing config to preserve values not sent
-                $existingConfig = $field->get('config');
-                if (is_string($existingConfig)) {
-                    $existingConfig = json_decode($existingConfig, true) ?: [];
-                } elseif (!is_array($existingConfig)) {
-                    $existingConfig = [];
-                }
-
-                $config = $existingConfig;
-                $configKeys = [
-                    'template', 'type', 'format', 'actions',
-                    // relation type
-                    'relation',
-                    // computed type
-                    'computed',
-                    // option type
-                    'option',
-                    // badge type
-                    'source_field', 'color_field',
-                    // datetime type
-                    // (format is already included)
-                    // price type
-                    'decimals', 'currency', 'currency_position', 'thousands_separator', 'decimal_separator',
-                    // weight type
-                    'unit', 'unit_position',
-                    // inline edit (category-products)
-                    'editable', 'editor_type', 'editor_options', 'editor_reference', 'editor_combo_endpoint',
-                ];
-                foreach ($configKeys as $key) {
+                $config = $this->repository->decodeConfig($field->get('config'));
+                foreach (self::SAVE_CONFIG_KEYS as $key) {
                     if (array_key_exists($key, $fieldData)) {
                         $config[$key] = $fieldData[$key];
                     }
                 }
 
-                if (($config['editor_type'] ?? '') !== GridColumnEditorType::COMBO) {
-                    unset($config['editor_reference'], $config['editor_combo_endpoint']);
-                }
-
-                $comboCheck = GridEditorReferenceRegistry::validateComboEditorConfig($config);
-                if (!$comboCheck['success']) {
-                    $this->modx->log(modX::LOG_LEVEL_ERROR,
-                        '[GridConfigService] Combo editor validation failed for ' . $gridKey . '.' . $fieldName . ': ' . ($comboCheck['message'] ?? ''));
+                $normalized = $this->normalizeComboEditorConfig($config);
+                if (!$normalized['success']) {
+                    $this->modx->log(
+                        modX::LOG_LEVEL_ERROR,
+                        '[GridConfigService] Combo editor validation failed for '
+                        . $gridKey . '.' . $fieldName . ': ' . ($normalized['message'] ?? '')
+                    );
 
                     return false;
                 }
 
-                $field->set('config', json_encode($config, JSON_UNESCAPED_UNICODE));
+                $field->set('config', $this->repository->encodeConfig($normalized['config']));
+                if (!$this->repository->save($field)) {
+                    $this->modx->log(
+                        modX::LOG_LEVEL_ERROR,
+                        "[GridConfigService] Failed to save field: {$gridKey}.{$fieldName}"
+                    );
 
-                if (!$field->save()) {
-                    $this->modx->log(modX::LOG_LEVEL_ERROR,
-                        "[GridConfigService] Failed to save field: {$gridKey}.{$fieldName}");
                     return false;
                 }
             }
 
-            // Delete fields not in new list (only non-system)
-            $fieldsToDelete = $this->modx->getCollection(msGridField::class, [
-                'grid_key' => $gridKey,
-                'field_name:NOT IN' => $fieldNamesToKeep,
-                'is_system' => false, // Protect system fields
-            ]);
-
-            foreach ($fieldsToDelete as $field) {
+            foreach ($this->repository->findNonSystemNotIn($gridKey, $fieldNamesToKeep) as $field) {
                 $fieldName = $field->get('field_name');
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[GridConfigService] Deleting field: {$gridKey}.{$fieldName}");
-
-                if (!$field->remove()) {
-                    $this->modx->log(modX::LOG_LEVEL_ERROR,
-                        "[GridConfigService] Failed to delete field: {$gridKey}.{$fieldName}");
+                $this->modx->log(modX::LOG_LEVEL_INFO, "[GridConfigService] Deleting field: {$gridKey}.{$fieldName}");
+                if (!$this->repository->remove($field)) {
+                    $this->modx->log(
+                        modX::LOG_LEVEL_ERROR,
+                        "[GridConfigService] Failed to delete field: {$gridKey}.{$fieldName}"
+                    );
                 }
             }
 
             return true;
         } catch (\Exception $e) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR,
-                "[GridConfigService] Error saving grid config: " . $e->getMessage());
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[GridConfigService] Error saving grid config: ' . $e->getMessage()
+            );
+
             return false;
         }
     }
 
     /**
-     * Delete field from grid configuration
-     *
-     * @param string $gridKey
-     * @param string $fieldName
-     * @return array
+     * @param array<string, mixed> $fieldData
+     */
+    private function applySavePayload(msGridField $field, array $fieldData, int $index): void
+    {
+        if (isset($fieldData['label'])) {
+            $field->set('label', $fieldData['label']);
+        }
+        if (isset($fieldData['visible'])) {
+            $field->set('visible', (bool) $fieldData['visible']);
+        }
+        $field->set('sort_order', $index);
+        if (isset($fieldData['sortable'])) {
+            $field->set('sortable', (bool) $fieldData['sortable']);
+        }
+        if (isset($fieldData['filterable'])) {
+            $field->set('filterable', (bool) $fieldData['filterable']);
+        }
+        if (isset($fieldData['frozen'])) {
+            $field->set('frozen', (bool) $fieldData['frozen']);
+        }
+        if (isset($fieldData['width'])) {
+            $field->set('width', $fieldData['width']);
+        }
+        if (isset($fieldData['minWidth'])) {
+            $field->set('min_width', $fieldData['minWidth']);
+        }
+    }
+
+    /**
+     * @return array{success: bool, message: string}
      */
     public function deleteField(string $gridKey, string $fieldName): array
     {
         try {
-            $field = $this->modx->getObject(msGridField::class, [
-                'grid_key' => $gridKey,
-                'field_name' => $fieldName,
-            ]);
-
+            $field = $this->repository->findOne($gridKey, $fieldName);
             if (!$field) {
                 return [
                     'success' => false,
-                    'message' => "Field not found: {$gridKey}.{$fieldName}"
+                    'message' => "Field not found: {$gridKey}.{$fieldName}",
                 ];
             }
 
-            // Protect system fields
             if ($field->get('is_system')) {
                 return [
                     'success' => false,
-                    'message' => 'Cannot delete system field'
+                    'message' => 'Cannot delete system field',
                 ];
             }
 
-            if ($field->remove()) {
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[GridConfigService] Field deleted: {$gridKey}.{$fieldName}");
+            if ($this->repository->remove($field)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_INFO,
+                    "[GridConfigService] Field deleted: {$gridKey}.{$fieldName}"
+                );
 
                 return [
                     'success' => true,
-                    'message' => 'Field deleted successfully'
-                ];
-            } else {
-                return [
-                    'success' => false,
-                    'message' => 'Failed to delete field from database'
+                    'message' => 'Field deleted successfully',
                 ];
             }
-        } catch (\Exception $e) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR,
-                "[GridConfigService] Error deleting field: " . $e->getMessage());
 
             return [
                 'success' => false,
-                'message' => 'Error deleting field: ' . $e->getMessage()
+                'message' => 'Failed to delete field from database',
+            ];
+        } catch (\Exception $e) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[GridConfigService] Error deleting field: ' . $e->getMessage()
+            );
+
+            return [
+                'success' => false,
+                'message' => 'Error deleting field: ' . $e->getMessage(),
             ];
         }
     }
 
     /**
-     * Add new field to grid configuration
-     *
-     * @param string $gridKey
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
+     * @return array{success: bool, message: string, field?: array<string, mixed>}
      */
     public function addField(string $gridKey, array $data): array
     {
         try {
-            // Basic validation
             if (empty($data['field_name'])) {
                 return ['success' => false, 'message' => 'field_name is required'];
             }
 
             if (!preg_match('/^[a-z0-9_]+$/i', $data['field_name'])) {
-                return ['success' => false, 'message' => 'field_name must contain only letters, numbers and underscores'];
+                return [
+                    'success' => false,
+                    'message' => 'field_name must contain only letters, numbers and underscores',
+                ];
             }
 
-            // Check uniqueness
-            $exists = $this->modx->getObject(msGridField::class, [
-                'grid_key' => $gridKey,
-                'field_name' => $data['field_name'],
-            ]);
-
-            if ($exists) {
+            if ($this->repository->findOne($gridKey, $data['field_name'])) {
                 return ['success' => false, 'message' => 'Field with this name already exists'];
             }
 
-            // Validation by type
-            $type = $data['type'] ?? 'model';
-            $config = $data['config'] ?? [];
-
-            switch ($type) {
-                case 'template':
-                    $validation = $this->validateTemplateConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-
-                case 'relation':
-                    $validation = $this->validateRelationConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    // Use updated config with resolvedTableName
-                    if (isset($validation['config'])) {
-                        $config = $validation['config'];
-                    }
-                    break;
-
-                case 'computed':
-                    $validation = $this->validateComputedConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-
-                case 'actions':
-                    $validation = $this->validateActionsConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-
-                case 'option':
-                    $validation = $this->validateOptionConfig(
-                        $config,
-                        (string) ($data['field_name'] ?? '')
-                    );
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
+            $prepared = $this->prepareTypedConfig(
+                (string) ($data['type'] ?? 'model'),
+                is_array($data['config'] ?? null) ? $data['config'] : [],
+                (string) $data['field_name']
+            );
+            if (!$prepared['success']) {
+                return $prepared;
             }
 
-            // Add type to config
-            $config['type'] = $type;
-
-            if (($config['editor_type'] ?? '') !== GridColumnEditorType::COMBO) {
-                unset($config['editor_reference'], $config['editor_combo_endpoint']);
-            }
-
-            $comboCheck = GridEditorReferenceRegistry::validateComboEditorConfig($config);
-            if (!$comboCheck['success']) {
-                return ['success' => false, 'message' => $comboCheck['message'] ?? 'Invalid combo editor configuration'];
-            }
-
-            // Get maximum sort_order
-            $maxSortOrder = 0;
-            $query = $this->modx->newQuery(msGridField::class);
-            $query->where(['grid_key' => $gridKey]);
-            $query->sortby('sort_order', 'DESC');
-            $query->limit(1);
-            $lastField = $this->modx->getObject(msGridField::class, $query);
-            if ($lastField) {
-                $maxSortOrder = (int)$lastField->get('sort_order');
-            }
-
-            // Create field
-            $field = $this->modx->newObject(msGridField::class);
-            $field->fromArray([
+            $field = $this->repository->create([
                 'grid_key' => $gridKey,
                 'field_name' => $data['field_name'],
                 'label' => $data['label'] ?? $data['field_name'],
@@ -411,300 +297,121 @@ class GridConfigService
                 'frozen' => $data['frozen'] ?? false,
                 'width' => $data['width'] ?? null,
                 'min_width' => $data['min_width'] ?? null,
-                'sort_order' => $maxSortOrder + 1,
+                'sort_order' => $this->repository->nextSortOrder($gridKey),
                 'is_system' => false,
-                'config' => json_encode($config, JSON_UNESCAPED_UNICODE),
+                'config' => $this->repository->encodeConfig($prepared['config']),
             ]);
 
-            if ($field->save()) {
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[GridConfigService] Field created: {$gridKey}.{$data['field_name']}");
+            if ($this->repository->save($field)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_INFO,
+                    "[GridConfigService] Field created: {$gridKey}.{$data['field_name']}"
+                );
 
                 return [
                     'success' => true,
                     'message' => 'Field created successfully',
-                    'field' => $field->toArray()
+                    'field' => $field->toArray(),
                 ];
-            } else {
-                return ['success' => false, 'message' => 'Failed to save field'];
             }
 
+            return ['success' => false, 'message' => 'Failed to save field'];
         } catch (\Exception $e) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR,
-                "[GridConfigService] Error adding field: " . $e->getMessage());
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[GridConfigService] Error adding field: ' . $e->getMessage()
+            );
 
             return [
                 'success' => false,
-                'message' => 'Error adding field: ' . $e->getMessage()
+                'message' => 'Error adding field: ' . $e->getMessage(),
             ];
         }
     }
 
     /**
-     * Update existing field in grid configuration
-     *
-     * @param string $gridKey
-     * @param string $fieldName
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
+     * @return array{success: bool, message: string, field?: array<string, mixed>}
      */
     public function updateField(string $gridKey, string $fieldName, array $data): array
     {
         try {
-            // Find existing field
-            $field = $this->modx->getObject(msGridField::class, [
-                'grid_key' => $gridKey,
-                'field_name' => $fieldName,
-            ]);
-
+            $field = $this->repository->findOne($gridKey, $fieldName);
             if (!$field) {
                 return ['success' => false, 'message' => "Field not found: {$gridKey}.{$fieldName}"];
             }
 
-            // Protect system fields from type changes
             if ($field->get('is_system')) {
                 return ['success' => false, 'message' => 'Cannot modify system field'];
             }
 
-            // Get field type
-            $type = $data['type'] ?? 'model';
-            $config = $data['config'] ?? [];
-
-            // Validation by type
-            switch ($type) {
-                case 'template':
-                    $validation = $this->validateTemplateConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-                case 'relation':
-                    $validation = $this->validateRelationConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    // Use updated config with resolvedTableName
-                    if (isset($validation['config'])) {
-                        $config = $validation['config'];
-                    }
-                    break;
-                case 'computed':
-                    $validation = $this->validateComputedConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-                case 'actions':
-                    $validation = $this->validateActionsConfig($config);
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
-                case 'option':
-                    $validation = $this->validateOptionConfig(
-                        $config,
-                        (string) ($data['field_name'] ?? $fieldName)
-                    );
-                    if (!$validation['success']) {
-                        return $validation;
-                    }
-                    break;
+            $prepared = $this->prepareTypedConfig(
+                (string) ($data['type'] ?? 'model'),
+                is_array($data['config'] ?? null) ? $data['config'] : [],
+                (string) ($data['field_name'] ?? $fieldName)
+            );
+            if (!$prepared['success']) {
+                return $prepared;
             }
 
-            // Add type to config
-            $config['type'] = $type;
-
-            if (($config['editor_type'] ?? '') !== GridColumnEditorType::COMBO) {
-                unset($config['editor_reference'], $config['editor_combo_endpoint']);
-            }
-
-            $comboCheck = GridEditorReferenceRegistry::validateComboEditorConfig($config);
-            if (!$comboCheck['success']) {
-                return ['success' => false, 'message' => $comboCheck['message'] ?? 'Invalid combo editor configuration'];
-            }
-
-            // Update field
             if (isset($data['label'])) {
                 $field->set('label', $data['label']);
             }
             if (isset($data['visible'])) {
-                $field->set('visible', (bool)$data['visible']);
+                $field->set('visible', (bool) $data['visible']);
             }
             if (isset($data['sortable'])) {
-                $field->set('sortable', (bool)$data['sortable']);
+                $field->set('sortable', (bool) $data['sortable']);
             }
             if (isset($data['filterable'])) {
-                $field->set('filterable', (bool)$data['filterable']);
+                $field->set('filterable', (bool) $data['filterable']);
             }
             if (isset($data['frozen'])) {
-                $field->set('frozen', (bool)$data['frozen']);
+                $field->set('frozen', (bool) $data['frozen']);
             }
             if (isset($data['width'])) {
                 $field->set('width', $data['width'] ?: null);
             }
 
-            // Update JSON config
-            $field->set('config', json_encode($config, JSON_UNESCAPED_UNICODE));
+            $field->set('config', $this->repository->encodeConfig($prepared['config']));
 
-            if ($field->save()) {
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[GridConfigService] Field updated: {$gridKey}.{$fieldName}");
+            if ($this->repository->save($field)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_INFO,
+                    "[GridConfigService] Field updated: {$gridKey}.{$fieldName}"
+                );
 
                 return [
                     'success' => true,
                     'message' => 'Field updated successfully',
-                    'field' => $field->toArray()
+                    'field' => $field->toArray(),
                 ];
-            } else {
-                return ['success' => false, 'message' => 'Failed to save field'];
             }
 
+            return ['success' => false, 'message' => 'Failed to save field'];
         } catch (\Exception $e) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR,
-                "[GridConfigService] Error updating field: " . $e->getMessage());
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[GridConfigService] Error updating field: ' . $e->getMessage()
+            );
 
             return [
                 'success' => false,
-                'message' => 'Error updating field: ' . $e->getMessage()
+                'message' => 'Error updating field: ' . $e->getMessage(),
             ];
         }
     }
 
     /**
-     * Validate Template field configuration
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function validateTemplateConfig(array $config): array
-    {
-        if (empty($config['template'])) {
-            return ['success' => false, 'message' => 'template is required for template field'];
-        }
-
-        if (!is_string($config['template'])) {
-            return ['success' => false, 'message' => 'template must be a string'];
-        }
-
-        return ['success' => true];
-    }
-
-    /**
-     * Validate Relation field configuration
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function validateRelationConfig(array $config): array
-    {
-        $relation = $config['relation'] ?? [];
-
-        if (empty($relation['table'])) {
-            return ['success' => false, 'message' => 'relation.table is required'];
-        }
-
-        if (empty($relation['foreignKey'])) {
-            return ['success' => false, 'message' => 'relation.foreignKey is required'];
-        }
-
-        if (empty($relation['displayField'])) {
-            return ['success' => false, 'message' => 'relation.displayField is required'];
-        }
-
-        // Validate aggregation
-        $aggregation = $relation['aggregation'] ?? null;
-        $allowedAggregations = ['COUNT', 'SUM', 'AVG', 'MIN', 'MAX'];
-
-        if ($aggregation !== null && !in_array($aggregation, $allowedAggregations)) {
-            return ['success' => false, 'message' => "Invalid aggregation type. Allowed: " . implode(', ', $allowedAggregations)];
-        }
-
-        // Determine type: model or direct table name
-        $tableOrModel = $relation['table'];
-        $isModel = strpos($tableOrModel, '\\') !== false || strpos($tableOrModel, '::') !== false;
-
-        if ($isModel) {
-            // This is model class - get table name
-            try {
-                $tableName = $this->modx->getTableName($tableOrModel);
-
-                if (empty($tableName)) {
-                    return ['success' => false, 'message' => "Unable to get table name for model: {$tableOrModel}"];
-                }
-
-                // Save resolved table name in config for query usage
-                $config['relation']['resolvedTableName'] = $tableName;
-            } catch (\Exception $e) {
-                return ['success' => false, 'message' => "Invalid model class: {$tableOrModel}. " . $e->getMessage()];
-            }
-        } else {
-            // This is direct table name - add table prefix if not already present
-            $tablePrefix = $this->modx->config['table_prefix'] ?? '';
-            if ($tablePrefix !== '' && !str_starts_with($tableOrModel, $tablePrefix)) {
-                $tableOrModel = $tablePrefix . $tableOrModel;
-            }
-            $config['relation']['resolvedTableName'] = $tableOrModel;
-        }
-
-        return ['success' => true, 'config' => $config];
-    }
-
-    /**
-     * Validate Computed field configuration
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function validateComputedConfig(array $config): array
-    {
-        $computed = $config['computed'] ?? [];
-
-        if (empty($computed['className'])) {
-            return ['success' => false, 'message' => 'computed.className is required'];
-        }
-
-        // Check that class exists
-        if (!class_exists($computed['className'])) {
-            return ['success' => false, 'message' => "Class {$computed['className']} not found"];
-        }
-
-        // Check that class implements required interface
-        $interfaces = class_implements($computed['className']);
-        if (!isset($interfaces['MiniShop3\\Interfaces\\ComputedFieldInterface'])) {
-            return ['success' => false, 'message' => "Class must implement ComputedFieldInterface"];
-        }
-
-        return ['success' => true];
-    }
-
-    /**
-     * Get filterable fields from grid configuration
-     *
-     * @param string $gridKey Grid key
-     * @return array Array of filterable field configs
+     * @return array<string, array{field_name: string, label: string, type: mixed, config: array<string, mixed>}>
      */
     public function getFilterableFields(string $gridKey): array
     {
-        $query = $this->modx->newQuery(msGridField::class);
-        $query->where([
-            'grid_key' => $gridKey,
-            'filterable' => true,
-        ]);
-        $query->sortby('sort_order', 'ASC');
-
         $filters = [];
-        $collection = $this->modx->getCollection(msGridField::class, $query);
 
-        foreach ($collection as $field) {
+        foreach ($this->repository->findFilterableByGridKey($gridKey) as $field) {
             $fieldName = $field->get('field_name');
-            $config = $field->get('config');
-
-            // Parse JSON config
-            if (is_string($config)) {
-                $config = json_decode($config, true) ?: [];
-            } elseif (!is_array($config)) {
-                $config = [];
-            }
+            $config = $this->repository->decodeConfig($field->get('config'));
 
             $filters[$fieldName] = [
                 'field_name' => $fieldName,
@@ -718,188 +425,53 @@ class GridConfigService
     }
 
     /**
-     * Validate Actions field configuration
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function validateActionsConfig(array $config): array
-    {
-        $actions = $config['actions'] ?? [];
-
-        // Actions can be empty array - this is allowed
-        if (!is_array($actions)) {
-            return ['success' => false, 'message' => 'actions must be an array'];
-        }
-
-        // Built-in Vue manager handlers (see vueManager/src/actionRegistry.js)
-        $allowedHandlers = ['edit', 'delete', 'view', 'refresh', 'addresses', 'publish', 'duplicate'];
-        $actionNames = [];
-
-        foreach ($actions as $index => $action) {
-            // Required field name
-            if (empty($action['name'])) {
-                return ['success' => false, 'message' => "actions[{$index}].name is required"];
-            }
-
-            // Check name uniqueness
-            if (in_array($action['name'], $actionNames)) {
-                return ['success' => false, 'message' => "Duplicate action name: {$action['name']}"];
-            }
-            $actionNames[] = $action['name'];
-
-            // Required field handler
-            if (empty($action['handler'])) {
-                return ['success' => false, 'message' => "actions[{$index}].handler is required"];
-            }
-
-            // Handler must be either built-in or start with 'custom:'
-            $handler = $action['handler'];
-            if (!in_array($handler, $allowedHandlers) && strpos($handler, 'custom:') !== 0) {
-                // Allow any handlers - they can be registered by plugins
-                // But log warning
-                $this->modx->log(modX::LOG_LEVEL_INFO,
-                    "[GridConfigService] Custom handler used: {$handler} in action {$action['name']}");
-            }
-
-            // Validate severity if specified
-            if (!empty($action['severity'])) {
-                $allowedSeverities = ['secondary', 'success', 'info', 'warn', 'danger'];
-                if (!in_array($action['severity'], $allowedSeverities)) {
-                    return ['success' => false, 'message' => "Invalid severity for action {$action['name']}. Allowed: " . implode(', ', $allowedSeverities)];
-                }
-            }
-        }
-
-        return ['success' => true];
-    }
-
-    /**
-     * Validate Option field configuration
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function validateOptionConfig(array $config, string $fieldName = ''): array
-    {
-        $option = $config['option'] ?? [];
-
-        if (empty($option['key'])) {
-            return ['success' => false, 'message' => 'option.key is required for option field'];
-        }
-
-        $key = (string) $option['key'];
-        if (!OptionColumnSpec::isValidOptionKey($key)) {
-            return ['success' => false, 'message' => 'option.key must contain only letters, numbers and underscores'];
-        }
-
-        if ($fieldName !== '' && !OptionColumnSpec::isValidFieldName($fieldName)) {
-            return [
-                'success' => false,
-                'message' => "Field name '{$fieldName}' is not allowed for option columns: "
-                    . "it collides with a builtin product column or contains invalid characters. "
-                    . "Use a name like 'option_{$key}' instead.",
-            ];
-        }
-
-        return ['success' => true];
-    }
-
-    /**
-     * Extract relation fields from grid config and group by table+foreignKey
-     * for efficient JOIN building
-     *
-     * @param array $gridFields Array of grid field configs
-     * @return array Grouped relation fields structure:
-     *   [
-     *     'table_foreignKey' => [
-     *       'table' => 'msOrderStatus',
-     *       'modelClass' => 'MiniShop3\Model\msOrderStatus',
-     *       'foreignKey' => 'status_id',
-     *       'alias' => 'rel_msOrderStatus_status_id',
-     *       'fields' => [
-     *         ['name' => 'status_name', 'displayField' => 'name'],
-     *         ['name' => 'status_color', 'displayField' => 'color'],
-     *       ]
-     *     ]
-     *   ]
+     * @param list<array<string, mixed>> $gridFields
+     * @return array<string, mixed>
      */
     public function extractRelationFields(array $gridFields): array
     {
-        $relationGroups = [];
-
-        foreach ($gridFields as $field) {
-            // Skip non-relation fields
-            if (($field['type'] ?? 'model') !== 'relation') {
-                continue;
-            }
-
-            $relation = $field['relation'] ?? null;
-            if (!$relation || empty($relation['table']) || empty($relation['foreignKey']) || empty($relation['displayField'])) {
-                continue;
-            }
-
-            $table = $relation['table'];
-            $foreignKey = $relation['foreignKey'];
-            $displayField = $relation['displayField'];
-            $fieldName = $field['name'];
-
-            // Group key: table + foreignKey (same table with same FK = one JOIN)
-            $groupKey = "{$table}_{$foreignKey}";
-
-            if (!isset($relationGroups[$groupKey])) {
-                // Resolve model class from table name
-                $modelClass = $this->resolveModelClass($table);
-
-                // Generate unique alias for this JOIN
-                $alias = "rel_{$table}_{$foreignKey}";
-
-                $relationGroups[$groupKey] = [
-                    'table' => $table,
-                    'modelClass' => $modelClass,
-                    'foreignKey' => $foreignKey,
-                    'alias' => $alias,
-                    'fields' => [],
-                ];
-            }
-
-            // Add field to this group
-            $relationGroups[$groupKey]['fields'][] = [
-                'name' => $fieldName,
-                'displayField' => $displayField,
-            ];
-        }
-
-        return $relationGroups;
+        return $this->relationExtractor->extract($gridFields);
     }
 
     /**
-     * Resolve full model class name from short table name
+     * Type rules + combo editor cleanup for add/update payloads.
      *
-     * @param string $tableName Short table name (e.g. 'msOrderStatus')
-     * @return string|null Full class name or null if not found
+     * @param array<string, mixed> $config
+     * @return array{success: bool, message?: string, config?: array<string, mixed>}
      */
-    protected function resolveModelClass(string $tableName): ?string
+    private function prepareTypedConfig(string $type, array $config, string $fieldName): array
     {
-        // Known MiniShop3 model mappings
-        $modelMap = [
-            'msOrder' => 'MiniShop3\\Model\\msOrder',
-            'msOrderStatus' => 'MiniShop3\\Model\\msOrderStatus',
-            'msOrderAddress' => 'MiniShop3\\Model\\msOrderAddress',
-            'msOrderProduct' => 'MiniShop3\\Model\\msOrderProduct',
-            'msDelivery' => 'MiniShop3\\Model\\msDelivery',
-            'msPayment' => 'MiniShop3\\Model\\msPayment',
-            'msProduct' => 'MiniShop3\\Model\\msProduct',
-            'msProductData' => 'MiniShop3\\Model\\msProductData',
-            'msCategory' => 'MiniShop3\\Model\\msCategory',
-            'msCategoryMember' => 'MiniShop3\\Model\\msCategoryMember',
-            'msVendor' => 'MiniShop3\\Model\\msVendor',
-            'msCustomer' => 'MiniShop3\\Model\\msCustomer',
-            'modUser' => 'MODX\\Revolution\\modUser',
-            'modUserProfile' => 'MODX\\Revolution\\modUserProfile',
-            'modResource' => 'MODX\\Revolution\\modResource',
-        ];
+        $validation = $this->typeValidator->validateForType($type, $config, $fieldName);
+        if (!$validation['success']) {
+            return $validation;
+        }
+        if (isset($validation['config'])) {
+            $config = $validation['config'];
+        }
 
-        return $modelMap[$tableName] ?? null;
+        $config['type'] = $type;
+
+        return $this->normalizeComboEditorConfig($config);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array{success: bool, message?: string, config?: array<string, mixed>}
+     */
+    private function normalizeComboEditorConfig(array $config): array
+    {
+        if (($config['editor_type'] ?? '') !== GridColumnEditorType::COMBO) {
+            unset($config['editor_reference'], $config['editor_combo_endpoint']);
+        }
+
+        $comboCheck = GridEditorReferenceRegistry::validateComboEditorConfig($config);
+        if (!$comboCheck['success']) {
+            return [
+                'success' => false,
+                'message' => $comboCheck['message'] ?? 'Invalid combo editor configuration',
+            ];
+        }
+
+        return ['success' => true, 'config' => $config];
     }
 }

--- a/core/components/minishop3/tests/GridColumnTypeValidatorTest.php
+++ b/core/components/minishop3/tests/GridColumnTypeValidatorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * GridColumnTypeValidator smoke (Phase A #365).
+ *
+ * Run: php tests/GridColumnTypeValidatorTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/GridValidatorModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Grid\GridColumnTypeValidator;
+use MiniShop3\Tests\Stubs\GridValidatorModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertTrue = static function (bool $cond, string $case) use ($fail): void {
+    if (!$cond) {
+        $fail($case);
+    }
+};
+
+$validator = new GridColumnTypeValidator(new GridValidatorModxStub());
+
+$failTemplate = $validator->validateForType('template', []);
+$assertTrue(($failTemplate['success'] ?? true) === false, 'template empty fails');
+
+$okTemplate = $validator->validateForType('template', ['template' => '{{name}}']);
+$assertTrue(($okTemplate['success'] ?? false) === true, 'template string ok');
+
+$failOption = $validator->validateForType('option', []);
+$assertTrue(($failOption['success'] ?? true) === false, 'option empty fails');
+
+$okOption = $validator->validateForType('option', ['option' => ['key' => 'color']], 'option_color');
+$assertTrue(($okOption['success'] ?? false) === true, 'option ok');
+
+$collision = $validator->validateForType('option', ['option' => ['key' => 'color']], 'price');
+$assertTrue(($collision['success'] ?? true) === false, 'option field name collision');
+
+$dupActions = $validator->validateForType('actions', [
+    'actions' => [
+        ['name' => 'edit', 'handler' => 'edit'],
+        ['name' => 'edit', 'handler' => 'delete'],
+    ],
+]);
+$assertTrue(($dupActions['success'] ?? true) === false, 'duplicate action name fails');
+
+$okActions = $validator->validateForType('actions', [
+    'actions' => [
+        ['name' => 'edit', 'handler' => 'edit'],
+        ['name' => 'delete', 'handler' => 'delete'],
+    ],
+]);
+$assertTrue(($okActions['success'] ?? false) === true, 'actions ok');
+
+$modelOk = $validator->validateForType('model', []);
+$assertTrue(($modelOk['success'] ?? false) === true, 'model type always ok');
+
+$failRelation = $validator->validateForType('relation', []);
+$assertTrue(($failRelation['success'] ?? true) === false, 'relation empty fails');
+
+$okRelation = $validator->validateForType('relation', [
+    'relation' => [
+        'table' => 'ms3_orders',
+        'foreignKey' => 'id',
+        'displayField' => 'num',
+    ],
+]);
+$assertTrue(($okRelation['success'] ?? false) === true, 'relation table ok');
+$assertTrue(
+    ($okRelation['config']['relation']['resolvedTableName'] ?? '') === 'modx_ms3_orders',
+    'relation resolvedTableName gets table_prefix'
+);
+
+$failAgg = $validator->validateForType('relation', [
+    'relation' => [
+        'table' => 'ms3_orders',
+        'foreignKey' => 'id',
+        'displayField' => 'num',
+        'aggregation' => 'MEDIAN',
+    ],
+]);
+$assertTrue(($failAgg['success'] ?? true) === false, 'invalid aggregation fails');
+
+fwrite(STDOUT, "OK: GridColumnTypeValidatorTest\n");
+exit(0);

--- a/core/components/minishop3/tests/Unit/Services/Grid/GridConfigRepositoryEmptyKeepTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Grid/GridConfigRepositoryEmptyKeepTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Grid;
+
+use MiniShop3\Services\Grid\GridConfigRepository;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Empty keep-list must not wipe all non-system fields (#365 Phase A review).
+ */
+final class GridConfigRepositoryEmptyKeepTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testEmptyKeepReturnsNoDeletionCandidates(): void
+    {
+        $modx = new class extends modX {
+            public function getCollection($class, $criteria = null, $cacheFlag = true): never
+            {
+                throw new \RuntimeException('getCollection must not run for empty keep');
+            }
+        };
+
+        $repo = new GridConfigRepository($modx);
+
+        self::assertSame([], $repo->findNonSystemNotIn('orders', []));
+    }
+}

--- a/core/components/minishop3/tests/Unit/Services/Grid/GridRelationFieldExtractorTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Grid/GridRelationFieldExtractorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Grid;
+
+use MiniShop3\Services\Grid\GridRelationFieldExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class GridRelationFieldExtractorTest extends TestCase
+{
+    public function testGroupsByTableAndForeignKey(): void
+    {
+        $extractor = new GridRelationFieldExtractor();
+        $groups = $extractor->extract([
+            [
+                'name' => 'status_name',
+                'type' => 'relation',
+                'relation' => [
+                    'table' => 'msOrderStatus',
+                    'foreignKey' => 'status_id',
+                    'displayField' => 'name',
+                ],
+            ],
+            [
+                'name' => 'status_color',
+                'type' => 'relation',
+                'relation' => [
+                    'table' => 'msOrderStatus',
+                    'foreignKey' => 'status_id',
+                    'displayField' => 'color',
+                ],
+            ],
+            [
+                'name' => 'pagetitle',
+                'type' => 'model',
+            ],
+        ]);
+
+        self::assertCount(1, $groups);
+        $group = $groups['msOrderStatus_status_id'];
+        self::assertSame('MiniShop3\\Model\\msOrderStatus', $group['modelClass']);
+        self::assertCount(2, $group['fields']);
+        self::assertSame('rel_msOrderStatus_status_id', $group['alias']);
+    }
+
+    public function testSkipsIncompleteRelation(): void
+    {
+        $extractor = new GridRelationFieldExtractor();
+        $groups = $extractor->extract([
+            [
+                'name' => 'broken',
+                'type' => 'relation',
+                'relation' => ['table' => 'msVendor'],
+            ],
+        ]);
+
+        self::assertSame([], $groups);
+    }
+}

--- a/core/components/minishop3/tests/stubs/GridValidatorModxStub.php
+++ b/core/components/minishop3/tests/stubs/GridValidatorModxStub.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MODX\Revolution\modX;
+
+/**
+ * Minimal modX for GridColumnTypeValidator unit tests (log + table_prefix).
+ */
+final class GridValidatorModxStub extends modX
+{
+    /** @var array<string, mixed> */
+    public $config = ['table_prefix' => 'modx_'];
+
+    public function __construct()
+    {
+    }
+
+    public function log($level, $msg = '', $target = '', $def = '', $file = '', $line = ''): void
+    {
+    }
+
+    public function getTableName($className, $escape = true): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
## Описание

Phase A из [#365](https://github.com/modx-pro/MiniShop3/issues/365): `GridConfigService` (~905 LOC) разрезан на persistence + type validators + relation extractor. Фасад остаётся публичным API для контроллеров (~477 LOC).

Новые классы:
- `GridConfigRepository` — чтение/сохранение `msGridField`
- `GridColumnTypeValidator` — template/relation/computed/actions/option
- `GridRelationFieldExtractor` — группировка JOIN для relation-колонок

Поведение mgr API без изменений контракта. Пустой keep-list при save больше не удаляет все non-system поля (безопасный guard вместо `NOT IN ()`).

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Refs #365 (Phase A only; OptionLoader / ProductData — отдельно)

## Как это было протестировано?

Gate E (локально, exit 0):

```bash
cd core/components/minishop3
php -l src/Services/GridConfigService.php
php -l src/Services/Grid/GridConfigRepository.php
php -l src/Services/Grid/GridColumnTypeValidator.php
php -l src/Services/Grid/GridRelationFieldExtractor.php
php -l src/Services/Grid/OptionColumnSpec.php
php -l tests/GridColumnTypeValidatorTest.php
php -l tests/Unit/Services/Grid/GridRelationFieldExtractorTest.php
php -l tests/Unit/Services/Grid/GridConfigRepositoryEmptyKeepTest.php
php -l tests/stubs/GridValidatorModxStub.php
vendor/bin/phpunit tests/Unit/Services/Grid/   # 14 tests, OK
php tests/GridColumnTypeValidatorTest.php      # OK
php tests/GridConfigRouteAclTest.php           # OK
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-365-split-grid-config-service`
- MODX: n/a (unit/smoke stubs)
- PHP: 8.4.17

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — n/a, без UI-строк
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — n/a, Vue не трогали
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — релизный цикл, не этот PR

## Дополнительные заметки

**Out of scope:** Phase B (`OptionLoaderService`), Phase C (`ProductDataService`), Vue (#354), memoize #352/#488.

**Review (Gate F):** code-reviewer + thermo-nuclear — blockers нет после фикса empty-keep. Soft: identity `extractRelationFields`, дубль scalar setters в `updateField`/`applySavePayload`, silent fail на `remove` в save (pre-existing).

**AC (#365, Phase A):**
| Критерий | Статус |
|----------|--------|
| GridConfigService ≤ ~500 LOC | да (477) |
| Публичные методы сохранены / facade | да |
| #352 memoize не ломается | n/a в этом PR (не трогали memoize) |
| php -l + smoke grid-config | да (lint + validator/extractor/empty-keep + ACL smoke) |