### PR TITLE
refactor(product): разрез ProductDataService (Phase C #365)

### DIFF
--- a/core/components/minishop3/src/Services/Product/ProductCategoryMembershipWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductCategoryMembershipWriter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msProductData;
+use MODX\Revolution\modX;
+
+/**
+ * Synchronizes msCategoryMember with product categories payload.
+ */
+class ProductCategoryMembershipWriter
+{
+    use ProductDataExplicitFieldsTrait;
+
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * Save additional product categories.
+     *
+     * If `categories` was not sent, leave msCategoryMember untouched.
+     */
+    public function saveCategories(msProductData $productData): void
+    {
+        $fields = $this->readExplicitFields($productData);
+        if (!array_key_exists('categories', $fields)) {
+            return;
+        }
+
+        $productId = $productData->get('id');
+        $categories = $this->normalizeList($fields['categories']);
+
+        $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
+
+        foreach ($categories as $categoryId) {
+            if (empty($categoryId) || !is_numeric($categoryId)) {
+                continue;
+            }
+
+            /** @var msCategoryMember $member */
+            $member = $this->modx->newObject(msCategoryMember::class);
+            $member->set('product_id', $productId);
+            $member->set('category_id', (int)$categoryId);
+            $member->save();
+        }
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function normalizeList(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = json_decode($value, true);
+        }
+
+        return is_array($value) ? $value : [];
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductDataExplicitFieldsTrait.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataExplicitFieldsTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+
+/**
+ * Read raw xPDO `_fields` (POST/explicit payload) without going through msProductData::get().
+ */
+trait ProductDataExplicitFieldsTrait
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private function readExplicitFields(msProductData $productData): array
+    {
+        $reflection = new \ReflectionClass($productData);
+        $property = $reflection->getProperty('_fields');
+        $property->setAccessible(true);
+        $fields = $property->getValue($productData);
+
+        return is_array($fields) ? $fields : [];
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -2,14 +2,10 @@
 
 namespace MiniShop3\Services\Product;
 
-use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
-use MiniShop3\Model\msProductFile;
-use MiniShop3\Model\msProductLink;
 use MiniShop3\Model\msProductOption;
 use MiniShop3\Services\ExtraFields\RepeaterFieldService;
-use MiniShop3\Utils\EventGate;
 use MODX\Revolution\modX;
 
 /**
@@ -20,52 +16,59 @@ use MODX\Revolution\modX;
  */
 class ProductDataService
 {
+    /** Error codes for updateProductData */
+    public const ERROR_FORBIDDEN = 403;
+    public const ERROR_NOT_FOUND = 404;
+    public const ERROR_VALIDATION = 422;
+    public const ERROR_SAVE = 500;
+
+    /** Allowed fields for inline / API update (msProductData) */
+    protected static array $allowedUpdateFields = [
+        'article', 'price', 'old_price', 'stock', 'weight',
+        'vendor_id', 'made_in', 'new', 'popular', 'favorite',
+    ];
+
+    /** Resource (modResource) fields updatable via same API (e.g. published) */
+    protected static array $allowedResourceFields = ['published'];
+
     /** @var modX */
     protected $modx;
 
-    /** @var array<string, array>|null */
-    protected ?array $productRepeaterFields = null;
+    protected ProductRepeaterSupport $repeaterSupport;
+    protected ProductCategoryMembershipWriter $categoryWriter;
+    protected ProductOptionsWriter $optionsWriter;
+    protected ProductLinksWriter $linksWriter;
+    protected ProductModifierHooks $modifierHooks;
+    protected ProductRemovalHelper $removalHelper;
 
-    /**
-     * @param modX $modx
-     */
     public function __construct(modX $modx)
     {
         $this->modx = $modx;
+        $this->repeaterSupport = new ProductRepeaterSupport($modx);
+        $this->categoryWriter = new ProductCategoryMembershipWriter($modx);
+        $this->optionsWriter = new ProductOptionsWriter($modx);
+        $this->linksWriter = new ProductLinksWriter($modx);
+        $this->modifierHooks = new ProductModifierHooks($modx);
+        $this->removalHelper = new ProductRemovalHelper($modx);
     }
 
     protected function getRepeaterFieldService(): RepeaterFieldService
     {
-        /** @var RepeaterFieldService $service */
-        $service = $this->modx->services->get('ms3_repeater_field');
-
-        return $service;
+        return $this->repeaterSupport->getRepeaterFieldService();
     }
 
     /**
+     * Overridable hook for tests (see TestableProductDataService).
+     *
      * @return array<string, array>
      */
     protected function getProductRepeaterFields(): array
     {
-        if ($this->productRepeaterFields === null) {
-            $this->productRepeaterFields = $this->getRepeaterFieldService()->getRepeaterFieldsForClass(
-                msProductData::class
-            );
-        }
-
-        return $this->productRepeaterFields;
+        return $this->repeaterSupport->getProductRepeaterFields();
     }
 
     /**
-     * Prepare object before saving
-     *
-     * Performs comprehensive product data preparation:
-     * - Prepare array fields (tags, color, size etc.) - remove duplicates, empty values
-     * - Set source_id for new products
-     * - Cast numeric and boolean fields to proper types (including extra fields)
-     *
-     * @param msProductData $productData
-     * @return void
+     * Prepare object before saving: array/repeater fields, source_id, numeric casts.
      */
     public function prepareObject(msProductData $productData): void
     {
@@ -74,353 +77,96 @@ class ProductDataService
 
         foreach ($productData->getArraysValues() as $name => $array) {
             if (isset($repeaterFields[$name])) {
-                $normalized = $repeaterService->processValue($array, $repeaterFields[$name]);
-                $productData->set($name, $normalized);
+                $productData->set($name, $repeaterService->processValue($array, $repeaterFields[$name]));
                 continue;
             }
 
-            $array = $productData->prepareOptionValues($array);
-            $productData->set($name, $array);
+            $productData->set($name, $productData->prepareOptionValues($array));
         }
 
         if ($productData->isNew()) {
             $productData->set('source_id', $this->modx->getOption('ms3_product_source_default', null, 1));
         }
 
-        // Cast all numeric and boolean fields (including extra fields) to proper types
-        // Prevents MySQL errors when empty string '' is sent for decimal/int/tinyint columns
+        // Cast numeric/boolean fields (incl. extra fields) so '' does not break MySQL decimals/ints
         foreach ($productData->_fieldMeta as $key => $meta) {
             if ($key === 'id') {
                 continue;
             }
+
             $phptype = $meta['phptype'] ?? '';
             $value = $productData->get($key);
+            $isEmpty = $value === '' || $value === null;
 
-            if ($phptype === 'float') {
-                $productData->set($key, ($value === '' || $value === null) ? 0.0 : (float)$value);
-            } elseif ($phptype === 'integer') {
-                $productData->set($key, ($value === '' || $value === null) ? 0 : (int)$value);
-            } elseif ($phptype === 'boolean') {
-                $productData->set($key, ($value === '' || $value === null) ? false : (bool)$value);
-            }
+            match ($phptype) {
+                'float' => $productData->set($key, $isEmpty ? 0.0 : (float)$value),
+                'integer' => $productData->set($key, $isEmpty ? 0 : (int)$value),
+                'boolean' => $productData->set($key, $isEmpty ? false : (bool)$value),
+                default => null,
+            };
         }
     }
 
-    /**
-     * Save additional product categories
-     *
-     * Synchronizes msCategoryMember table with categories array from 'categories' field
-     * Expected data format: JSON array [3,4,27]
-     *
-     * IMPORTANT: msProductData::get('categories') is overridden and reads from DB,
-     * so we use reflection to get the value from $_fields (POST data)
-     *
-     * If `categories` was not sent (e.g. manager save before the Categories tab mounted its
-     * hidden field), leave msCategoryMember untouched — same contract as saveLinks().
-     *
-     * @param msProductData $productData
-     * @return void
-     */
     public function saveCategories(msProductData $productData): void
     {
-        $productId = $productData->get('id');
-
-        $reflection = new \ReflectionClass($productData);
-        $property = $reflection->getProperty('_fields');
-        $property->setAccessible(true);
-        $fields = $property->getValue($productData);
-
-        if (!array_key_exists('categories', $fields)) {
-            return;
-        }
-
-        $categories = $fields['categories'];
-
-        if (is_string($categories)) {
-            $categories = json_decode($categories, true);
-            if (!is_array($categories)) {
-                $categories = [];
-            }
-        } elseif (!is_array($categories)) {
-            $categories = [];
-        }
-
-        $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
-
-        foreach ($categories as $categoryId) {
-            if (!empty($categoryId) && is_numeric($categoryId)) {
-                /** @var msCategoryMember $member */
-                $member = $this->modx->newObject(msCategoryMember::class);
-                $member->set('product_id', $productId);
-                $member->set('category_id', (int)$categoryId);
-                $member->save();
-            }
-        }
+        $this->categoryWriter->saveCategories($productData);
     }
 
     /**
-     * Save product options
-     *
-     * Synchronizes data from JSON fields with msProductOption table
-     * via msProductOption::saveProductOptions() method
-     *
-     * @param msProductData $productData
      * @param array|null $options If null: built from JSON fields explicitly present in POST/_fields on
      *                           $productData (including cleared empty values). If array: explicit keys/values
      *                           (e.g. manager POST options-*); then $removeOther is honored.
      * @param bool $removeOther When $options is non-null: if true, delete msProductOption rows whose keys are absent
      *                         from $options. When $options is null: ignored — always treated as false so category-only
      *                         options not mirrored in JSON fields are preserved (#153, #158).
-     * @return void
      */
     public function saveOptions(msProductData $productData, ?array $options = null, bool $removeOther = true): void
     {
-        $productId = $productData->get('id');
-
-        $optionsExplicit = $options !== null;
-        $repeaterKeys = array_keys($this->getProductRepeaterFields());
-
-        if ($options === null) {
-            $options = [];
-            $reflection = new \ReflectionClass($productData);
-            $property = $reflection->getProperty('_fields');
-            $property->setAccessible(true);
-            $rawFields = $property->getValue($productData);
-
-            foreach ($productData->_fieldMeta as $key => $meta) {
-                if (($meta['phptype'] ?? '') !== 'json') {
-                    continue;
-                }
-                if (in_array($key, $repeaterKeys, true)) {
-                    continue;
-                }
-                if (!array_key_exists($key, $rawFields)) {
-                    continue;
-                }
-
-                $fieldValue = $productData->get($key);
-                $options[$key] = !empty($fieldValue) ? $fieldValue : null;
-            }
-        }
-
-        // When options=null we only sync JSON fields — do not remove custom category options
-        $removeOther = $optionsExplicit ? $removeOther : false;
-
-        /** @var msProductOption $optionInstance */
-        $optionInstance = $this->modx->newObject(msProductOption::class);
-        $optionInstance->saveProductOptions($productId, $options, $removeOther);
+        $this->optionsWriter->saveOptions(
+            $productData,
+            $options,
+            $removeOther,
+            array_keys($this->getProductRepeaterFields())
+        );
     }
 
-    /**
-     * Save product links
-     *
-     * Synchronizes msProductLink table with links array from 'links' field
-     * Links can be master->slave (product is master) and slave->master (product is dependent)
-     *
-     * IMPORTANT: Only syncs if 'links' field was explicitly passed in POST data.
-     * Links are managed via separate UI, so we don't touch them on regular product save.
-     *
-     * @param msProductData $productData
-     * @return void
-     */
     public function saveLinks(msProductData $productData): void
     {
-        $productId = $productData->get('id');
-
-        // Use reflection to check if 'links' was explicitly passed in POST data
-        $reflection = new \ReflectionClass($productData);
-        $property = $reflection->getProperty('_fields');
-        $property->setAccessible(true);
-        $fields = $property->getValue($productData);
-
-        // If 'links' key doesn't exist in POST data - don't touch existing links
-        if (!array_key_exists('links', $fields)) {
-            return;
-        }
-
-        $links = $fields['links'];
-
-        if (is_string($links)) {
-            $links = json_decode($links, true);
-        }
-
-        if (!is_array($links)) {
-            return;
-        }
-
-        $this->modx->removeCollection(msProductLink::class, ['master' => $productId]);
-
-        foreach ($links as $link) {
-            if (!empty($link['slave']) && !empty($link['link'])) {
-                /** @var msProductLink $productLink */
-                $productLink = $this->modx->newObject(msProductLink::class);
-                $productLink->set('master', $productId);
-                $productLink->set('slave', $link['slave']);
-                $productLink->set('link', $link['link']);
-                $productLink->save();
-            }
-        }
+        $this->linksWriter->saveLinks($productData);
     }
 
-    /**
-     * Remove product with all related data
-     *
-     * Deletes options, categories, links, files and media source directories
-     * Cleans database from all product traces
-     *
-     * @param msProductData $productData
-     * @param array $ancestors
-     * @return bool
-     */
     public function removeProduct(msProductData $productData, array $ancestors = []): bool
     {
-        $productId = $productData->get('id');
-
-        $this->modx->removeCollection(msProductOption::class, ['product_id' => $productId]);
-
-        $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
-
-        $this->modx->removeCollection(msProductLink::class, [
-            'master' => $productId,
-            'OR:slave:=' => $productId
-        ]);
-
-        if ($productData->xpdo->getCount(msProductFile::class, ['product_id' => $productId]) > 0) {
-            $source = $productData->initializeMediaSource($productData->Product->get('context_key'));
-            if ($source) {
-                $files = $productData->xpdo->getIterator(msProductFile::class, ['product_id' => $productId]);
-                /** @var msProductFile $file */
-                foreach ($files as $file) {
-                    $file->remove();
-                }
-            }
-        }
-
-        // Remove empty product catalog directory via ProductImageService
-        /** @var ProductImageService $imageService */
-        $imageService = $this->modx->services->get('ms3_product_image');
-        if ($imageService) {
-            $imageService->removeProductCatalog($productData);
-        }
-
-        return true;
+        return $this->removalHelper->removeProduct($productData, $ancestors);
     }
 
     /**
-     * Get product price with plugin modifiers
-     *
-     * Invokes msOnGetProductPrice event for price modification.
-     * Supports plugin chaining: each plugin can read/modify price via $modx->eventData
-     *
-     * Plugin example:
-     * ```php
-     * case 'msOnGetProductPrice':
-     *     $price = $modx->eventData['msOnGetProductPrice']['price'] ?? $scriptProperties['price'];
-     *     $newPrice = $price * 0.9; // 10% discount
-     *     $modx->eventData['msOnGetProductPrice']['price'] = $newPrice;
-     *     $modx->event->returnedValues['price'] = $newPrice;
-     *     break;
-     * ```
-     *
-     * @param msProductData $productData
      * @param array $data Additional product data
      * @return mixed|string
      */
     public function getModifiedPrice(msProductData $productData, array $data = [])
     {
-        $eventName = 'msOnGetProductPrice';
-        $price = !empty($data['price'])
-            ? $data['price']
-            : $productData->get('price');
-
-        return $this->invokeProductModifier(
-            $eventName,
-            ['price' => $price, 'data' => $data],
-            ['price' => $price, 'data' => $data],
-            'price',
-            $price,
-        );
+        return $this->modifierHooks->getModifiedPrice($productData, $data);
     }
 
     /**
-     * Get product weight with plugin modifiers
-     *
-     * Invokes msOnGetProductWeight event for weight modification.
-     * Supports plugin chaining: each plugin can read/modify weight via $modx->eventData
-     *
-     * Plugin example:
-     * ```php
-     * case 'msOnGetProductWeight':
-     *     $weight = $modx->eventData['msOnGetProductWeight']['weight'] ?? $scriptProperties['weight'];
-     *     $newWeight = $weight + 0.5; // Add packaging weight
-     *     $modx->eventData['msOnGetProductWeight']['weight'] = $newWeight;
-     *     $modx->event->returnedValues['weight'] = $newWeight;
-     *     break;
-     * ```
-     *
-     * @param msProductData $productData
      * @param array $data Additional product data
      * @return mixed|string
      */
     public function getModifiedWeight(msProductData $productData, array $data = [])
     {
-        $eventName = 'msOnGetProductWeight';
-        $weight = !empty($data['weight'])
-            ? $data['weight']
-            : $productData->get('weight');
-
-        return $this->invokeProductModifier(
-            $eventName,
-            ['weight' => $weight, 'data' => $data],
-            ['weight' => $weight, 'data' => $data],
-            'weight',
-            $weight,
-        );
+        return $this->modifierHooks->getModifiedWeight($productData, $data);
     }
 
     /**
-     * Modify product fields via plugins
-     *
-     * Invokes msOnGetProductFields event for custom product field processing.
-     * Supports plugin chaining: each plugin can read/modify fields via $modx->eventData
-     *
-     * Plugin example:
-     * ```php
-     * case 'msOnGetProductFields':
-     *     $data = $modx->eventData['msOnGetProductFields']['data'] ?? $scriptProperties['data'];
-     *     $data['custom_field'] = 'value';
-     *     $modx->eventData['msOnGetProductFields']['data'] = $data;
-     *     $modx->event->returnedValues['data'] = $data;
-     *     break;
-     * ```
-     *
-     * @param msProductData $productData
      * @param array $data Product fields
      * @return array Modified fields
      */
     public function getModifiedFields(msProductData $productData, array $data = []): array
     {
-        $eventName = 'msOnGetProductFields';
-
-        /** @var array<string, mixed> */
-        return $this->invokeProductModifier(
-            $eventName,
-            ['data' => $data],
-            ['data' => $data],
-            'data',
-            $data,
-            true,
-        );
+        return $this->modifierHooks->getModifiedFields($productData, $data);
     }
 
-    /**
-     * Get product option keys
-     *
-     * Delegates call to msProductOption to get list of all option keys
-     *
-     * @param msProductData $productData
-     * @return array
-     */
     public function getOptionKeys(msProductData $productData): array
     {
         $productId = $productData->get('id');
@@ -435,14 +181,7 @@ class ProductDataService
     }
 
     /**
-     * Get product option fields
-     *
-     * Delegates call to msProductOption to get option fields
-     * with current values and ExtJS metadata
-     *
-     * @param msProductData $productData
      * @param array $keys Filter by option keys
-     * @return array
      */
     public function getOptionFields(msProductData $productData, array $keys = []): array
     {
@@ -450,61 +189,31 @@ class ProductDataService
         $option = $this->modx->newObject(msProductOption::class);
         $option->set('product_id', $productData->get('id'));
         $result = $option->getOptionFields($productData->get('id'));
+
         return is_array($result) ? $result : [];
     }
 
     /**
-     * Get product data by ID
-     *
-     * Loads msProduct and msProductData, merges their fields into one array
-     * Used in API controllers to get complete product data
-     *
-     * @param int $productId Product ID
      * @return array|null Data array or null if not found
      */
     public function getProductData(int $productId): ?array
     {
-        /** @var msProduct $product */
+        /** @var msProduct|null $product */
         $product = $this->modx->getObject(msProduct::class, $productId);
-
         if (!$product) {
             return null;
         }
 
         $productData = $product->loadData();
-
         if (!$productData) {
             return null;
         }
 
-        $data = array_merge(
-            $product->toArray(),
-            $productData->toArray()
-        );
-
-        return $data;
+        return array_merge($product->toArray(), $productData->toArray());
     }
 
     /**
-     * Allowed fields for inline / API update (msProductData)
-     */
-    protected static array $allowedUpdateFields = [
-        'article', 'price', 'old_price', 'stock', 'weight',
-        'vendor_id', 'made_in', 'new', 'popular', 'favorite',
-    ];
-
-    /**
-     * Resource (modResource) fields updatable via same API (e.g. published)
-     */
-    protected static array $allowedResourceFields = ['published'];
-
-    /**
      * Apply published state to product resource and save.
-     * Invokes OnDocPublished / OnDocUnPublished for plugin compatibility.
-     *
-     * @param msProduct $product
-     * @param int $published 0 or 1
-     * @return bool True if saved successfully
      */
     protected function applyPublishedToResource(msProduct $product, int $published): bool
     {
@@ -516,22 +225,21 @@ class ProductDataService
             $product->set('publishedon', 0);
             $product->set('publishedby', 0);
         }
+
         if (!$product->save()) {
             return false;
         }
-        $eventName = $published ? 'OnDocPublished' : 'OnDocUnPublished';
-        $this->modx->invokeEvent($eventName, [
+
+        $this->modx->invokeEvent($published ? 'OnDocPublished' : 'OnDocUnPublished', [
             'id' => $product->get('id'),
             'resource' => $product,
         ]);
+
         return true;
     }
 
     /**
-     * Validate productData update values (minimal server-side validation).
-     *
-     * @param array $filtered Filtered allowed fields
-     * @return bool True if valid
+     * Minimal server-side validation for productData update values.
      */
     protected function validateProductDataUpdate(array $filtered): bool
     {
@@ -549,21 +257,13 @@ class ProductDataService
         if (isset($filtered['weight']) && (float)$filtered['weight'] < 0) {
             return false;
         }
+
         return true;
     }
 
-    /** Error codes for updateProductData */
-    public const ERROR_FORBIDDEN = 403;
-    public const ERROR_NOT_FOUND = 404;
-    public const ERROR_VALIDATION = 422;
-    public const ERROR_SAVE = 500;
-
     /**
      * Update product data (msProductData and optionally resource fields like published).
-     * Saves productData first, then resource (published). On resource failure, rolls back productData.
      *
-     * @param int $productId Product ID
-     * @param array $data Data to update
      * @return array Success: ['ok' => true, 'data' => array]. Error: ['ok' => false, 'code' => int, 'message' => string]
      */
     public function updateProductData(int $productId, array $data): array
@@ -572,7 +272,7 @@ class ProductDataService
             return ['ok' => false, 'code' => self::ERROR_FORBIDDEN, 'message' => 'Permission denied'];
         }
 
-        /** @var msProduct $product */
+        /** @var msProduct|null $product */
         $product = $this->modx->getObject(msProduct::class, $productId);
         if (!$product) {
             return ['ok' => false, 'code' => self::ERROR_NOT_FOUND, 'message' => 'Product not found'];
@@ -581,7 +281,7 @@ class ProductDataService
             return ['ok' => false, 'code' => self::ERROR_FORBIDDEN, 'message' => 'Save permission denied'];
         }
 
-        /** @var msProductData $productData */
+        /** @var msProductData|null $productData */
         $productData = $product->loadData();
         if (!$productData) {
             return ['ok' => false, 'code' => self::ERROR_NOT_FOUND, 'message' => 'Product data not found'];
@@ -591,29 +291,27 @@ class ProductDataService
         // Without the extra keys, repeater values get silently dropped here and
         // prepareObject() then normalises the in-memory null/empty to [] on save —
         // user input is lost with no error (#301).
-        $allowedKeys = array_merge(
-            self::$allowedUpdateFields,
-            array_keys($this->getProductRepeaterFields())
+        $filtered = array_intersect_key(
+            $data,
+            array_flip(array_merge(self::$allowedUpdateFields, array_keys($this->getProductRepeaterFields())))
         );
-        $filtered = array_intersect_key($data, array_flip($allowedKeys));
         $resourceData = array_intersect_key($data, array_flip(self::$allowedResourceFields));
 
         if (!$this->validateProductDataUpdate($filtered)) {
             return ['ok' => false, 'code' => self::ERROR_VALIDATION, 'message' => 'Validation failed'];
         }
 
-        $fieldsToUpdate = $filtered;
-
-        $repeaterError = $this->normalizeRepeaterFieldsInPayload($fieldsToUpdate);
+        $repeaterError = $this->normalizeRepeaterFieldsInPayload($filtered);
         if ($repeaterError !== null) {
             return ['ok' => false, 'code' => self::ERROR_VALIDATION, 'message' => $repeaterError];
         }
+
         $oldValues = [];
-        foreach (array_keys($fieldsToUpdate) as $key) {
+        foreach (array_keys($filtered) as $key) {
             $oldValues[$key] = $productData->get($key);
         }
 
-        $productData->fromArray($fieldsToUpdate);
+        $productData->fromArray($filtered);
         if (!$productData->save()) {
             return ['ok' => false, 'code' => self::ERROR_SAVE, 'message' => 'Failed to save product data'];
         }
@@ -623,6 +321,7 @@ class ProductDataService
             if (!$this->applyPublishedToResource($product, $published)) {
                 $productData->fromArray($oldValues);
                 $productData->save();
+
                 return ['ok' => false, 'code' => self::ERROR_SAVE, 'message' => 'Failed to update published state'];
             }
         }
@@ -631,6 +330,7 @@ class ProductDataService
         if (isset($resourceData['published'])) {
             $result['published'] = (bool)$product->get('published');
         }
+
         return ['ok' => true, 'data' => $result];
     }
 
@@ -641,75 +341,9 @@ class ProductDataService
      */
     protected function normalizeRepeaterFieldsInPayload(array &$payload): ?string
     {
-        $repeaterFields = $this->getProductRepeaterFields();
-        if ($repeaterFields === []) {
-            return null;
-        }
-
-        $repeaterService = $this->getRepeaterFieldService();
-        $this->modx->lexicon->load('minishop3:default');
-
-        foreach ($repeaterFields as $fieldKey => $config) {
-            if (!array_key_exists($fieldKey, $payload)) {
-                continue;
-            }
-
-            try {
-                $payload[$fieldKey] = $repeaterService->processValue($payload[$fieldKey], $config);
-            } catch (\InvalidArgumentException $e) {
-                return $this->modx->lexicon('ms3_repeater_validation_error', [
-                    'field' => $fieldKey,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Invoke product modifier event with eventData chaining and returnedValues fallback.
-     *
-     * @param array<string, mixed> $eventData
-     * @param array<string, mixed> $properties
-     */
-    private function invokeProductModifier(
-        string $eventName,
-        array $eventData,
-        array $properties,
-        string $valueKey,
-        mixed $default,
-        bool $patchViaApplyReturnedArray = false,
-    ): mixed {
-        if (empty($this->modx->eventMap[$eventName])) {
-            return $default;
-        }
-
-        $this->modx->eventData[$eventName] = $eventData;
-        EventGate::clearReturnedValues($this->modx);
-        $this->modx->invokeEvent($eventName, $properties);
-
-        $value = $default;
-        if (isset($this->modx->eventData[$eventName][$valueKey])) {
-            $fromEventData = $this->modx->eventData[$eventName][$valueKey];
-            if ($patchViaApplyReturnedArray) {
-                if (is_array($fromEventData)) {
-                    $value = $fromEventData;
-                }
-            } else {
-                $value = $fromEventData;
-            }
-        }
-
-        $returnedValues = EventGate::getReturnedValues($this->modx);
-        if ($patchViaApplyReturnedArray && is_array($default)) {
-            $value = EventGate::applyReturnedArray(is_array($value) ? $value : $default, $returnedValues, $valueKey);
-        } elseif (array_key_exists($valueKey, $returnedValues)) {
-            $value = $returnedValues[$valueKey];
-        }
-
-        unset($this->modx->eventData[$eventName]);
-
-        return $value;
+        return $this->repeaterSupport->normalizeRepeaterFieldsInPayload(
+            $payload,
+            $this->getProductRepeaterFields()
+        );
     }
 }

--- a/core/components/minishop3/src/Services/Product/ProductLinksWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductLinksWriter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductLink;
+use MODX\Revolution\modX;
+
+/**
+ * Synchronizes msProductLink rows from product links payload.
+ */
+class ProductLinksWriter
+{
+    use ProductDataExplicitFieldsTrait;
+
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * Save product links when the `links` key was explicitly passed in POST data.
+     */
+    public function saveLinks(msProductData $productData): void
+    {
+        $fields = $this->readExplicitFields($productData);
+        if (!array_key_exists('links', $fields)) {
+            return;
+        }
+
+        $links = $fields['links'];
+        if (is_string($links)) {
+            $links = json_decode($links, true);
+        }
+        if (!is_array($links)) {
+            return;
+        }
+
+        $productId = $productData->get('id');
+        $this->modx->removeCollection(msProductLink::class, ['master' => $productId]);
+
+        foreach ($links as $link) {
+            if (empty($link['slave']) || empty($link['link'])) {
+                continue;
+            }
+
+            /** @var msProductLink $productLink */
+            $productLink = $this->modx->newObject(msProductLink::class);
+            $productLink->set('master', $productId);
+            $productLink->set('slave', $link['slave']);
+            $productLink->set('link', $link['link']);
+            $productLink->save();
+        }
+    }
+
+}

--- a/core/components/minishop3/src/Services/Product/ProductModifierHooks.php
+++ b/core/components/minishop3/src/Services/Product/ProductModifierHooks.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Utils\EventGate;
+use MODX\Revolution\modX;
+
+/**
+ * Plugin event hooks for price, weight and field modifiers (EventGate / #219).
+ */
+class ProductModifierHooks
+{
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return mixed|string
+     */
+    public function getModifiedPrice(msProductData $productData, array $data = [])
+    {
+        $price = !empty($data['price']) ? $data['price'] : $productData->get('price');
+
+        return $this->invokeProductModifier(
+            'msOnGetProductPrice',
+            ['price' => $price, 'data' => $data],
+            ['price' => $price, 'data' => $data],
+            'price',
+            $price,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return mixed|string
+     */
+    public function getModifiedWeight(msProductData $productData, array $data = [])
+    {
+        $weight = !empty($data['weight']) ? $data['weight'] : $productData->get('weight');
+
+        return $this->invokeProductModifier(
+            'msOnGetProductWeight',
+            ['weight' => $weight, 'data' => $data],
+            ['weight' => $weight, 'data' => $data],
+            'weight',
+            $weight,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    public function getModifiedFields(msProductData $productData, array $data = []): array
+    {
+        /** @var array<string, mixed> */
+        return $this->invokeProductModifier(
+            'msOnGetProductFields',
+            ['data' => $data],
+            ['data' => $data],
+            'data',
+            $data,
+            true,
+        );
+    }
+
+    /**
+     * Invoke product modifier event with eventData chaining and returnedValues fallback.
+     *
+     * @param array<string, mixed> $eventData
+     * @param array<string, mixed> $properties
+     */
+    private function invokeProductModifier(
+        string $eventName,
+        array $eventData,
+        array $properties,
+        string $valueKey,
+        mixed $default,
+        bool $patchViaApplyReturnedArray = false,
+    ): mixed {
+        if (empty($this->modx->eventMap[$eventName])) {
+            return $default;
+        }
+
+        $this->modx->eventData[$eventName] = $eventData;
+        EventGate::clearReturnedValues($this->modx);
+        $this->modx->invokeEvent($eventName, $properties);
+
+        $value = $default;
+        if (isset($this->modx->eventData[$eventName][$valueKey])) {
+            $fromEventData = $this->modx->eventData[$eventName][$valueKey];
+            if ($patchViaApplyReturnedArray) {
+                if (is_array($fromEventData)) {
+                    $value = $fromEventData;
+                }
+            } else {
+                $value = $fromEventData;
+            }
+        }
+
+        $returnedValues = EventGate::getReturnedValues($this->modx);
+        if ($patchViaApplyReturnedArray && is_array($default)) {
+            $value = EventGate::applyReturnedArray(is_array($value) ? $value : $default, $returnedValues, $valueKey);
+        } elseif (array_key_exists($valueKey, $returnedValues)) {
+            $value = $returnedValues[$valueKey];
+        }
+
+        unset($this->modx->eventData[$eventName]);
+
+        return $value;
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductModifierHooks.php
+++ b/core/components/minishop3/src/Services/Product/ProductModifierHooks.php
@@ -89,13 +89,16 @@ class ProductModifierHooks
             return $default;
         }
 
-        $this->modx->eventData[$eventName] = $eventData;
+        // MODX runtime bag for plugin chaining (#219); not declared on modX stubs.
+        // @phpstan-ignore property.notFound
+        $eventDataBag = &$this->modx->eventData;
+        $eventDataBag[$eventName] = $eventData;
         EventGate::clearReturnedValues($this->modx);
         $this->modx->invokeEvent($eventName, $properties);
 
         $value = $default;
-        if (isset($this->modx->eventData[$eventName][$valueKey])) {
-            $fromEventData = $this->modx->eventData[$eventName][$valueKey];
+        if (isset($eventDataBag[$eventName][$valueKey])) {
+            $fromEventData = $eventDataBag[$eventName][$valueKey];
             if ($patchViaApplyReturnedArray) {
                 if (is_array($fromEventData)) {
                     $value = $fromEventData;
@@ -112,7 +115,7 @@ class ProductModifierHooks
             $value = $returnedValues[$valueKey];
         }
 
-        unset($this->modx->eventData[$eventName]);
+        unset($eventDataBag[$eventName]);
 
         return $value;
     }

--- a/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
@@ -42,7 +42,7 @@ class ProductOptionsWriter
 
         /** @var msProductOption $optionInstance */
         $optionInstance = $this->modx->newObject(msProductOption::class);
-        $optionInstance->saveProductOptions($productData->get('id'), $options, $removeOther);
+        $optionInstance->saveProductOptions((int) $productData->get('id'), $options, $removeOther);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductOptionsWriter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductOption;
+use MODX\Revolution\modX;
+
+/**
+ * Synchronizes msProductOption rows from JSON fields or explicit option arrays.
+ */
+class ProductOptionsWriter
+{
+    use ProductDataExplicitFieldsTrait;
+
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @param list<string> $repeaterKeys Repeater JSON field keys to exclude from option sync
+     */
+    public function saveOptions(
+        msProductData $productData,
+        ?array $options = null,
+        bool $removeOther = true,
+        array $repeaterKeys = []
+    ): void {
+        $optionsExplicit = $options !== null;
+
+        if (!$optionsExplicit) {
+            $options = $this->collectJsonFieldOptions($productData, $repeaterKeys);
+        }
+
+        // When options=null we only sync JSON fields — do not remove custom category options
+        $removeOther = $optionsExplicit ? $removeOther : false;
+
+        /** @var msProductOption $optionInstance */
+        $optionInstance = $this->modx->newObject(msProductOption::class);
+        $optionInstance->saveProductOptions($productData->get('id'), $options, $removeOther);
+    }
+
+    /**
+     * @param list<string> $repeaterKeys
+     * @return array<string, mixed>
+     */
+    private function collectJsonFieldOptions(msProductData $productData, array $repeaterKeys): array
+    {
+        $rawFields = $this->readExplicitFields($productData);
+        $repeaterKeySet = array_fill_keys($repeaterKeys, true);
+        $options = [];
+
+        foreach ($productData->_fieldMeta as $key => $meta) {
+            if (($meta['phptype'] ?? '') !== 'json') {
+                continue;
+            }
+            if (isset($repeaterKeySet[$key]) || !array_key_exists($key, $rawFields)) {
+                continue;
+            }
+
+            $fieldValue = $productData->get($key);
+            $options[$key] = !empty($fieldValue) ? $fieldValue : null;
+        }
+
+        return $options;
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductRemovalHelper.php
+++ b/core/components/minishop3/src/Services/Product/ProductRemovalHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Model\msProductLink;
+use MiniShop3\Model\msProductOption;
+use MODX\Revolution\modX;
+
+/**
+ * Removes product-related rows and media when a product is deleted.
+ */
+class ProductRemovalHelper
+{
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @param list<int|string> $ancestors
+     */
+    public function removeProduct(msProductData $productData, array $ancestors = []): bool
+    {
+        $productId = $productData->get('id');
+
+        $this->modx->removeCollection(msProductOption::class, ['product_id' => $productId]);
+        $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
+        $this->modx->removeCollection(msProductLink::class, [
+            'master' => $productId,
+            'OR:slave:=' => $productId,
+        ]);
+
+        $this->removeProductFiles($productData, $productId);
+
+        /** @var ProductImageService|null $imageService */
+        $imageService = $this->modx->services->get('ms3_product_image');
+        if ($imageService) {
+            $imageService->removeProductCatalog($productData);
+        }
+
+        return true;
+    }
+
+    private function removeProductFiles(msProductData $productData, int|string $productId): void
+    {
+        if ($productData->xpdo->getCount(msProductFile::class, ['product_id' => $productId]) < 1) {
+            return;
+        }
+
+        $source = $productData->initializeMediaSource($productData->Product->get('context_key'));
+        if (!$source) {
+            return;
+        }
+
+        /** @var msProductFile $file */
+        foreach ($productData->xpdo->getIterator(msProductFile::class, ['product_id' => $productId]) as $file) {
+            $file->remove();
+        }
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductRemovalHelper.php
+++ b/core/components/minishop3/src/Services/Product/ProductRemovalHelper.php
@@ -28,7 +28,7 @@ class ProductRemovalHelper
      */
     public function removeProduct(msProductData $productData, array $ancestors = []): bool
     {
-        $productId = $productData->get('id');
+        $productId = (int) $productData->get('id');
 
         $this->modx->removeCollection(msProductOption::class, ['product_id' => $productId]);
         $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
@@ -48,13 +48,18 @@ class ProductRemovalHelper
         return true;
     }
 
-    private function removeProductFiles(msProductData $productData, int|string $productId): void
+    private function removeProductFiles(msProductData $productData, int $productId): void
     {
         if ($productData->xpdo->getCount(msProductFile::class, ['product_id' => $productId]) < 1) {
             return;
         }
 
-        $source = $productData->initializeMediaSource($productData->Product->get('context_key'));
+        $product = $productData->getOne('Product');
+        if (!$product) {
+            return;
+        }
+
+        $source = $productData->initializeMediaSource($product->get('context_key'));
         if (!$source) {
             return;
         }

--- a/core/components/minishop3/src/Services/Product/ProductRepeaterSupport.php
+++ b/core/components/minishop3/src/Services/Product/ProductRepeaterSupport.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Services\ExtraFields\RepeaterFieldService;
+use MODX\Revolution\modX;
+
+/**
+ * Repeater extra-field metadata and payload normalization for msProductData.
+ */
+class ProductRepeaterSupport
+{
+    protected modX $modx;
+
+    /** @var array<string, array>|null */
+    protected ?array $productRepeaterFields = null;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    public function getRepeaterFieldService(): RepeaterFieldService
+    {
+        /** @var RepeaterFieldService $service */
+        $service = $this->modx->services->get('ms3_repeater_field');
+
+        return $service;
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getProductRepeaterFields(): array
+    {
+        return $this->productRepeaterFields ??= $this->getRepeaterFieldService()->getRepeaterFieldsForClass(
+            msProductData::class
+        );
+    }
+
+    /**
+     * Validate and normalize repeater extra fields in manager API payload.
+     *
+     * @param array<string, mixed> $payload
+     * @param array<string, array>|null $repeaterFields When null, loads from msProductData repeater config
+     */
+    public function normalizeRepeaterFieldsInPayload(array &$payload, ?array $repeaterFields = null): ?string
+    {
+        $repeaterFields ??= $this->getProductRepeaterFields();
+        if ($repeaterFields === []) {
+            return null;
+        }
+
+        $repeaterService = $this->getRepeaterFieldService();
+        $this->modx->lexicon->load('minishop3:default');
+
+        foreach ($repeaterFields as $fieldKey => $config) {
+            if (!array_key_exists($fieldKey, $payload)) {
+                continue;
+            }
+
+            try {
+                $payload[$fieldKey] = $repeaterService->processValue($payload[$fieldKey], $config);
+            } catch (\InvalidArgumentException $e) {
+                return $this->modx->lexicon('ms3_repeater_validation_error', [
+                    'field' => $fieldKey,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Описание

Phase C из [#365](https://github.com/modx-pro/MiniShop3/issues/365): `ProductDataService` (~746 LOC) → фасад **~349 LOC** + collaborators:

- `ProductCategoryMembershipWriter` — `saveCategories`
- `ProductOptionsWriter` — `saveOptions`
- `ProductLinksWriter` — `saveLinks`
- `ProductModifierHooks` — price/weight/fields plugin hooks (#219)
- `ProductRepeaterSupport` — repeater metadata / normalize (#301)
- `ProductRemovalHelper` — `removeProduct`
- `ProductDataExplicitFieldsTrait` — общий read `_fields`

Публичный API для `msProductData` / processors / API сохранён.

## Тип изменений

- [x] Рефакторинг (без изменения функциональности)

## Связанные Issues

Refs #365 (Phase C; GridConfig #513, OptionLoader #514)

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Product/ProductDataService.php
php -l src/Services/Product/Product*.php
vendor/bin/phpunit tests/Integration/Product/UpdateProductDataPermissionsTest.php
# OK (5 tests), exit 0
```

- [x] Автоматические тесты
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы — n/a
- [ ] PHPStan — CI
- [x] ESLint — n/a
- [ ] CHANGELOG — релизный цикл

## Дополнительные заметки

**Review:** blockers нет. Soft: protected `getProductRepeaterFields` оставлен для `TestableProductDataService`; `prepareObject`/`updateProductData` остаются на фасаде (оркестрация).

**AC Phase C:**
| Критерий | Статус |
|----------|--------|
| Save categories/options/links/repeater/price → collaborators | да |
| ProductDataService = facade ≤ ~500 LOC | да (~349) |
| Публичные методы сохранены | да |