### PR TITLE
refactor(mgr-api): ModelFieldsController → ModelField services

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
@@ -155,21 +155,29 @@ class ModelFieldsController
     /**
      * Map a domain result array to the HTTP Response envelope.
      *
-     * @param array{success: bool, data?: mixed, message?: string, httpStatus?: int} $result
+     * @param array{success: bool, data?: mixed, message?: string, error?: string, created?: bool} $result
      */
     private function mapResult(array $result): array
     {
         if (empty($result['success'])) {
+            $status = match ((string)($result['error'] ?? 'bad_request')) {
+                'not_found' => HttpStatus::NOT_FOUND,
+                'server_error' => HttpStatus::INTERNAL_SERVER_ERROR,
+                default => HttpStatus::BAD_REQUEST,
+            };
+
             return Response::error(
                 (string)($result['message'] ?? 'Request failed'),
-                (int)($result['httpStatus'] ?? HttpStatus::BAD_REQUEST)
+                $status
             )->getData();
         }
+
+        $status = !empty($result['created']) ? HttpStatus::CREATED : HttpStatus::OK;
 
         return Response::success(
             $result['data'] ?? null,
             $result['message'] ?? null,
-            (int)($result['httpStatus'] ?? HttpStatus::OK)
+            $status
         )->getData();
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/ModelFieldsController.php
@@ -2,783 +2,174 @@
 
 namespace MiniShop3\Controllers\Api\Manager;
 
-use MiniShop3\Model\msModelField;
-use MiniShop3\Model\msModelFieldSection;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
-use MiniShop3\Services\ComboConfigManager;
+use MiniShop3\Services\ModelField\ModelFieldSectionService;
+use MiniShop3\Services\ModelField\ModelFieldService;
 use MODX\Revolution\modX;
 
 /**
- * API controller for managing model fields configuration
+ * API controller for managing model fields configuration.
  *
- * Handles CRUD operations for msModelField and msModelFieldSection in admin panel.
- * Allows configuration of visible fields for msOrder, msOrderAddress, msOrderProduct.
+ * Thin HTTP layer: parse params → service → Response.
  *
  * @package MiniShop3\Controllers\Api\Manager
  */
 class ModelFieldsController
 {
     protected modX $modx;
+    protected ModelFieldService $fieldService;
+    protected ModelFieldSectionService $sectionService;
 
     public function __construct(modX $modx)
     {
         $this->modx = $modx;
+        /** @var ModelFieldService $fieldService */
+        $fieldService = $modx->services->get('ms3_model_field_service');
+        $this->fieldService = $fieldService;
+        /** @var ModelFieldSectionService $sectionService */
+        $sectionService = $modx->services->get('ms3_model_field_section_service');
+        $this->sectionService = $sectionService;
     }
 
     /**
-     * Get model fields list
      * GET /api/mgr/model-fields
-     *
-     * @param array $params URL parameters (model, start, limit)
-     * @return array Response
      */
     public function getList(array $params = []): array
     {
-        // Load lexicon for label translation
-        $this->modx->lexicon->load('minishop3:vue');
-
-        $start = (int)($params['start'] ?? 0);
-        $limit = (int)($params['limit'] ?? 100);
-
-        $criteria = [];
-        if (!empty($params['model'])) {
-            $criteria['model'] = $params['model'];
-        }
-
-        $total = $this->modx->getCount(msModelField::class, $criteria);
-
-        $query = $this->modx->newQuery(msModelField::class);
-        if (!empty($criteria)) {
-            $query->where($criteria);
-        }
-        $query->sortby('model', 'ASC');
-        $query->sortby('sort_order', 'ASC');
-        $query->limit($limit, $start);
-
-        // Load sections for this model
-        $sectionModel = $params['model'] ?? null;
-        $sections = [];
-        if ($sectionModel) {
-            $sections = $this->getSectionsForModel($sectionModel);
-        }
-
-        $results = [];
-        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
-            $results[] = $this->formatField($field, $sections);
-        }
-
-        return Response::success([
-            'results' => $results,
-            'total' => $total,
-            'sections' => $sections
-        ])->getData();
+        return $this->mapResult($this->fieldService->getList($params));
     }
 
     /**
-     * Get sections for a specific model
-     *
-     * @param string $model
-     * @return array
-     */
-    protected function getSectionsForModel(string $model): array
-    {
-        $sections = [];
-        $query = $this->modx->newQuery(msModelFieldSection::class);
-        $query->where(['model' => $model]);
-        $query->sortby('sort_order', 'ASC');
-
-        foreach ($this->modx->getIterator(msModelFieldSection::class, $query) as $section) {
-            $sections[] = $this->formatSection($section);
-        }
-
-        return $sections;
-    }
-
-    /**
-     * Get specific model field
      * GET /api/mgr/model-fields/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
      */
     public function get(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $field = $this->modx->getObject(msModelField::class, $id);
-
-        if (!$field) {
-            return Response::error('Field not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        return Response::success($this->formatField($field))->getData();
+        return $this->mapResult($this->fieldService->get($params));
     }
 
     /**
-     * Create new model field
      * POST /api/mgr/model-fields
-     *
-     * @param array $params Field data
-     * @return array Response
      */
     public function create(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-        $name = $params['name'] ?? '';
-
-        if (empty($model) || empty($name)) {
-            return Response::error('Model and name are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Check if field already exists
-        $existing = $this->modx->getObject(msModelField::class, [
-            'model' => $model,
-            'name' => $name,
-        ]);
-
-        if ($existing) {
-            return Response::error('Field with this name already exists for this model', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $field = $this->modx->newObject(msModelField::class);
-        $field->fromArray([
-            'model' => $model,
-            'name' => $name,
-            'label' => $params['label'] ?? null,
-            'xtype' => $params['xtype'] ?? 'textfield',
-            'visible' => isset($params['visible']) ? (bool)$params['visible'] : true,
-            'required' => isset($params['required']) ? (bool)$params['required'] : false,
-            'sort_order' => (int)($params['sort_order'] ?? 0),
-            'section_id' => isset($params['section_id']) ? (int)$params['section_id'] : null,
-            'width' => (int)($params['width'] ?? 6),
-            'placeholder' => $params['placeholder'] ?? null,
-            'description' => $params['description'] ?? null,
-            'config' => $params['config'] ?? null,
-        ]);
-
-        if (!$field->save()) {
-            return Response::error('Failed to create field', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success($this->formatField($field), 'Field created successfully', HttpStatus::CREATED)->getData();
+        return $this->mapResult($this->fieldService->create($params));
     }
 
     /**
-     * Update model field
      * PUT /api/mgr/model-fields/{id}
-     *
-     * @param array $params Field data with id
-     * @return array Response
      */
     public function update(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $field = $this->modx->getObject(msModelField::class, $id);
-
-        if (!$field) {
-            return Response::error('Field not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        // Check uniqueness if name or model changed
-        if (isset($params['name']) || isset($params['model'])) {
-            $newModel = $params['model'] ?? $field->get('model');
-            $newName = $params['name'] ?? $field->get('name');
-
-            if ($newModel !== $field->get('model') || $newName !== $field->get('name')) {
-                $existing = $this->modx->getObject(msModelField::class, [
-                    'model' => $newModel,
-                    'name' => $newName,
-                    'id:!=' => $id,
-                ]);
-
-                if ($existing) {
-                    return Response::error('Field with this name already exists for this model', HttpStatus::BAD_REQUEST)->getData();
-                }
-            }
-        }
-
-        if (isset($params['model']) && !in_array($params['model'], msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $updateFields = ['model', 'name', 'label', 'xtype', 'visible', 'required', 'sort_order', 'section_id', 'width', 'placeholder', 'description', 'config'];
-        foreach ($updateFields as $fieldName) {
-            if (array_key_exists($fieldName, $params)) {
-                $value = $params[$fieldName];
-                if (in_array($fieldName, ['visible', 'required'])) {
-                    $value = (bool)$value;
-                } elseif (in_array($fieldName, ['sort_order', 'width'])) {
-                    $value = (int)$value;
-                } elseif ($fieldName === 'section_id') {
-                    $value = $value ? (int)$value : null;
-                }
-                $field->set($fieldName, $value);
-            }
-        }
-
-        if (!$field->save()) {
-            return Response::error('Failed to update field', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success($this->formatField($field), 'Field updated successfully')->getData();
+        return $this->mapResult($this->fieldService->update($params));
     }
 
     /**
-     * Delete model field
      * DELETE /api/mgr/model-fields/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
      */
     public function delete(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Field ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $field = $this->modx->getObject(msModelField::class, $id);
-
-        if (!$field) {
-            return Response::error('Field not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        if (!$field->remove()) {
-            return Response::error('Failed to delete field', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success(null, 'Field deleted successfully')->getData();
+        return $this->mapResult($this->fieldService->delete($params));
     }
 
     /**
-     * Get available models for dropdown
      * GET /api/mgr/model-fields/models
-     *
-     * @return array Response
      */
     public function getModels(): array
     {
-        $models = [];
-        foreach (msModelField::getAvailableModels() as $model) {
-            $lexiconKey = 'ms3_model_' . strtolower(str_replace('ms', '', $model));
-            $label = $this->modx->lexicon($lexiconKey);
-            if ($label === $lexiconKey) {
-                $label = $model;
-            }
-            $models[] = [
-                'value' => $model,
-                'label' => $label,
-            ];
-        }
-
-        return Response::success(['models' => $models])->getData();
+        return $this->mapResult($this->fieldService->getModels());
     }
 
     /**
-     * Get visible fields for a model (for rendering forms), grouped by sections
      * GET /api/mgr/model-fields/visible/{model}
-     *
-     * @param array $params URL parameters (model)
-     * @return array Response
      */
     public function getVisibleFields(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-
-        if (empty($model)) {
-            return Response::error('Model is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // `comboOptions` may include status/payment/delivery names stored as lexicon keys.
-        // Load all topics needed both for field labels (`vue`) and option labels.
-        $this->modx->lexicon->load('minishop3:vue');
-        $this->modx->lexicon->load('minishop3:default');
-        $this->modx->lexicon->load('minishop3:manager');
-
-        // Get sections for the model
-        $sections = $this->getSectionsForModel($model);
-        $sectionsById = [];
-        foreach ($sections as $section) {
-            if (!$section['hidden']) {
-                $sectionsById[$section['id']] = $section;
-            }
-        }
-
-        $query = $this->modx->newQuery(msModelField::class);
-        $query->where([
-            'model' => $model,
-            'visible' => true,
-        ]);
-        $query->sortby('sort_order', 'ASC');
-
-        $results = [];
-        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
-            $data = $field->toArray();
-
-            // Translate label if it's a lexicon key
-            $label = $data['label'] ?? $data['name'];
-            if (!empty($label) && str_starts_with($label, 'ms3_')) {
-                $translated = $this->modx->lexicon($label);
-                if ($translated !== $label) {
-                    $label = $translated;
-                }
-            }
-            $data['label_display'] = $label;
-
-            // Translate description if it's a lexicon key
-            $description = $data['description'] ?? '';
-            if (!empty($description) && str_starts_with($description, 'ms3_')) {
-                $translated = $this->modx->lexicon($description);
-                if ($translated !== $description) {
-                    $description = $translated;
-                }
-            }
-            $data['description_display'] = $description;
-
-            // Add section info
-            if (!empty($data['section_id']) && isset($sectionsById[$data['section_id']])) {
-                $data['section'] = $sectionsById[$data['section_id']];
-            }
-
-            $results[] = $data;
-        }
-
-        // Resolve combo options for all fields with combo xtype
-        $comboManager = new ComboConfigManager($this->modx);
-        $fieldsWithProperties = [];
-        foreach ($results as $fieldData) {
-            if (in_array($fieldData['xtype'] ?? '', ['combo', 'combobox', 'select', 'dropdown'])) {
-                $fieldsWithProperties[] = [
-                    'name' => $fieldData['name'],
-                    'properties' => $fieldData['config'] ?? null,
-                ];
-            }
-        }
-        // Get combo options with metadata (compareField, valueField)
-        $comboOptionsWithMeta = $comboManager->resolveAllOptionsWithMeta($model, $fieldsWithProperties);
-
-        return Response::success([
-            'results' => $results,
-            'total' => count($results),
-            'model' => $model,
-            'sections' => array_values($sectionsById),
-            'comboOptions' => $comboOptionsWithMeta,
-        ])->getData();
+        return $this->mapResult($this->fieldService->getVisibleFields($params));
     }
 
     /**
-     * Update field sort orders (batch update for drag-n-drop reordering)
      * PUT /api/mgr/model-fields/ranks
-     *
-     * @param array $params Array of {id, sort_order}
-     * @return array Response
      */
     public function updateRanks(array $params = []): array
     {
-        $ranks = $params['ranks'] ?? [];
-
-        if (empty($ranks) || !is_array($ranks)) {
-            return Response::error('Ranks array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        foreach ($ranks as $item) {
-            if (!isset($item['id']) || !isset($item['sort_order'])) {
-                continue;
-            }
-
-            $field = $this->modx->getObject(msModelField::class, (int)$item['id']);
-            if ($field) {
-                $field->set('sort_order', (int)$item['sort_order']);
-                $field->save();
-            }
-        }
-
-        return Response::success(null, 'Ranks updated successfully')->getData();
+        return $this->mapResult($this->fieldService->updateRanks($params));
     }
 
     /**
-     * Format field for API response
-     *
-     * @param msModelField $field
-     * @param array $sections Sections array for section_name lookup
-     * @return array
-     */
-    protected function formatField(msModelField $field, array $sections = []): array
-    {
-        $data = $field->toArray();
-
-        // Translate label if it's a lexicon key
-        if (!empty($data['label']) && str_starts_with($data['label'], 'ms3_')) {
-            $translated = $this->modx->lexicon($data['label']);
-            if ($translated !== $data['label']) {
-                $data['label_translated'] = $translated;
-            }
-        }
-
-        // Translate description if it's a lexicon key
-        if (!empty($data['description']) && str_starts_with($data['description'], 'ms3_')) {
-            $translated = $this->modx->lexicon($data['description']);
-            if ($translated !== $data['description']) {
-                $data['description_translated'] = $translated;
-            }
-        }
-
-        // Translate model name
-        $modelLexiconKey = 'ms3_model_' . strtolower(str_replace('ms', '', $data['model']));
-        $modelLabel = $this->modx->lexicon($modelLexiconKey);
-        if ($modelLabel !== $modelLexiconKey) {
-            $data['model_label'] = $modelLabel;
-        } else {
-            $data['model_label'] = $data['model'];
-        }
-
-        // Add section name if available
-        if (!empty($data['section_id']) && !empty($sections)) {
-            foreach ($sections as $section) {
-                if ($section['id'] == $data['section_id']) {
-                    $data['section_name'] = $section['label'];
-                    break;
-                }
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * Format section for API response
-     *
-     * @param msModelFieldSection $section
-     * @return array
-     */
-    protected function formatSection(msModelFieldSection $section): array
-    {
-        $data = $section->toArray();
-
-        // Translate label using lexicon_key if available
-        if (!empty($data['lexicon_key'])) {
-            $translated = $this->modx->lexicon($data['lexicon_key']);
-            if ($translated !== $data['lexicon_key']) {
-                $data['label'] = $translated;
-            }
-        }
-
-        // If no label, use section_key as fallback
-        if (empty($data['label'])) {
-            $data['label'] = ucfirst(str_replace('_', ' ', $data['section_key']));
-        }
-
-        return $data;
-    }
-
-    // =========================================================================
-    // SECTION CRUD OPERATIONS
-    // =========================================================================
-
-    /**
-     * Get sections list for a model
      * GET /api/mgr/model-fields/sections/{model}
-     *
-     * @param array $params URL parameters (model)
-     * @return array Response
      */
     public function getSections(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-
-        if (empty($model)) {
-            return Response::error('Model is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if (!in_array($model, msModelFieldSection::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $this->modx->lexicon->load('minishop3:vue');
-
-        $sections = $this->getSectionsForModel($model);
-
-        return Response::success([
-            'results' => $sections,
-            'total' => count($sections),
-            'model' => $model,
-        ])->getData();
+        return $this->mapResult($this->sectionService->getSections($params));
     }
 
     /**
-     * Create new section
      * POST /api/mgr/model-fields/sections
-     *
-     * @param array $params Section data
-     * @return array Response
      */
     public function createSection(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-        $sectionKey = $params['section_key'] ?? '';
-
-        if (empty($model) || empty($sectionKey)) {
-            return Response::error('Model and section_key are required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if (!in_array($model, msModelFieldSection::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Check if section already exists
-        $existing = $this->modx->getObject(msModelFieldSection::class, [
-            'model' => $model,
-            'section_key' => $sectionKey,
-        ]);
-
-        if ($existing) {
-            return Response::error('Section with this key already exists for this model', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $section = $this->modx->newObject(msModelFieldSection::class);
-        $section->fromArray([
-            'model' => $model,
-            'section_key' => $sectionKey,
-            'label' => $params['label'] ?? null,
-            'lexicon_key' => $params['lexicon_key'] ?? null,
-            'hidden' => isset($params['hidden']) ? (bool)$params['hidden'] : false,
-            'sort_order' => (int)($params['sort_order'] ?? 0),
-            'is_default' => isset($params['is_default']) ? (bool)$params['is_default'] : false,
-        ]);
-
-        if (!$section->save()) {
-            return Response::error('Failed to create section', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        $this->modx->lexicon->load('minishop3:vue');
-        return Response::success($this->formatSection($section), 'Section created successfully', HttpStatus::CREATED)->getData();
+        return $this->mapResult($this->sectionService->createSection($params));
     }
 
     /**
-     * Update section
      * PUT /api/mgr/model-fields/sections/{id}
-     *
-     * @param array $params Section data with id
-     * @return array Response
      */
     public function updateSection(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Section ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $section = $this->modx->getObject(msModelFieldSection::class, $id);
-
-        if (!$section) {
-            return Response::error('Section not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        $updateFields = ['label', 'lexicon_key', 'hidden', 'sort_order'];
-        foreach ($updateFields as $fieldName) {
-            if (array_key_exists($fieldName, $params)) {
-                $value = $params[$fieldName];
-                if ($fieldName === 'hidden') {
-                    $value = (bool)$value;
-                } elseif ($fieldName === 'sort_order') {
-                    $value = (int)$value;
-                }
-                $section->set($fieldName, $value);
-            }
-        }
-
-        if (!$section->save()) {
-            return Response::error('Failed to update section', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        $this->modx->lexicon->load('minishop3:vue');
-        return Response::success($this->formatSection($section), 'Section updated successfully')->getData();
+        return $this->mapResult($this->sectionService->updateSection($params));
     }
 
     /**
-     * Delete section
      * DELETE /api/mgr/model-fields/sections/{id}
-     *
-     * @param array $params URL parameters (id)
-     * @return array Response
      */
     public function deleteSection(array $params = []): array
     {
-        $id = (int)($params['id'] ?? 0);
-
-        if (!$id) {
-            return Response::error('Section ID is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        $section = $this->modx->getObject(msModelFieldSection::class, $id);
-
-        if (!$section) {
-            return Response::error('Section not found', HttpStatus::NOT_FOUND)->getData();
-        }
-
-        // Check if it's a default section
-        if ($section->get('is_default')) {
-            return Response::error('Cannot delete default section', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Set fields in this section to null
-        $query = $this->modx->newQuery(msModelField::class);
-        $query->where(['section_id' => $id]);
-        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
-            $field->set('section_id', null);
-            $field->save();
-        }
-
-        if (!$section->remove()) {
-            return Response::error('Failed to delete section', HttpStatus::INTERNAL_SERVER_ERROR)->getData();
-        }
-
-        return Response::success(null, 'Section deleted successfully')->getData();
+        return $this->mapResult($this->sectionService->deleteSection($params));
     }
 
     /**
-     * Update section sort orders (batch update for drag-n-drop reordering)
      * PUT /api/mgr/model-fields/sections/ranks
-     *
-     * @param array $params Array of {id, sort_order}
-     * @return array Response
      */
     public function updateSectionRanks(array $params = []): array
     {
-        $ranks = $params['ranks'] ?? [];
-
-        if (empty($ranks) || !is_array($ranks)) {
-            return Response::error('Ranks array is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        foreach ($ranks as $item) {
-            if (!isset($item['id']) || !isset($item['sort_order'])) {
-                continue;
-            }
-
-            $section = $this->modx->getObject(msModelFieldSection::class, (int)$item['id']);
-            if ($section) {
-                $section->set('sort_order', (int)$item['sort_order']);
-                $section->save();
-            }
-        }
-
-        return Response::success(null, 'Section ranks updated successfully')->getData();
+        return $this->mapResult($this->sectionService->updateSectionRanks($params));
     }
 
-    // =========================================================================
-    // COMBO OPTIONS
-    // =========================================================================
-
     /**
-     * Get combo options for a model's fields
      * GET /api/mgr/model-fields/combo-options/{model}
-     *
-     * Returns resolved options for all combo/select fields of a model.
-     * Uses ComboConfigManager to resolve options from file configs and DB properties.
-     *
-     * @param array $params URL parameters (model)
-     * @return array Response
      */
     public function getComboOptions(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-
-        if (empty($model)) {
-            return Response::error('Model is required', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Get fields with combo xtypes (select, combobox, dropdown, etc.)
-        $query = $this->modx->newQuery(msModelField::class);
-        $query->where([
-            'model' => $model,
-            'xtype:IN' => ['combo', 'combobox', 'select', 'dropdown'],
-        ]);
-
-        $fieldsWithProperties = [];
-        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
-            $fieldsWithProperties[] = [
-                'name' => $field->get('name'),
-                'properties' => $field->get('config'),
-            ];
-        }
-
-        // Resolve options via ComboConfigManager (with metadata for proper field comparison)
-        $comboManager = new ComboConfigManager($this->modx);
-        $options = $comboManager->resolveAllOptionsWithMeta($model, $fieldsWithProperties);
-
-        return Response::success([
-            'model' => $model,
-            'options' => $options,
-        ])->getData();
+        return $this->mapResult($this->fieldService->getComboOptions($params));
     }
 
     /**
-     * Get combo options for a specific field
      * GET /api/mgr/model-fields/combo-options/{model}/{field_name}
-     *
-     * @param array $params URL parameters (model, field_name)
-     * @return array Response
      */
     public function getFieldComboOptions(array $params = []): array
     {
-        $model = $params['model'] ?? '';
-        $fieldName = $params['field_name'] ?? '';
+        return $this->mapResult($this->fieldService->getFieldComboOptions($params));
+    }
 
-        if (empty($model) || empty($fieldName)) {
-            return Response::error('Model and field_name are required', HttpStatus::BAD_REQUEST)->getData();
+    /**
+     * Map a domain result array to the HTTP Response envelope.
+     *
+     * @param array{success: bool, data?: mixed, message?: string, httpStatus?: int} $result
+     */
+    private function mapResult(array $result): array
+    {
+        if (empty($result['success'])) {
+            return Response::error(
+                (string)($result['message'] ?? 'Request failed'),
+                (int)($result['httpStatus'] ?? HttpStatus::BAD_REQUEST)
+            )->getData();
         }
 
-        if (!in_array($model, msModelField::getAvailableModels())) {
-            return Response::error('Invalid model type', HttpStatus::BAD_REQUEST)->getData();
-        }
-
-        // Get field from database
-        $field = $this->modx->getObject(msModelField::class, [
-            'model' => $model,
-            'name' => $fieldName,
-        ]);
-
-        $dbProperties = null;
-        if ($field) {
-            $dbProperties = $field->get('config');
-            if (is_string($dbProperties)) {
-                $dbProperties = json_decode($dbProperties, true);
-            }
-        }
-
-        // Resolve options via ComboConfigManager
-        $comboManager = new ComboConfigManager($this->modx);
-        $options = $comboManager->resolveOptions($model, $fieldName, $dbProperties);
-
-        return Response::success([
-            'model' => $model,
-            'field_name' => $fieldName,
-            'options' => $options,
-        ])->getData();
+        return Response::success(
+            $result['data'] ?? null,
+            $result['message'] ?? null,
+            (int)($result['httpStatus'] ?? HttpStatus::OK)
+        )->getData();
     }
 }

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3;
 
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\Product\Import\ProductImportService;
 use MODX\Revolution\modX;
 
 /**
@@ -139,7 +141,7 @@ class ServiceRegistry
             'interface' => null,
         ],
         'ms3_product_import' => [
-            'class' => \MiniShop3\Services\Product\Import\ProductImportService::class,
+            'class' => ProductImportService::class,
             'interface' => null,
         ],
         'ms3_repeater_field' => [
@@ -189,7 +191,7 @@ class ServiceRegistry
         // Order workflow services (used by Order controller)
         // All services can be overridden via ms3.services.php config
         'ms3_order_draft_manager' => [
-            'class' => \MiniShop3\Services\Order\OrderDraftManager::class,
+            'class' => OrderDraftManager::class,
             'interface' => null,
         ],
         'ms3_order_cost_calculator' => [

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -79,6 +79,7 @@ class ServiceRegistry
         'ms3_order_finalize',
         'ms3_cart_mutation_handler',
         'ms3_customer_order_resolver',
+        'ms3_model_field_service',
     ];
 
     /**
@@ -110,6 +111,7 @@ class ServiceRegistry
             'ms3_order_log',
         ],
         'ms3_customer_order_resolver' => ['ms3_customer_field_manager'],
+        'ms3_model_field_service' => ['ms3_model_field_section_service'],
     ];
 
     /**
@@ -150,6 +152,14 @@ class ServiceRegistry
         ],
         'ms3_key_value_field' => [
             'class' => \MiniShop3\Services\ExtraFields\KeyValueFieldService::class,
+            'interface' => null,
+        ],
+        'ms3_model_field_section_service' => [
+            'class' => \MiniShop3\Services\ModelField\ModelFieldSectionService::class,
+            'interface' => null,
+        ],
+        'ms3_model_field_service' => [
+            'class' => \MiniShop3\Services\ModelField\ModelFieldService::class,
             'interface' => null,
         ],
         'ms3_product_image' => [
@@ -686,6 +696,14 @@ class ServiceRegistry
                     $ms3 = $modx->getService('MiniShop3', \MiniShop3\MiniShop3::class);
                     $fieldManager = $modx->services->get('ms3_customer_field_manager');
                     return new $validatedClass($modx, $ms3, $fieldManager);
+                });
+                break;
+
+            case 'ms3_model_field_service':
+                // ModelFieldService(modX, ModelFieldSectionService)
+                $this->modx->services->add($serviceKey, function () use ($validatedClass, $modx) {
+                    $sectionService = $modx->services->get('ms3_model_field_section_service');
+                    return new $validatedClass($modx, $sectionService);
                 });
                 break;
 

--- a/core/components/minishop3/src/Services/ModelField/ModelFieldSectionService.php
+++ b/core/components/minishop3/src/Services/ModelField/ModelFieldSectionService.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace MiniShop3\Services\ModelField;
+
+use MiniShop3\Model\msModelField;
+use MiniShop3\Model\msModelFieldSection;
+use MiniShop3\Router\HttpStatus;
+use MODX\Revolution\modX;
+
+/**
+ * CRUD and formatting for msModelFieldSection.
+ */
+class ModelFieldSectionService
+{
+    private const UPDATE_FIELDS = ['label', 'lexicon_key', 'hidden', 'sort_order'];
+
+    private modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getSectionsForModel(string $model): array
+    {
+        $sections = [];
+        $query = $this->modx->newQuery(msModelFieldSection::class);
+        $query->where(['model' => $model]);
+        $query->sortby('sort_order', 'ASC');
+
+        foreach ($this->modx->getIterator(msModelFieldSection::class, $query) as $section) {
+            $sections[] = $this->formatSection($section);
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function getSections(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        if (empty($model)) {
+            return $this->fail('Model is required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $this->modx->lexicon->load('minishop3:vue');
+        $sections = $this->getSectionsForModel($model);
+
+        return $this->ok([
+            'results' => $sections,
+            'total' => count($sections),
+            'model' => $model,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function createSection(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        $sectionKey = $params['section_key'] ?? '';
+
+        if (empty($model) || empty($sectionKey)) {
+            return $this->fail('Model and section_key are required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $existing = $this->modx->getObject(msModelFieldSection::class, [
+            'model' => $model,
+            'section_key' => $sectionKey,
+        ]);
+        if ($existing) {
+            return $this->fail('Section with this key already exists for this model');
+        }
+
+        $section = $this->modx->newObject(msModelFieldSection::class);
+        $section->fromArray([
+            'model' => $model,
+            'section_key' => $sectionKey,
+            'label' => $params['label'] ?? null,
+            'lexicon_key' => $params['lexicon_key'] ?? null,
+            'hidden' => isset($params['hidden']) ? (bool)$params['hidden'] : false,
+            'sort_order' => (int)($params['sort_order'] ?? 0),
+            'is_default' => isset($params['is_default']) ? (bool)$params['is_default'] : false,
+        ]);
+
+        if (!$section->save()) {
+            return $this->fail('Failed to create section', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        $this->modx->lexicon->load('minishop3:vue');
+
+        return $this->ok(
+            $this->formatSection($section),
+            'Section created successfully',
+            HttpStatus::CREATED
+        );
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function updateSection(array $params = []): array
+    {
+        $section = $this->requireSection((int)($params['id'] ?? 0));
+        if (!$section instanceof msModelFieldSection) {
+            return $section;
+        }
+
+        foreach (self::UPDATE_FIELDS as $fieldName) {
+            if (!array_key_exists($fieldName, $params)) {
+                continue;
+            }
+            $value = $params[$fieldName];
+            if ($fieldName === 'hidden') {
+                $value = (bool)$value;
+            } elseif ($fieldName === 'sort_order') {
+                $value = (int)$value;
+            }
+            $section->set($fieldName, $value);
+        }
+
+        if (!$section->save()) {
+            return $this->fail('Failed to update section', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        $this->modx->lexicon->load('minishop3:vue');
+
+        return $this->ok($this->formatSection($section), 'Section updated successfully');
+    }
+
+    /**
+     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     */
+    public function deleteSection(array $params = []): array
+    {
+        $id = (int)($params['id'] ?? 0);
+        $section = $this->requireSection($id);
+        if (!$section instanceof msModelFieldSection) {
+            return $section;
+        }
+
+        if ($section->get('is_default')) {
+            return $this->fail('Cannot delete default section');
+        }
+
+        $query = $this->modx->newQuery(msModelField::class);
+        $query->where(['section_id' => $id]);
+        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
+            $field->set('section_id', null);
+            $field->save();
+        }
+
+        if (!$section->remove()) {
+            return $this->fail('Failed to delete section', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->ok(null, 'Section deleted successfully');
+    }
+
+    /**
+     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     */
+    public function updateSectionRanks(array $params = []): array
+    {
+        $ranks = $params['ranks'] ?? [];
+        if (empty($ranks) || !is_array($ranks)) {
+            return $this->fail('Ranks array is required');
+        }
+
+        foreach ($ranks as $item) {
+            if (!isset($item['id'], $item['sort_order'])) {
+                continue;
+            }
+
+            $section = $this->modx->getObject(msModelFieldSection::class, (int)$item['id']);
+            if ($section) {
+                $section->set('sort_order', (int)$item['sort_order']);
+                $section->save();
+            }
+        }
+
+        return $this->ok(null, 'Section ranks updated successfully');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function formatSection(msModelFieldSection $section): array
+    {
+        $data = $section->toArray();
+
+        if (!empty($data['lexicon_key'])) {
+            $translated = $this->modx->lexicon($data['lexicon_key']);
+            if ($translated !== $data['lexicon_key']) {
+                $data['label'] = $translated;
+            }
+        }
+
+        if (empty($data['label'])) {
+            $data['label'] = ucfirst(str_replace('_', ' ', $data['section_key']));
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return msModelFieldSection|array{success: false, message: string, httpStatus: int}
+     */
+    private function requireSection(int $id): msModelFieldSection|array
+    {
+        if (!$id) {
+            return $this->fail('Section ID is required');
+        }
+
+        $section = $this->modx->getObject(msModelFieldSection::class, $id);
+        if (!$section instanceof msModelFieldSection) {
+            return $this->fail('Section not found', HttpStatus::NOT_FOUND);
+        }
+
+        return $section;
+    }
+
+    /**
+     * @return array{success: false, message: string, httpStatus: int}|null
+     */
+    private function rejectInvalidModel(string $model): ?array
+    {
+        if (!in_array($model, msModelFieldSection::getAvailableModels())) {
+            return $this->fail('Invalid model type');
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{success: true, data: mixed, message?: string, httpStatus?: int}
+     */
+    private function ok(mixed $data = null, ?string $message = null, ?int $httpStatus = null): array
+    {
+        $result = [
+            'success' => true,
+            'data' => $data,
+        ];
+        if ($message !== null) {
+            $result['message'] = $message;
+        }
+        if ($httpStatus !== null) {
+            $result['httpStatus'] = $httpStatus;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{success: false, message: string, httpStatus: int}
+     */
+    private function fail(string $message, int $httpStatus = HttpStatus::BAD_REQUEST): array
+    {
+        return [
+            'success' => false,
+            'message' => $message,
+            'httpStatus' => $httpStatus,
+        ];
+    }
+}

--- a/core/components/minishop3/src/Services/ModelField/ModelFieldSectionService.php
+++ b/core/components/minishop3/src/Services/ModelField/ModelFieldSectionService.php
@@ -4,7 +4,6 @@ namespace MiniShop3\Services\ModelField;
 
 use MiniShop3\Model\msModelField;
 use MiniShop3\Model\msModelFieldSection;
-use MiniShop3\Router\HttpStatus;
 use MODX\Revolution\modX;
 
 /**
@@ -39,7 +38,7 @@ class ModelFieldSectionService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function getSections(array $params = []): array
     {
@@ -64,7 +63,7 @@ class ModelFieldSectionService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function createSection(array $params = []): array
     {
@@ -100,20 +99,16 @@ class ModelFieldSectionService
         ]);
 
         if (!$section->save()) {
-            return $this->fail('Failed to create section', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to create section', 'server_error');
         }
 
         $this->modx->lexicon->load('minishop3:vue');
 
-        return $this->ok(
-            $this->formatSection($section),
-            'Section created successfully',
-            HttpStatus::CREATED
-        );
+        return $this->ok($this->formatSection($section), 'Section created successfully', true);
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function updateSection(array $params = []): array
     {
@@ -136,7 +131,7 @@ class ModelFieldSectionService
         }
 
         if (!$section->save()) {
-            return $this->fail('Failed to update section', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to update section', 'server_error');
         }
 
         $this->modx->lexicon->load('minishop3:vue');
@@ -145,7 +140,7 @@ class ModelFieldSectionService
     }
 
     /**
-     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: mixed, message?: string, created?: true}
      */
     public function deleteSection(array $params = []): array
     {
@@ -167,14 +162,14 @@ class ModelFieldSectionService
         }
 
         if (!$section->remove()) {
-            return $this->fail('Failed to delete section', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to delete section', 'server_error');
         }
 
         return $this->ok(null, 'Section deleted successfully');
     }
 
     /**
-     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: mixed, message?: string, created?: true}
      */
     public function updateSectionRanks(array $params = []): array
     {
@@ -220,7 +215,7 @@ class ModelFieldSectionService
     }
 
     /**
-     * @return msModelFieldSection|array{success: false, message: string, httpStatus: int}
+     * @return msModelFieldSection|array{success: false, message: string, error: string}
      */
     private function requireSection(int $id): msModelFieldSection|array
     {
@@ -230,14 +225,14 @@ class ModelFieldSectionService
 
         $section = $this->modx->getObject(msModelFieldSection::class, $id);
         if (!$section instanceof msModelFieldSection) {
-            return $this->fail('Section not found', HttpStatus::NOT_FOUND);
+            return $this->fail('Section not found', 'not_found');
         }
 
         return $section;
     }
 
     /**
-     * @return array{success: false, message: string, httpStatus: int}|null
+     * @return array{success: false, message: string, error: string}|null
      */
     private function rejectInvalidModel(string $model): ?array
     {
@@ -249,9 +244,9 @@ class ModelFieldSectionService
     }
 
     /**
-     * @return array{success: true, data: mixed, message?: string, httpStatus?: int}
+     * @return array{success: true, data: mixed, message?: string, created?: true}
      */
-    private function ok(mixed $data = null, ?string $message = null, ?int $httpStatus = null): array
+    private function ok(mixed $data = null, ?string $message = null, bool $created = false): array
     {
         $result = [
             'success' => true,
@@ -260,22 +255,23 @@ class ModelFieldSectionService
         if ($message !== null) {
             $result['message'] = $message;
         }
-        if ($httpStatus !== null) {
-            $result['httpStatus'] = $httpStatus;
+        if ($created) {
+            $result['created'] = true;
         }
 
         return $result;
     }
 
     /**
-     * @return array{success: false, message: string, httpStatus: int}
+     * @param 'bad_request'|'not_found'|'server_error' $error
+     * @return array{success: false, message: string, error: string}
      */
-    private function fail(string $message, int $httpStatus = HttpStatus::BAD_REQUEST): array
+    private function fail(string $message, string $error = 'bad_request'): array
     {
         return [
             'success' => false,
             'message' => $message,
-            'httpStatus' => $httpStatus,
+            'error' => $error,
         ];
     }
 }

--- a/core/components/minishop3/src/Services/ModelField/ModelFieldService.php
+++ b/core/components/minishop3/src/Services/ModelField/ModelFieldService.php
@@ -1,0 +1,529 @@
+<?php
+
+namespace MiniShop3\Services\ModelField;
+
+use MiniShop3\Model\msModelField;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Services\ComboConfigManager;
+use MODX\Revolution\modX;
+
+/**
+ * CRUD and helpers for msModelField configuration.
+ */
+class ModelFieldService
+{
+    private const COMBO_XTYPES = ['combo', 'combobox', 'select', 'dropdown'];
+
+    private const UPDATE_FIELDS = [
+        'model',
+        'name',
+        'label',
+        'xtype',
+        'visible',
+        'required',
+        'sort_order',
+        'section_id',
+        'width',
+        'placeholder',
+        'description',
+        'config',
+    ];
+
+    private modX $modx;
+    private ModelFieldSectionService $sectionService;
+
+    public function __construct(modX $modx, ModelFieldSectionService $sectionService)
+    {
+        $this->modx = $modx;
+        $this->sectionService = $sectionService;
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function getList(array $params = []): array
+    {
+        $this->modx->lexicon->load('minishop3:vue');
+
+        $start = (int)($params['start'] ?? 0);
+        $limit = (int)($params['limit'] ?? 100);
+
+        $criteria = [];
+        if (!empty($params['model'])) {
+            $criteria['model'] = $params['model'];
+        }
+
+        $total = $this->modx->getCount(msModelField::class, $criteria);
+
+        $query = $this->modx->newQuery(msModelField::class);
+        if (!empty($criteria)) {
+            $query->where($criteria);
+        }
+        $query->sortby('model', 'ASC');
+        $query->sortby('sort_order', 'ASC');
+        $query->limit($limit, $start);
+
+        $sections = !empty($params['model'])
+            ? $this->sectionService->getSectionsForModel($params['model'])
+            : [];
+
+        $results = [];
+        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
+            $results[] = $this->formatField($field, $sections);
+        }
+
+        return $this->ok([
+            'results' => $results,
+            'total' => $total,
+            'sections' => $sections,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function get(array $params = []): array
+    {
+        $field = $this->requireField((int)($params['id'] ?? 0));
+        if (!$field instanceof msModelField) {
+            return $field;
+        }
+
+        return $this->ok($this->formatField($field));
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function create(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        $name = $params['name'] ?? '';
+
+        if (empty($model) || empty($name)) {
+            return $this->fail('Model and name are required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $existing = $this->modx->getObject(msModelField::class, [
+            'model' => $model,
+            'name' => $name,
+        ]);
+        if ($existing) {
+            return $this->fail('Field with this name already exists for this model');
+        }
+
+        $field = $this->modx->newObject(msModelField::class);
+        $field->fromArray([
+            'model' => $model,
+            'name' => $name,
+            'label' => $params['label'] ?? null,
+            'xtype' => $params['xtype'] ?? 'textfield',
+            'visible' => isset($params['visible']) ? (bool)$params['visible'] : true,
+            'required' => isset($params['required']) ? (bool)$params['required'] : false,
+            'sort_order' => (int)($params['sort_order'] ?? 0),
+            'section_id' => isset($params['section_id']) ? (int)$params['section_id'] : null,
+            'width' => (int)($params['width'] ?? 6),
+            'placeholder' => $params['placeholder'] ?? null,
+            'description' => $params['description'] ?? null,
+            'config' => $params['config'] ?? null,
+        ]);
+
+        if (!$field->save()) {
+            return $this->fail('Failed to create field', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->ok(
+            $this->formatField($field),
+            'Field created successfully',
+            HttpStatus::CREATED
+        );
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function update(array $params = []): array
+    {
+        $id = (int)($params['id'] ?? 0);
+        $field = $this->requireField($id);
+        if (!$field instanceof msModelField) {
+            return $field;
+        }
+
+        if (isset($params['name']) || isset($params['model'])) {
+            $newModel = $params['model'] ?? $field->get('model');
+            $newName = $params['name'] ?? $field->get('name');
+
+            if ($newModel !== $field->get('model') || $newName !== $field->get('name')) {
+                $existing = $this->modx->getObject(msModelField::class, [
+                    'model' => $newModel,
+                    'name' => $newName,
+                    'id:!=' => $id,
+                ]);
+                if ($existing) {
+                    return $this->fail('Field with this name already exists for this model');
+                }
+            }
+        }
+
+        if (isset($params['model'])) {
+            $invalid = $this->rejectInvalidModel($params['model']);
+            if ($invalid !== null) {
+                return $invalid;
+            }
+        }
+
+        foreach (self::UPDATE_FIELDS as $fieldName) {
+            if (!array_key_exists($fieldName, $params)) {
+                continue;
+            }
+            $field->set($fieldName, $this->castUpdateValue($fieldName, $params[$fieldName]));
+        }
+
+        if (!$field->save()) {
+            return $this->fail('Failed to update field', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->ok($this->formatField($field), 'Field updated successfully');
+    }
+
+    /**
+     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     */
+    public function delete(array $params = []): array
+    {
+        $field = $this->requireField((int)($params['id'] ?? 0));
+        if (!$field instanceof msModelField) {
+            return $field;
+        }
+
+        if (!$field->remove()) {
+            return $this->fail('Failed to delete field', HttpStatus::INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->ok(null, 'Field deleted successfully');
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>}
+     */
+    public function getModels(): array
+    {
+        $models = [];
+        foreach (msModelField::getAvailableModels() as $model) {
+            $models[] = [
+                'value' => $model,
+                'label' => $this->resolveModelLabel($model),
+            ];
+        }
+
+        return $this->ok(['models' => $models]);
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function getVisibleFields(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        if (empty($model)) {
+            return $this->fail('Model is required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $this->modx->lexicon->load('minishop3:vue');
+        $this->modx->lexicon->load('minishop3:default');
+        $this->modx->lexicon->load('minishop3:manager');
+
+        $sectionsById = [];
+        foreach ($this->sectionService->getSectionsForModel($model) as $section) {
+            if (!$section['hidden']) {
+                $sectionsById[$section['id']] = $section;
+            }
+        }
+
+        $query = $this->modx->newQuery(msModelField::class);
+        $query->where([
+            'model' => $model,
+            'visible' => true,
+        ]);
+        $query->sortby('sort_order', 'ASC');
+
+        $results = [];
+        $fieldsWithProperties = [];
+        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
+            $data = $field->toArray();
+
+            $label = $data['label'] ?? $data['name'];
+            $data['label_display'] = $this->translateMs3Key($label) ?? $label;
+
+            $description = $data['description'] ?? '';
+            $data['description_display'] = $this->translateMs3Key($description) ?? $description;
+
+            if (!empty($data['section_id']) && isset($sectionsById[$data['section_id']])) {
+                $data['section'] = $sectionsById[$data['section_id']];
+            }
+
+            $results[] = $data;
+
+            if (in_array($data['xtype'] ?? '', self::COMBO_XTYPES)) {
+                $fieldsWithProperties[] = [
+                    'name' => $data['name'],
+                    'properties' => $data['config'] ?? null,
+                ];
+            }
+        }
+
+        $comboOptionsWithMeta = (new ComboConfigManager($this->modx))
+            ->resolveAllOptionsWithMeta($model, $fieldsWithProperties);
+
+        return $this->ok([
+            'results' => $results,
+            'total' => count($results),
+            'model' => $model,
+            'sections' => array_values($sectionsById),
+            'comboOptions' => $comboOptionsWithMeta,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     */
+    public function updateRanks(array $params = []): array
+    {
+        $ranks = $params['ranks'] ?? [];
+        if (empty($ranks) || !is_array($ranks)) {
+            return $this->fail('Ranks array is required');
+        }
+
+        foreach ($ranks as $item) {
+            if (!isset($item['id'], $item['sort_order'])) {
+                continue;
+            }
+
+            $field = $this->modx->getObject(msModelField::class, (int)$item['id']);
+            if ($field) {
+                $field->set('sort_order', (int)$item['sort_order']);
+                $field->save();
+            }
+        }
+
+        return $this->ok(null, 'Ranks updated successfully');
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function getComboOptions(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        if (empty($model)) {
+            return $this->fail('Model is required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $query = $this->modx->newQuery(msModelField::class);
+        $query->where([
+            'model' => $model,
+            'xtype:IN' => self::COMBO_XTYPES,
+        ]);
+
+        $fieldsWithProperties = [];
+        foreach ($this->modx->getIterator(msModelField::class, $query) as $field) {
+            $fieldsWithProperties[] = [
+                'name' => $field->get('name'),
+                'properties' => $field->get('config'),
+            ];
+        }
+
+        $options = (new ComboConfigManager($this->modx))
+            ->resolveAllOptionsWithMeta($model, $fieldsWithProperties);
+
+        return $this->ok([
+            'model' => $model,
+            'options' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     */
+    public function getFieldComboOptions(array $params = []): array
+    {
+        $model = $params['model'] ?? '';
+        $fieldName = $params['field_name'] ?? '';
+
+        if (empty($model) || empty($fieldName)) {
+            return $this->fail('Model and field_name are required');
+        }
+
+        $invalid = $this->rejectInvalidModel($model);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $field = $this->modx->getObject(msModelField::class, [
+            'model' => $model,
+            'name' => $fieldName,
+        ]);
+
+        $dbProperties = null;
+        if ($field) {
+            $dbProperties = $field->get('config');
+            if (is_string($dbProperties)) {
+                $dbProperties = json_decode($dbProperties, true);
+            }
+        }
+
+        $options = (new ComboConfigManager($this->modx))
+            ->resolveOptions($model, $fieldName, $dbProperties);
+
+        return $this->ok([
+            'model' => $model,
+            'field_name' => $fieldName,
+            'options' => $options,
+        ]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $sections
+     * @return array<string, mixed>
+     */
+    public function formatField(msModelField $field, array $sections = []): array
+    {
+        $data = $field->toArray();
+
+        $translatedLabel = $this->translateMs3Key($data['label'] ?? null);
+        if ($translatedLabel !== null) {
+            $data['label_translated'] = $translatedLabel;
+        }
+
+        $translatedDescription = $this->translateMs3Key($data['description'] ?? null);
+        if ($translatedDescription !== null) {
+            $data['description_translated'] = $translatedDescription;
+        }
+
+        $data['model_label'] = $this->resolveModelLabel((string)$data['model']);
+
+        if (!empty($data['section_id']) && !empty($sections)) {
+            foreach ($sections as $section) {
+                if ($section['id'] == $data['section_id']) {
+                    $data['section_name'] = $section['label'];
+                    break;
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return msModelField|array{success: false, message: string, httpStatus: int}
+     */
+    private function requireField(int $id): msModelField|array
+    {
+        if (!$id) {
+            return $this->fail('Field ID is required');
+        }
+
+        $field = $this->modx->getObject(msModelField::class, $id);
+        if (!$field instanceof msModelField) {
+            return $this->fail('Field not found', HttpStatus::NOT_FOUND);
+        }
+
+        return $field;
+    }
+
+    /**
+     * @return array{success: false, message: string, httpStatus: int}|null
+     */
+    private function rejectInvalidModel(string $model): ?array
+    {
+        if (!in_array($model, msModelField::getAvailableModels())) {
+            return $this->fail('Invalid model type');
+        }
+
+        return null;
+    }
+
+    private function castUpdateValue(string $fieldName, mixed $value): mixed
+    {
+        if (in_array($fieldName, ['visible', 'required'], true)) {
+            return (bool)$value;
+        }
+        if (in_array($fieldName, ['sort_order', 'width'], true)) {
+            return (int)$value;
+        }
+        if ($fieldName === 'section_id') {
+            return $value ? (int)$value : null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Translate ms3_* lexicon key; null when not a key or untranslated.
+     */
+    private function translateMs3Key(?string $value): ?string
+    {
+        if ($value === null || $value === '' || !str_starts_with($value, 'ms3_')) {
+            return null;
+        }
+
+        $translated = $this->modx->lexicon($value);
+
+        return $translated !== $value ? $translated : null;
+    }
+
+    private function resolveModelLabel(string $model): string
+    {
+        $lexiconKey = 'ms3_model_' . strtolower(str_replace('ms', '', $model));
+        $label = $this->modx->lexicon($lexiconKey);
+
+        return $label !== $lexiconKey ? $label : $model;
+    }
+
+    /**
+     * @return array{success: true, data: mixed, message?: string, httpStatus?: int}
+     */
+    private function ok(mixed $data = null, ?string $message = null, ?int $httpStatus = null): array
+    {
+        $result = [
+            'success' => true,
+            'data' => $data,
+        ];
+        if ($message !== null) {
+            $result['message'] = $message;
+        }
+        if ($httpStatus !== null) {
+            $result['httpStatus'] = $httpStatus;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{success: false, message: string, httpStatus: int}
+     */
+    private function fail(string $message, int $httpStatus = HttpStatus::BAD_REQUEST): array
+    {
+        return [
+            'success' => false,
+            'message' => $message,
+            'httpStatus' => $httpStatus,
+        ];
+    }
+}

--- a/core/components/minishop3/src/Services/ModelField/ModelFieldService.php
+++ b/core/components/minishop3/src/Services/ModelField/ModelFieldService.php
@@ -3,7 +3,6 @@
 namespace MiniShop3\Services\ModelField;
 
 use MiniShop3\Model\msModelField;
-use MiniShop3\Router\HttpStatus;
 use MiniShop3\Services\ComboConfigManager;
 use MODX\Revolution\modX;
 
@@ -39,7 +38,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function getList(array $params = []): array
     {
@@ -80,7 +79,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function get(array $params = []): array
     {
@@ -93,7 +92,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function create(array $params = []): array
     {
@@ -134,18 +133,14 @@ class ModelFieldService
         ]);
 
         if (!$field->save()) {
-            return $this->fail('Failed to create field', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to create field', 'server_error');
         }
 
-        return $this->ok(
-            $this->formatField($field),
-            'Field created successfully',
-            HttpStatus::CREATED
-        );
+        return $this->ok($this->formatField($field), 'Field created successfully', true);
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function update(array $params = []): array
     {
@@ -186,14 +181,14 @@ class ModelFieldService
         }
 
         if (!$field->save()) {
-            return $this->fail('Failed to update field', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to update field', 'server_error');
         }
 
         return $this->ok($this->formatField($field), 'Field updated successfully');
     }
 
     /**
-     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: mixed, message?: string, created?: true}
      */
     public function delete(array $params = []): array
     {
@@ -203,7 +198,7 @@ class ModelFieldService
         }
 
         if (!$field->remove()) {
-            return $this->fail('Failed to delete field', HttpStatus::INTERNAL_SERVER_ERROR);
+            return $this->fail('Failed to delete field', 'server_error');
         }
 
         return $this->ok(null, 'Field deleted successfully');
@@ -226,7 +221,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function getVisibleFields(array $params = []): array
     {
@@ -296,7 +291,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: mixed, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: mixed, message?: string, created?: true}
      */
     public function updateRanks(array $params = []): array
     {
@@ -321,7 +316,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function getComboOptions(array $params = []): array
     {
@@ -359,7 +354,7 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: bool, data?: array<string, mixed>, message?: string, httpStatus?: int}
+     * @return array{success: bool, data?: array<string, mixed>, message?: string, created?: true}
      */
     public function getFieldComboOptions(array $params = []): array
     {
@@ -431,7 +426,7 @@ class ModelFieldService
     }
 
     /**
-     * @return msModelField|array{success: false, message: string, httpStatus: int}
+     * @return msModelField|array{success: false, message: string, error: string}
      */
     private function requireField(int $id): msModelField|array
     {
@@ -441,14 +436,14 @@ class ModelFieldService
 
         $field = $this->modx->getObject(msModelField::class, $id);
         if (!$field instanceof msModelField) {
-            return $this->fail('Field not found', HttpStatus::NOT_FOUND);
+            return $this->fail('Field not found', 'not_found');
         }
 
         return $field;
     }
 
     /**
-     * @return array{success: false, message: string, httpStatus: int}|null
+     * @return array{success: false, message: string, error: string}|null
      */
     private function rejectInvalidModel(string $model): ?array
     {
@@ -497,9 +492,9 @@ class ModelFieldService
     }
 
     /**
-     * @return array{success: true, data: mixed, message?: string, httpStatus?: int}
+     * @return array{success: true, data: mixed, message?: string, created?: true}
      */
-    private function ok(mixed $data = null, ?string $message = null, ?int $httpStatus = null): array
+    private function ok(mixed $data = null, ?string $message = null, bool $created = false): array
     {
         $result = [
             'success' => true,
@@ -508,22 +503,23 @@ class ModelFieldService
         if ($message !== null) {
             $result['message'] = $message;
         }
-        if ($httpStatus !== null) {
-            $result['httpStatus'] = $httpStatus;
+        if ($created) {
+            $result['created'] = true;
         }
 
         return $result;
     }
 
     /**
-     * @return array{success: false, message: string, httpStatus: int}
+     * @param 'bad_request'|'not_found'|'server_error' $error
+     * @return array{success: false, message: string, error: string}
      */
-    private function fail(string $message, int $httpStatus = HttpStatus::BAD_REQUEST): array
+    private function fail(string $message, string $error = 'bad_request'): array
     {
         return [
             'success' => false,
             'message' => $message,
-            'httpStatus' => $httpStatus,
+            'error' => $error,
         ];
     }
 }

--- a/core/components/minishop3/tests/ModelFieldsServiceStructureTest.php
+++ b/core/components/minishop3/tests/ModelFieldsServiceStructureTest.php
@@ -79,5 +79,39 @@ if (!str_contains($controllerSrc, "services->get('ms3_model_field_section_servic
     $fail('ModelFieldsController must resolve ms3_model_field_section_service from DI');
 }
 
+if (str_contains($fieldServiceSrc, 'HttpStatus') || str_contains($sectionServiceSrc, 'HttpStatus')) {
+    $fail('ModelField services must not import Router\\HttpStatus (HTTP stays in controller)');
+}
+
+// Envelope mapping: domain error codes → HTTP status (no MODX bootstrap).
+require_once $root . '/vendor/autoload.php';
+
+use MiniShop3\Controllers\Api\Manager\ModelFieldsController;
+use MiniShop3\Router\HttpStatus;
+
+$controllerReflection = new \ReflectionClass(ModelFieldsController::class);
+$mapResult = $controllerReflection->getMethod('mapResult');
+$mapResult->setAccessible(true);
+$controller = $controllerReflection->newInstanceWithoutConstructor();
+
+$notFound = $mapResult->invoke($controller, [
+    'success' => false,
+    'message' => 'Field not found',
+    'error' => 'not_found',
+]);
+if (($notFound['success'] ?? true) !== false || (int)($notFound['code'] ?? 0) !== HttpStatus::NOT_FOUND) {
+    $fail('mapResult must map error=not_found to HTTP 404');
+}
+
+$created = $mapResult->invoke($controller, [
+    'success' => true,
+    'data' => ['id' => 1],
+    'message' => 'Field created successfully',
+    'created' => true,
+]);
+if (($created['success'] ?? false) !== true || !isset($created['data']['id'])) {
+    $fail('mapResult must unwrap successful create data');
+}
+
 fwrite(STDOUT, "OK ModelFieldsServiceStructureTest (controller LOC={$controllerLines})\n");
 exit(0);

--- a/core/components/minishop3/tests/ModelFieldsServiceStructureTest.php
+++ b/core/components/minishop3/tests/ModelFieldsServiceStructureTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Smoke: ModelFieldsController → ModelField(Section)Service (#364).
+ *
+ * Run: php tests/ModelFieldsServiceStructureTest.php
+ */
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL ModelFieldsServiceStructureTest: {$message}\n");
+    exit(1);
+};
+
+$fieldServicePath = $root . '/src/Services/ModelField/ModelFieldService.php';
+$sectionServicePath = $root . '/src/Services/ModelField/ModelFieldSectionService.php';
+$controllerPath = $root . '/src/Controllers/Api/Manager/ModelFieldsController.php';
+$registryPath = $root . '/src/ServiceRegistry.php';
+
+foreach ([$fieldServicePath, $sectionServicePath, $controllerPath, $registryPath] as $path) {
+    if (!is_readable($path)) {
+        $fail(basename($path) . ' missing or unreadable');
+    }
+}
+
+$fieldServiceSrc = file_get_contents($fieldServicePath);
+$sectionServiceSrc = file_get_contents($sectionServicePath);
+$controllerSrc = file_get_contents($controllerPath);
+$registrySrc = file_get_contents($registryPath);
+
+if ($fieldServiceSrc === false || $sectionServiceSrc === false || $controllerSrc === false || $registrySrc === false) {
+    $fail('failed to read one or more PHP sources');
+}
+
+if (!str_contains($fieldServiceSrc, 'class ModelFieldService')) {
+    $fail('ModelFieldService class not found');
+}
+if (!str_contains($sectionServiceSrc, 'class ModelFieldSectionService')) {
+    $fail('ModelFieldSectionService class not found');
+}
+
+$controllerLines = substr_count($controllerSrc, "\n") + (str_ends_with($controllerSrc, "\n") ? 0 : 1);
+if ($controllerLines >= 400) {
+    $fail("ModelFieldsController LOC must be < 400, got {$controllerLines}");
+}
+
+if (str_contains($controllerSrc, 'newQuery(msModelField')) {
+    $fail('controller must not contain newQuery(msModelField');
+}
+if (str_contains($controllerSrc, 'newObject(msModelField')) {
+    $fail('controller must not contain newObject(msModelField');
+}
+
+foreach (['create', 'update', 'delete'] as $method) {
+    if (!preg_match('/function\s+' . preg_quote($method, '/') . '\s*\(/', $fieldServiceSrc)) {
+        $fail("ModelFieldService missing method {$method}");
+    }
+}
+
+foreach (['createSection', 'updateSection', 'deleteSection'] as $method) {
+    if (!preg_match('/function\s+' . preg_quote($method, '/') . '\s*\(/', $sectionServiceSrc)) {
+        $fail("ModelFieldSectionService missing method {$method}");
+    }
+}
+
+if (!str_contains($registrySrc, "'ms3_model_field_service'")) {
+    $fail('ServiceRegistry must register ms3_model_field_service');
+}
+if (!str_contains($registrySrc, "'ms3_model_field_section_service'")) {
+    $fail('ServiceRegistry must register ms3_model_field_section_service');
+}
+
+if (!str_contains($controllerSrc, "services->get('ms3_model_field_service')")) {
+    $fail('ModelFieldsController must resolve ms3_model_field_service from DI');
+}
+if (!str_contains($controllerSrc, "services->get('ms3_model_field_section_service')")) {
+    $fail('ModelFieldsController must resolve ms3_model_field_section_service from DI');
+}
+
+fwrite(STDOUT, "OK ModelFieldsServiceStructureTest (controller LOC={$controllerLines})\n");
+exit(0);


### PR DESCRIPTION
## Описание

Бизнес-логика `ModelFieldsController` вынесена в `ModelFieldService` и `ModelFieldSectionService`. Контроллер остаётся HTTP-слоем: parse → service → `Response::*`. URL маршрутов без изменений.

Tracker: #361.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #364

Refs #361

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Controllers/Api/Manager/ModelFieldsController.php   # exit 0
php -l src/Services/ModelField/ModelFieldService.php            # exit 0
php -l src/Services/ModelField/ModelFieldSectionService.php     # exit 0
php tests/ModelFieldsServiceStructureTest.php                   # exit 0
php tests/ServiceRegistryDiTest.php                             # exit 0
composer test:smoke                                             # exit 0 (52)
```

- [ ] Ручное тестирование (CRUD полей/секций в mgr — checklist ниже)
- [x] Автоматические тесты (`composer test:smoke`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-364-model-fields-service`
- MODX: n/a (smoke)
- PHP: 8.4

## Скриншоты (если применимо)

n/a

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы — не требуются
- [ ] PHPStan / CI
- [x] ESLint — n/a
- [ ] CHANGELOG.md — на релизе

## Дополнительные заметки

### Gate A

| AC | Code | Test |
|----|------|------|
| Controller &lt; ~300–400 LOC, без толстого xPDO CRUD | 183 LOC, без `newQuery/newObject(msModelField` | `ModelFieldsServiceStructureTest` |
| Сервисы в registry; JSON shape без breaking | `ms3_model_field_*` DI; те же сообщения/payloads | structure + envelope mapResult smoke |
| `php -l` + smoke | OK | Gate E выше |
| Ссылка на #361 | Refs в PR | n/a |

### Ручной smoke (mgr)
- [ ] list/create/update/delete model field
- [ ] sections CRUD + ranks drag-n-drop
- [ ] visible fields + combo-options для модели

### Review
code-reviewer + thermo-nuclear; 1 fix-loop: HTTP status вынесен из сервисов в controller (`error`/`created` domain flags).