### PR TITLE
fix(migrations): inline ruble symbol in currency mojibake repair

### DIFF
--- a/core/components/minishop3/migrations/20260801190000_repair_currency_symbol_mojibake.php
+++ b/core/components/minishop3/migrations/20260801190000_repair_currency_symbol_mojibake.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
-use MiniShop3\Utils\Format;
 use Phinx\Migration\AbstractMigration;
 
 /**
  * Repair ms3_currency_symbol when the ruble was stored as ASCII "?" (mojibake).
+ *
+ * Self-contained: do not import MiniShop3 application classes — during transport
+ * install/upgrade Phinx may run before the new Format.php (with DEFAULT_CURRENCY_SYMBOL) is loaded.
  *
  * @see https://github.com/modx-pro/MiniShop3/issues/497
  */
@@ -17,6 +19,9 @@ final class RepairCurrencySymbolMojibake extends AbstractMigration
     private const NAMESPACE = 'minishop3';
 
     private const MOJIBAKE = '?';
+
+    /** Ruble sign (U+20BD). Keep in sync with MiniShop3\Utils\Format::DEFAULT_CURRENCY_SYMBOL */
+    private const RUBLE_SYMBOL = "\u{20BD}";
 
     public function up(): void
     {
@@ -29,7 +34,7 @@ final class RepairCurrencySymbolMojibake extends AbstractMigration
             . " WHERE `key` = :key AND `namespace` = :namespace AND `value` = :broken"
         );
         $stmt->execute([
-            'symbol' => Format::DEFAULT_CURRENCY_SYMBOL,
+            'symbol' => self::RUBLE_SYMBOL,
             'key' => self::SETTING_KEY,
             'namespace' => self::NAMESPACE,
             'broken' => self::MOJIBAKE,

--- a/core/components/minishop3/tests/MigrationSelfContainedTest.php
+++ b/core/components/minishop3/tests/MigrationSelfContainedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Migrations must not import MiniShop3 application code (transport install runs Phinx
+ * before guaranteed autoload of the new component classes).
+ *
+ * Run: php tests/MigrationSelfContainedTest.php
+ */
+
+declare(strict_types=1);
+
+$migrationsDir = dirname(__DIR__) . '/migrations';
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL MigrationSelfContainedTest: {$message}\n");
+    exit(1);
+};
+
+$files = glob($migrationsDir . '/*.php') ?: [];
+if ($files === []) {
+    $fail('no migration files found');
+}
+
+foreach ($files as $file) {
+    $source = (string) file_get_contents($file);
+    $basename = basename($file);
+
+    if (preg_match('/^use MiniShop3\\\\/m', $source)) {
+        $fail("{$basename} imports MiniShop3 namespace — keep migrations self-contained");
+    }
+}
+
+fwrite(STDOUT, "OK MigrationSelfContainedTest (" . count($files) . " migrations)\n");
+exit(0);


### PR DESCRIPTION
## Summary

Миграция `repair_currency_symbol_mojibake` падала при установке пакета: `Undefined constant Format::DEFAULT_CURRENCY_SYMBOL`. Phinx во время transport resolver не гарантирует загрузку нового `Format.php` с константой.

- Inline `RUBLE_SYMBOL = "\u{20BD}"` вместо `Format::DEFAULT_CURRENCY_SYMBOL`
- Smoke `MigrationSelfContainedTest`: запрет `use MiniShop3\` в migrations/

## Thermo-nuclear (кратко)

Boundary leak: миграция тянула application layer. Fix = code-judo: удалить import, оставить комментарий sync с `Format`.

Closes #519
Refs #497

## Test plan

```bash
php -l core/components/minishop3/migrations/20260801190000_repair_currency_symbol_mojibake.php
cd core/components/minishop3 && php tests/MigrationSelfContainedTest.php
```