### PR TITLE
fix(di): OptionCategoryService в ms3_option_service (Settings/Category Options)

### DIFF
--- a/core/components/minishop3/config/ms3.services.example.php
+++ b/core/components/minishop3/config/ms3.services.example.php
@@ -190,14 +190,15 @@ return [
      *
      * Categories:
      * ----------
-     * 'ms3_category_service'        - Category operations
-     * 'ms3_category_option_service' - Category options
+     * 'ms3_category_service'         - Category operations
+     * 'ms3_category_option_service'  - Category → option fields (Category\CategoryOptionService)
      *
      * Product Options (override via ms3.services.php / ms3.services.d/):
      * --------------
-     * 'ms3_option_service'          - EAV options facade
-     * 'ms3_option_loader'           - load option values / admin fields
-     * 'ms3_option_sync'             - save/sync product option values
+     * 'ms3_option_service'           - EAV options facade
+     * 'ms3_option_loader'            - load option values / admin fields
+     * 'ms3_option_sync'              - save/sync product option values
+     * 'ms3_option_category_service'  - option ↔ category links (Option\OptionCategoryService)
      *
      * Order manager cost:
      * -------------------

--- a/core/components/minishop3/src/Processors/Api/ProcessesManagerConnectorRouteTrait.php
+++ b/core/components/minishop3/src/Processors/Api/ProcessesManagerConnectorRouteTrait.php
@@ -73,7 +73,8 @@ trait ProcessesManagerConnectorRouteTrait
                 $responseData['message'] ?? 'API request failed',
                 $responseData
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // TypeError/Error must stay JSON — display_errors HTML breaks Vue request.json() (#531/#532).
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[MiniShop3 API] ' . $e->getMessage());
             http_response_code(500);
 

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -93,7 +93,7 @@ class ServiceRegistry
         'ms3_option_service' => [
             'ms3_option_loader',
             'ms3_option_sync',
-            'ms3_category_option_service',
+            'ms3_option_category_service',
         ],
         'ms3_order_field_manager' => ['ms3_order_draft_manager'],
         'ms3_order_address_manager' => ['ms3_order_draft_manager', 'ms3_order_field_manager'],
@@ -265,6 +265,10 @@ class ServiceRegistry
         ],
         'ms3_category_option_service' => [
             'class' => \MiniShop3\Services\Category\CategoryOptionService::class,
+            'interface' => null,
+        ],
+        'ms3_option_category_service' => [
+            'class' => \MiniShop3\Services\Option\OptionCategoryService::class,
             'interface' => null,
         ],
         'ms3_image' => [
@@ -626,10 +630,11 @@ class ServiceRegistry
         switch ($serviceKey) {
             case 'ms3_option_service':
                 // OptionService(xPDO, OptionLoaderService, OptionSyncService, OptionCategoryService)
+                // Not ms3_category_option_service (Category\CategoryOptionService) — #531/#532.
                 $this->modx->services->add($serviceKey, function () use ($validatedClass, $modx) {
                     $loader = $modx->services->get('ms3_option_loader');
                     $sync = $modx->services->get('ms3_option_sync');
-                    $category = $modx->services->get('ms3_category_option_service');
+                    $category = $modx->services->get('ms3_option_category_service');
 
                     return new $validatedClass($modx, $loader, $sync, $category);
                 });

--- a/core/components/minishop3/tests/RouterRoutePlansTest.php
+++ b/core/components/minishop3/tests/RouterRoutePlansTest.php
@@ -109,6 +109,9 @@ if (!str_contains($traitSrc, 'System routes not found:')) {
 if (!str_contains($traitSrc, 'http_response_code(404)')) {
     $fail('trait must call http_response_code(404) when rejecting storefront routes');
 }
+if (!str_contains($traitSrc, 'catch (\\Throwable')) {
+    $fail('trait must catch \\Throwable so TypeError stays JSON (#531/#532)');
+}
 if (str_contains($traitSrc, 'loadWebRoutes') || str_contains($traitSrc, 'ManagerConnectorRouteLoader')) {
     $fail('trait must not load web routes or use deleted ManagerConnectorRouteLoader');
 }

--- a/core/components/minishop3/tests/ServiceRegistryDiTest.php
+++ b/core/components/minishop3/tests/ServiceRegistryDiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * DI registry smoke for #363 — OptionSync/Loader/Category + ManagerOrderCostRecalculator.
+ * DI registry smoke — OptionService wiring (#363, #531/#532).
  *
  * Run: php tests/ServiceRegistryDiTest.php
  */
@@ -12,6 +12,9 @@ require __DIR__ . '/stubs/ModxStub.php';
 require __DIR__ . '/../vendor/autoload.php';
 
 use MiniShop3\ServiceRegistry;
+use MiniShop3\Services\Category\CategoryOptionService;
+use MiniShop3\Services\Option\OptionCategoryService;
+use MiniShop3\Services\Option\OptionService;
 use MODX\Revolution\modX;
 
 $fail = static function (string $message): never {
@@ -27,6 +30,7 @@ if ($registrySrc === false || $registrySrc === '') {
 foreach ([
     'ms3_option_loader',
     'ms3_option_sync',
+    'ms3_option_category_service',
     'ms3_category_option_service',
     'ms3_manager_order_cost_recalculator',
 ] as $key) {
@@ -47,8 +51,15 @@ if (!str_contains($registrySrc, "case 'ms3_option_service':")) {
     $fail('registerServiceWithDependencies must wire ms3_option_service');
 }
 
-if (!str_contains($registrySrc, "services->get('ms3_category_option_service')")) {
-    $fail('registerServiceWithDependencies must resolve ms3_category_option_service for OptionService');
+if (!str_contains($registrySrc, "services->get('ms3_option_category_service')")) {
+    $fail('ms3_option_service factory must resolve ms3_option_category_service (#531/#532)');
+}
+
+if (preg_match(
+    "/case 'ms3_option_service':.*?services->get\\('ms3_category_option_service'\\)/s",
+    $registrySrc
+) === 1) {
+    $fail('ms3_option_service must not inject ms3_category_option_service (wrong class) (#531/#532)');
 }
 
 if (!str_contains($registrySrc, 'SERVICES_WITH_MODX_AND_MS3')) {
@@ -68,7 +79,10 @@ if (preg_match('/new\s+OptionSyncService\s*\(/', $optionServiceSrc)) {
 if (preg_match('/new\s+OptionCategoryService\s*\(/', $optionServiceSrc)) {
     $fail('OptionService must not instantiate OptionCategoryService directly');
 }
-if (!preg_match('/OptionLoaderService\s+\$loader,\s*OptionSyncService\s+\$sync,\s*OptionCategoryService\s+\$category/s', $optionServiceSrc)) {
+if (!preg_match(
+    '/OptionLoaderService\s+\$loader,\s*OptionSyncService\s+\$sync,\s*OptionCategoryService\s+\$category/s',
+    $optionServiceSrc
+)) {
     $fail('OptionService constructor must accept loader/sync/category from DI');
 }
 
@@ -90,6 +104,7 @@ if ($example === false) {
 foreach ([
     'ms3_option_loader',
     'ms3_option_sync',
+    'ms3_option_category_service',
     'ms3_category_option_service',
     'ms3_manager_order_cost_recalculator',
 ] as $key) {
@@ -98,18 +113,22 @@ foreach ([
     }
 }
 
-// Behavior test: every factory-map key and every declared dependency must be
-// a registered service key, so the DI wiring can actually resolve at runtime
-// (#363 review: verify factory map keys exist).
 $modx = new modX();
 $registry = new class ($modx) extends ServiceRegistry {
     protected function loadCustomServices(): void
     {
         // skip filesystem config loading in unit test
     }
+
+    public function defaultServiceMap(): array
+    {
+        return $this->defaultServices;
+    }
 };
+
 $registered = $registry->getRegisteredServices();
 $registeredSet = array_flip($registered);
+$defaults = $registry->defaultServiceMap();
 
 $assertRegistered = static function (string $key, string $map) use ($registeredSet, $fail): void {
     if (!isset($registeredSet[$key])) {
@@ -122,9 +141,6 @@ foreach (ServiceRegistry::CONTROLLERS_WITH_MS3_ONLY as $key) {
 }
 foreach (ServiceRegistry::SERVICES_WITH_MODX_AND_MS3 as $key) {
     $assertRegistered($key, 'SERVICES_WITH_MODX_AND_MS3');
-    if ($key !== 'ms3_manager_order_cost_recalculator') {
-        continue;
-    }
 }
 if (!in_array('ms3_manager_order_cost_recalculator', ServiceRegistry::SERVICES_WITH_MODX_AND_MS3, true)) {
     $fail('ms3_manager_order_cost_recalculator must use modX+MiniShop3 factory');
@@ -146,8 +162,34 @@ if (!in_array('ms3_option_loader', $optionDeps, true)) {
 if (!in_array('ms3_option_sync', $optionDeps, true)) {
     $fail('ms3_option_service must depend on ms3_option_sync');
 }
-if (!in_array('ms3_category_option_service', $optionDeps, true)) {
-    $fail('ms3_option_service must depend on ms3_category_option_service');
+if (!in_array('ms3_option_category_service', $optionDeps, true)) {
+    $fail('ms3_option_service must depend on ms3_option_category_service (#531/#532)');
+}
+if (in_array('ms3_category_option_service', $optionDeps, true)) {
+    $fail('ms3_option_service must not depend on ms3_category_option_service (#531/#532)');
+}
+
+if (($defaults['ms3_option_category_service']['class'] ?? null) !== OptionCategoryService::class) {
+    $fail('ms3_option_category_service must map to Option\\OptionCategoryService');
+}
+if (($defaults['ms3_category_option_service']['class'] ?? null) !== CategoryOptionService::class) {
+    $fail('ms3_category_option_service must map to Category\\CategoryOptionService');
+}
+
+$ctor = new ReflectionMethod(OptionService::class, '__construct');
+$params = $ctor->getParameters();
+if (count($params) < 4) {
+    $fail('OptionService::__construct must have 4 parameters');
+}
+$categoryType = $params[3]->getType();
+if (!$categoryType instanceof ReflectionNamedType || $categoryType->getName() !== OptionCategoryService::class) {
+    $fail('OptionService 4th ctor param must be typed OptionCategoryService');
+}
+
+// Class map for 4th DI dep must match ctor type (catches CategoryOptionService mix-up).
+$categoryDepClass = $defaults['ms3_option_category_service']['class'] ?? null;
+if ($categoryDepClass !== $categoryType->getName()) {
+    $fail('ms3_option_category_service class must match OptionService 4th ctor type');
 }
 
 fwrite(STDOUT, "OK ServiceRegistryDiTest\n");


### PR DESCRIPTION
## Описание

Один root cause для [#531](https://github.com/modx-pro/MiniShop3/issues/531) и [#532](https://github.com/modx-pro/MiniShop3/issues/532): фабрика `ms3_option_service` инжектила `Category\CategoryOptionService` вместо `Option\OptionCategoryService` → `TypeError` → HTML в connector → Vue `RequestError: Unexpected token '<'`.

- Зарегистрирован `ms3_option_category_service` → `Option\OptionCategoryService`
- Factory `ms3_option_service` берёт этот ключ (не `ms3_category_option_service`)
- `ms3_category_option_service` остаётся для `msCategory` / `CategoryOptionService`
- Connector: `catch (\Throwable)` — TypeError остаётся JSON
- `ServiceRegistryDiTest` переписан: class map + reflection 4-го параметра ctor; запрет неверного wiring

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #531
Closes #532

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/ServiceRegistry.php                                  # exit 0
php -l src/Processors/Api/ProcessesManagerConnectorRouteTrait.php # exit 0
php tests/ServiceRegistryDiTest.php                             # OK, exit 0
php tests/RouterRoutePlansTest.php                              # OK, exit 0
php tests/run-smoke.php                                         # OK, exit 0
```

- [x] Автоматические тесты (регрессия DI + Throwable в trait)
- [ ] Ручное: Settings → Опции, Category → Опции (после установки пакета)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [ ] CHANGELOG.md — нет (не релиз)

## Дополнительные заметки

- Review: code-reviewer + thermo-nuclear — BLOCK/high нет
- Out of scope: frontend try/catch в `OptionsGrid` / `ResourceCategoryTree` (желательно отдельно); lazy DI в `OptionsController`
- После merge: пересобрать/переустановить пакет на стенде с 1.12.0-beta1