### PR TITLE
fix(vue): изоляция confirm-диалогов категории через group — двойной confirm (#538)

### DIFF
--- a/vueManager/src/components/ActionsColumn.vue
+++ b/vueManager/src/components/ActionsColumn.vue
@@ -67,6 +67,16 @@ const props = defineProps({
   },
 
   /**
+   * ConfirmDialog group to target. Set it (matching a <ConfirmDialog group="...">)
+   * to isolate the confirm on pages where several Vue apps share one PrimeVue
+   * ConfirmationEventBus. Omit to stay ungrouped (default).
+   */
+  confirmGroup: {
+    type: String,
+    default: null,
+  },
+
+  /**
    * Show icons only (without text)
    */
   iconOnly: {
@@ -98,6 +108,7 @@ const { _ } = useLexicon()
 
 const { executeAction } = useActions({
   gridId: props.gridId,
+  confirmGroup: props.confirmGroup,
   onRefresh: () => emit('refresh'),
   onEdit: data => emit('edit', data),
   onDelete: data => emit('delete', data),

--- a/vueManager/src/components/CategoryOptionsTab.vue
+++ b/vueManager/src/components/CategoryOptionsTab.vue
@@ -25,6 +25,11 @@ const toast = useToast()
 const confirm = useConfirm()
 const { _ } = useLexicon()
 
+// Confirm group for this tab's PrimeVue ConfirmDialog. Shared by <ConfirmDialog> and
+// both confirm.require() calls — a typo silently kills the confirm (matches no dialog),
+// so keep it a single source of truth.
+const CONFIRM_GROUP = 'category-options'
+
 const links = ref([])
 const loading = ref(false)
 const searchQuery = ref('')
@@ -182,7 +187,7 @@ async function performBulkAction(action) {
 function confirmBulkRemove() {
   if (selectedRows.value.length === 0) return
   confirm.require({
-    group: 'category-options',
+    group: CONFIRM_GROUP,
     message:
       _('ms3_options_remove_confirm') ||
       'Удалить выбранные опции из категории? Значения опций у товаров будут удалены.',
@@ -256,7 +261,7 @@ async function performCopy() {
 
 function confirmSingleRemove(row) {
   confirm.require({
-    group: 'category-options',
+    group: CONFIRM_GROUP,
     message:
       _('ms3_option_remove_confirm') || `Удалить опцию «${row.caption || row.key}» из категории?`,
     header: _('confirm') || 'Подтверждение',
@@ -298,7 +303,7 @@ onMounted(() => {
 <template>
   <div class="category-options-tab">
     <Toast />
-    <ConfirmDialog group="category-options" />
+    <ConfirmDialog :group="CONFIRM_GROUP" />
 
     <div class="toolbar">
       <Button

--- a/vueManager/src/components/CategoryOptionsTab.vue
+++ b/vueManager/src/components/CategoryOptionsTab.vue
@@ -182,6 +182,7 @@ async function performBulkAction(action) {
 function confirmBulkRemove() {
   if (selectedRows.value.length === 0) return
   confirm.require({
+    group: 'category-options',
     message:
       _('ms3_options_remove_confirm') ||
       'Удалить выбранные опции из категории? Значения опций у товаров будут удалены.',
@@ -255,6 +256,7 @@ async function performCopy() {
 
 function confirmSingleRemove(row) {
   confirm.require({
+    group: 'category-options',
     message:
       _('ms3_option_remove_confirm') || `Удалить опцию «${row.caption || row.key}» из категории?`,
     header: _('confirm') || 'Подтверждение',
@@ -296,7 +298,7 @@ onMounted(() => {
 <template>
   <div class="category-options-tab">
     <Toast />
-    <ConfirmDialog />
+    <ConfirmDialog group="category-options" />
 
     <div class="toolbar">
       <Button

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -9,7 +9,6 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Tag from 'primevue/tag'
 import Toast from 'primevue/toast'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, defineProps, onMounted, ref, watch } from 'vue'
 import draggable from 'vuedraggable'
@@ -33,7 +32,6 @@ const props = defineProps({
 })
 
 const toast = useToast()
-useConfirm()
 const { _ } = useLexicon()
 
 // Bulk selection
@@ -46,6 +44,7 @@ const {
   confirmBulkDelete,
 } = useSelection({
   entityName: 'product',
+  confirmGroup: 'category-products',
   deleteBulk: async ids => {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
@@ -772,7 +771,7 @@ onMounted(async () => {
 <template>
   <div class="category-products-grid">
     <Toast />
-    <ConfirmDialog append-to="self" />
+    <ConfirmDialog group="category-products" append-to="self" />
 
     <Card>
       <template #title>
@@ -974,6 +973,7 @@ onMounted(async () => {
                           :data="product"
                           :actions="getActionsConfig(column)"
                           grid-id="category-products"
+                          confirm-group="category-products"
                           @view="viewProduct"
                           @edit="editProduct"
                           @delete="deleteProduct"

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -34,6 +34,11 @@ const props = defineProps({
 const toast = useToast()
 const { _ } = useLexicon()
 
+// Confirm group for this grid's PrimeVue ConfirmDialog. Shared by <ConfirmDialog>,
+// useSelection and <ActionsColumn> — a typo in any one silently kills the confirm
+// (the require() then matches no dialog), so keep it a single source of truth.
+const CONFIRM_GROUP = 'category-products'
+
 // Bulk selection
 const {
   selectedItems,
@@ -44,7 +49,7 @@ const {
   confirmBulkDelete,
 } = useSelection({
   entityName: 'product',
-  confirmGroup: 'category-products',
+  confirmGroup: CONFIRM_GROUP,
   deleteBulk: async ids => {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
@@ -771,7 +776,7 @@ onMounted(async () => {
 <template>
   <div class="category-products-grid">
     <Toast />
-    <ConfirmDialog group="category-products" append-to="self" />
+    <ConfirmDialog :group="CONFIRM_GROUP" append-to="self" />
 
     <Card>
       <template #title>
@@ -973,7 +978,7 @@ onMounted(async () => {
                           :data="product"
                           :actions="getActionsConfig(column)"
                           grid-id="category-products"
-                          confirm-group="category-products"
+                          :confirm-group="CONFIRM_GROUP"
                           @view="viewProduct"
                           @edit="editProduct"
                           @delete="deleteProduct"

--- a/vueManager/src/composables/useActions.js
+++ b/vueManager/src/composables/useActions.js
@@ -22,6 +22,9 @@ import actionRegistry from '../actionRegistry.js'
  * @param {Function} options.onPublish - Callback for publishing/unpublishing
  * @param {Function} options.onDuplicate - Callback for duplicating
  * @param {Function} options.onCustomAction - Callback for custom actions (event, data)
+ * @param {string} options.confirmGroup - ConfirmDialog group to target (isolates the
+ *   confirm on pages where several Vue apps share one PrimeVue ConfirmationEventBus).
+ *   Omit to stay ungrouped (default, backward compatible).
  */
 export function useActions(options = {}) {
   const toast = useToast()
@@ -30,6 +33,7 @@ export function useActions(options = {}) {
 
   const {
     gridId = 'unknown',
+    confirmGroup = null,
     onRefresh = () => {},
     onEdit = () => {},
     onDelete = () => {},
@@ -105,6 +109,7 @@ export function useActions(options = {}) {
           : _('action_confirm_title')
 
         confirm.require({
+          group: confirmGroup || undefined,
           message,
           header,
           icon: 'pi pi-exclamation-triangle',

--- a/vueManager/src/composables/useActions.js
+++ b/vueManager/src/composables/useActions.js
@@ -109,6 +109,12 @@ export function useActions(options = {}) {
           : _('action_confirm_title')
 
         confirm.require({
+          // `|| undefined` is load-bearing, NOT cosmetic. PrimeVue ConfirmDialog matches
+          // with strict `options.group === this.group`, and an ungrouped dialog has
+          // `this.group === undefined`. `confirmGroup` defaults to null, and
+          // `null === undefined` is false — passing null would make every ungrouped grid's
+          // confirm silently match no dialog (dead delete button). Do NOT "simplify" to
+          // `group: confirmGroup`. (Note: Toast uses loose `==`, so this trap is confirm-only.)
           group: confirmGroup || undefined,
           message,
           header,

--- a/vueManager/src/composables/useSelection.js
+++ b/vueManager/src/composables/useSelection.js
@@ -110,6 +110,10 @@ export function useSelection(options = {}) {
     const count = selectionCount.value
 
     confirm.require({
+      // `|| undefined` is load-bearing: PrimeVue ConfirmDialog matches with strict
+      // `options.group === this.group` (ungrouped dialog => this.group === undefined).
+      // confirmGroup defaults to null, and `null === undefined` is false, so passing null
+      // would silently break ungrouped grids. Do NOT reduce to `group: confirmGroup`.
       group: confirmGroup || undefined,
       message: _('bulk_delete_confirm_message').replace('{count}', count),
       header: _('bulk_delete_confirm_title'),

--- a/vueManager/src/composables/useSelection.js
+++ b/vueManager/src/composables/useSelection.js
@@ -19,6 +19,8 @@ import { computed, ref } from 'vue'
  * @param {Function} options.onSuccess Callback after successful bulk action
  * @param {Function} options.getItemId Function to get item ID, default: (item) => item.id
  * @param {Function} options.getItemName Function to get item display name for messages
+ * @param {string} options.confirmGroup ConfirmDialog group to target, isolates the bulk
+ *   confirm when several Vue apps share one PrimeVue ConfirmationEventBus (default: ungrouped)
  * @returns {Object} Selection state and methods
  */
 export function useSelection(options = {}) {
@@ -27,6 +29,7 @@ export function useSelection(options = {}) {
     deleteBulk = null,
     onSuccess = null,
     getItemId = item => item.id,
+    confirmGroup = null,
   } = options
 
   const confirm = useConfirm()
@@ -107,6 +110,7 @@ export function useSelection(options = {}) {
     const count = selectionCount.value
 
     confirm.require({
+      group: confirmGroup || undefined,
       message: _('bulk_delete_confirm_message').replace('{count}', count),
       header: _('bulk_delete_confirm_title'),
       icon: 'pi pi-exclamation-triangle',


### PR DESCRIPTION
Fixes #538

## Проблема

Админка → редактирование категории → вкладка «Сетка товаров». Клик по удалению (строка **или** «Удалить выбранные») показывал **два диалога подтверждения сразу**.

## Причина

Страница `category/update` монтирует **два независимых Vue-приложения** (`update.class.php:70-71`): `category-products` (`CategoryProductsGrid`) и `category-options` (`CategoryOptionsTab`). PrimeVue вынесен в общий Import Map (externalized в `vite.config.js`) → один экземпляр модуля на страницу, а `ConfirmationEventBus` внутри PrimeVue — **модульный singleton**. Значит `confirm.require()` без `group` ловится **всеми** смонтированными ungrouped `<ConfirmDialog>` на странице, в каком бы приложении они ни были. На этой странице их было два → два диалога.

## Решение

Namespace обоих приложений через confirm-`group` (паттерн уже используется в `ExtraFieldsManager`, `GridFieldsConfig`, `ModelFieldsGrid`, `ProductDataConfig`):

- `useActions` / `useSelection` — новая **опциональная** опция `confirmGroup`, подставляется в `confirm.require({ group })`. По умолчанию `null` → ungrouped (полная обратная совместимость).
- `ActionsColumn` — новый проп `confirmGroup`, проброс в `useActions`.
- `CategoryProductsGrid` — `group="category-products"` на `<ConfirmDialog>`; группа прокинута в `useSelection` и `ActionsColumn`; убран висячий `useConfirm()` (мусор от рефактора).
- `CategoryOptionsTab` — `group="category-options"` на `<ConfirmDialog>` и в обоих `confirm.require`.

Остальные гриды (Customers/Orders/Deliveries/Payments/…) **не тронуты**: `confirmGroup` opt-in, по умолчанию ungrouped — поведение прежнее.

## Проверка

- ESLint (5 файлов) ✓
- `npm run build` ✓
- Проверено на DEV после hard-reload: в сетке товаров и в опциях категории теперь **один** confirm, удаление (строчное и bulk) работает.

## Связанное

Системный риск той же природы (общая шина PrimeVue на страницах с несколькими Vue-приложениями/табами, потенциально `product-tabs`, а также `ToastEventBus`) вынесен отдельно: #539.
