### PR TITLE
fix(vue): изоляция PrimeVue Confirm/Toast через UI groups (#539)

### DIFF
--- a/vueManager/package.json
+++ b/vueManager/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "lint:ci": "eslint . --max-warnings 0",
-    "test:smoke": "node --test tests/*.test.js",
+    "test:smoke": "node --test tests/*.test.js && node scripts/check-ui-group-smoke.mjs",
     "format": "prettier --write \"src/**/*.{js,vue,scss,css}\"",
     "format:check": "prettier --check \"src/**/*.{js,vue,scss,css}\"",
     "lint:all": "npm run lint && npm run format:check && npm run lint:scss",

--- a/vueManager/scripts/check-ui-group-smoke.mjs
+++ b/vueManager/scripts/check-ui-group-smoke.mjs
@@ -30,24 +30,48 @@ function mustContain(rel, snippets) {
   }
 }
 
+/**
+ * In files with a grouped ConfirmDialog, every local confirm.require must
+ * pass group:. If confirms go through useSelection/useActions, require uiGroup wiring.
+ */
+function assertGroupedConfirmWiring(rel) {
+  const text = read(rel)
+  if (!/<ConfirmDialog[^>]*:group=/.test(text) && !/<ConfirmDialog[^>]*\sgroup=/.test(text)) {
+    return
+  }
+
+  const requireCalls = [...text.matchAll(/confirm\.require\s*\(\s*\{([\s\S]*?)\}\s*\)/g)]
+  if (requireCalls.length === 0) {
+    if (!/\buiGroup\s*:/.test(text) && !/:ui-group=/.test(text) && !/:confirm-group=/.test(text)) {
+      fail(`${rel}: grouped ConfirmDialog without confirm.require group or uiGroup wiring`)
+    }
+    return
+  }
+
+  for (const [, body] of requireCalls) {
+    if (!/\bgroup\s*:/.test(body)) {
+      fail(`${rel}: confirm.require must pass group: when ConfirmDialog is grouped`)
+    }
+  }
+}
+
 mustContain('composables/uiGroup.js', [
   'MS3_UI_GROUP',
   'provideUiGroup',
   'useGroupedToast',
   'toUiGroup',
   'withToastGroup',
+  '...toast',
 ])
 
-mustContain('composables/useActions.js', ['useGroupedToast', 'toUiGroup'])
-mustContain('composables/useSelection.js', ['useGroupedToast', 'toUiGroup'])
+mustContain('composables/useActions.js', ['useGroupedToast', 'toUiGroup', 'uiGroup'])
+mustContain('composables/useSelection.js', ['useGroupedToast', 'toUiGroup', 'uiGroup'])
 
 mustContain('components/gallery/ProductGallery.vue', [
-  "UI_GROUP = 'product-gallery'",
   'group: UI_GROUP',
   ':group="UI_GROUP"',
 ])
 mustContain('components/product/ProductLinksTab.vue', [
-  "UI_GROUP = 'product-links'",
   'group: UI_GROUP',
   ':group="UI_GROUP"',
 ])
@@ -57,6 +81,7 @@ mustContain('components/CategoryProductsGrid.vue', [
   'useGroupedToast',
   '<Toast :group="UI_GROUP"',
   '<ConfirmDialog :group="UI_GROUP"',
+  'uiGroup:',
 ])
 mustContain('components/CategoryOptionsTab.vue', [
   'useUiGroup()',
@@ -67,5 +92,14 @@ mustContain('components/CategoryOptionsTab.vue', [
 
 mustContain('entries/category-products.js', ["provideUiGroup(app, 'category-products')"])
 mustContain('entries/category-options.js', ["provideUiGroup(app, 'category-options')"])
+
+for (const rel of [
+  'components/gallery/ProductGallery.vue',
+  'components/product/ProductLinksTab.vue',
+  'components/CategoryProductsGrid.vue',
+  'components/CategoryOptionsTab.vue',
+]) {
+  assertGroupedConfirmWiring(rel)
+}
 
 console.warn('OK: check-ui-group-smoke')

--- a/vueManager/scripts/check-ui-group-smoke.mjs
+++ b/vueManager/scripts/check-ui-group-smoke.mjs
@@ -6,6 +6,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -67,4 +68,4 @@ mustContain('components/CategoryOptionsTab.vue', [
 mustContain('entries/category-products.js', ["provideUiGroup(app, 'category-products')"])
 mustContain('entries/category-options.js', ["provideUiGroup(app, 'category-options')"])
 
-console.log('OK: check-ui-group-smoke')
+console.warn('OK: check-ui-group-smoke')

--- a/vueManager/scripts/check-ui-group-smoke.mjs
+++ b/vueManager/scripts/check-ui-group-smoke.mjs
@@ -1,0 +1,70 @@
+/**
+ * Smoke: PrimeVue ConfirmDialog/Toast UI groups for shared EventBus (#539).
+ *
+ * Run: node vueManager/scripts/check-ui-group-smoke.mjs
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcRoot = path.join(__dirname, '..', 'src')
+
+function fail(message) {
+  console.error(`FAIL: ${message}`)
+  process.exit(1)
+}
+
+function read(rel) {
+  return fs.readFileSync(path.join(srcRoot, rel), 'utf8')
+}
+
+function mustContain(rel, snippets) {
+  const text = read(rel)
+  for (const snippet of snippets) {
+    if (!text.includes(snippet)) {
+      fail(`${rel} must contain: ${JSON.stringify(snippet)}`)
+    }
+  }
+}
+
+mustContain('composables/uiGroup.js', [
+  'MS3_UI_GROUP',
+  'provideUiGroup',
+  'useGroupedToast',
+  'toUiGroup',
+  'withToastGroup',
+])
+
+mustContain('composables/useActions.js', ['useGroupedToast', 'toUiGroup'])
+mustContain('composables/useSelection.js', ['useGroupedToast', 'toUiGroup'])
+
+mustContain('components/gallery/ProductGallery.vue', [
+  "UI_GROUP = 'product-gallery'",
+  'group: UI_GROUP',
+  ':group="UI_GROUP"',
+])
+mustContain('components/product/ProductLinksTab.vue', [
+  "UI_GROUP = 'product-links'",
+  'group: UI_GROUP',
+  ':group="UI_GROUP"',
+])
+
+mustContain('components/CategoryProductsGrid.vue', [
+  'useUiGroup()',
+  'useGroupedToast',
+  '<Toast :group="UI_GROUP"',
+  '<ConfirmDialog :group="UI_GROUP"',
+])
+mustContain('components/CategoryOptionsTab.vue', [
+  'useUiGroup()',
+  'useGroupedToast',
+  '<Toast :group="UI_GROUP"',
+  '<ConfirmDialog :group="UI_GROUP"',
+])
+
+mustContain('entries/category-products.js', ["provideUiGroup(app, 'category-products')"])
+mustContain('entries/category-options.js', ["provideUiGroup(app, 'category-options')"])
+
+console.log('OK: check-ui-group-smoke')

--- a/vueManager/src/components/ActionsColumn.vue
+++ b/vueManager/src/components/ActionsColumn.vue
@@ -67,9 +67,16 @@ const props = defineProps({
   },
 
   /**
-   * ConfirmDialog group to target. Set it (matching a <ConfirmDialog group="...">)
-   * to isolate the confirm on pages where several Vue apps share one PrimeVue
-   * ConfirmationEventBus. Omit to stay ungrouped (default).
+   * ConfirmDialog/Toast group. Matches `<ConfirmDialog :group>` / `<Toast :group>`.
+   * Prefer this over `confirmGroup`.
+   */
+  uiGroup: {
+    type: String,
+    default: null,
+  },
+
+  /**
+   * @deprecated Use `uiGroup`. Kept as alias for existing call sites.
    */
   confirmGroup: {
     type: String,
@@ -108,7 +115,7 @@ const { _ } = useLexicon()
 
 const { executeAction } = useActions({
   gridId: props.gridId,
-  confirmGroup: props.confirmGroup,
+  uiGroup: props.uiGroup || props.confirmGroup,
   onRefresh: () => emit('refresh'),
   onEdit: data => emit('edit', data),
   onDelete: data => emit('delete', data),

--- a/vueManager/src/components/CategoryOptionsTab.vue
+++ b/vueManager/src/components/CategoryOptionsTab.vue
@@ -12,23 +12,21 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Toast from 'primevue/toast'
 import { useConfirm } from 'primevue/useconfirm'
-import { useToast } from 'primevue/usetoast'
 import { onMounted, ref, watch } from 'vue'
 
+import { useGroupedToast, useUiGroup } from '../composables/uiGroup.js'
 import request from '../request.js'
 
 const props = defineProps({
   categoryId: { type: Number, required: true },
 })
 
-const toast = useToast()
 const confirm = useConfirm()
 const { _ } = useLexicon()
 
-// Confirm group for this tab's PrimeVue ConfirmDialog. Shared by <ConfirmDialog> and
-// both confirm.require() calls — a typo silently kills the confirm (matches no dialog),
-// so keep it a single source of truth.
-const CONFIRM_GROUP = 'category-options'
+// From entry provideUiGroup('category-options'); fallback for non-entry mounts (#538/#539).
+const UI_GROUP = useUiGroup() || 'category-options'
+const toast = useGroupedToast(UI_GROUP)
 
 const links = ref([])
 const loading = ref(false)
@@ -187,7 +185,7 @@ async function performBulkAction(action) {
 function confirmBulkRemove() {
   if (selectedRows.value.length === 0) return
   confirm.require({
-    group: CONFIRM_GROUP,
+    group: UI_GROUP,
     message:
       _('ms3_options_remove_confirm') ||
       'Удалить выбранные опции из категории? Значения опций у товаров будут удалены.',
@@ -261,7 +259,7 @@ async function performCopy() {
 
 function confirmSingleRemove(row) {
   confirm.require({
-    group: CONFIRM_GROUP,
+    group: UI_GROUP,
     message:
       _('ms3_option_remove_confirm') || `Удалить опцию «${row.caption || row.key}» из категории?`,
     header: _('confirm') || 'Подтверждение',
@@ -302,8 +300,8 @@ onMounted(() => {
 
 <template>
   <div class="category-options-tab">
-    <Toast />
-    <ConfirmDialog :group="CONFIRM_GROUP" />
+    <Toast :group="UI_GROUP" />
+    <ConfirmDialog :group="UI_GROUP" />
 
     <div class="toolbar">
       <Button

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -48,7 +48,7 @@ const {
   confirmBulkDelete,
 } = useSelection({
   entityName: 'product',
-  confirmGroup: UI_GROUP,
+  uiGroup: UI_GROUP,
   deleteBulk: async ids => {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
@@ -977,7 +977,7 @@ onMounted(async () => {
                           :data="product"
                           :actions="getActionsConfig(column)"
                           grid-id="category-products"
-                          :confirm-group="UI_GROUP"
+                          :ui-group="UI_GROUP"
                           @view="viewProduct"
                           @edit="editProduct"
                           @delete="deleteProduct"

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -9,10 +9,10 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Tag from 'primevue/tag'
 import Toast from 'primevue/toast'
-import { useToast } from 'primevue/usetoast'
 import { computed, defineProps, onMounted, ref, watch } from 'vue'
 import draggable from 'vuedraggable'
 
+import { useGroupedToast, useUiGroup } from '../composables/uiGroup.js'
 import { useCategoryProductsInlineEdit } from '../composables/useCategoryProductsInlineEdit.js'
 import { useSelection } from '../composables/useSelection.js'
 import { useStaleRequestGuard } from '../composables/useStaleRequestGuard.js'
@@ -31,13 +31,12 @@ const props = defineProps({
   },
 })
 
-const toast = useToast()
 const { _ } = useLexicon()
 
-// Confirm group for this grid's PrimeVue ConfirmDialog. Shared by <ConfirmDialog>,
-// useSelection and <ActionsColumn> — a typo in any one silently kills the confirm
-// (the require() then matches no dialog), so keep it a single source of truth.
-const CONFIRM_GROUP = 'category-products'
+// From entry provideUiGroup('category-products'); fallback keeps confirm/toast alive
+// if the grid is mounted outside that entry (#538/#539).
+const UI_GROUP = useUiGroup() || 'category-products'
+const toast = useGroupedToast(UI_GROUP)
 
 // Bulk selection
 const {
@@ -49,7 +48,7 @@ const {
   confirmBulkDelete,
 } = useSelection({
   entityName: 'product',
-  confirmGroup: CONFIRM_GROUP,
+  confirmGroup: UI_GROUP,
   deleteBulk: async ids => {
     await request.post(`/api/mgr/categories/${props.categoryId}/products/multiple`, {
       method: 'delete',
@@ -775,8 +774,8 @@ onMounted(async () => {
 
 <template>
   <div class="category-products-grid">
-    <Toast />
-    <ConfirmDialog :group="CONFIRM_GROUP" append-to="self" />
+    <Toast :group="UI_GROUP" />
+    <ConfirmDialog :group="UI_GROUP" append-to="self" />
 
     <Card>
       <template #title>
@@ -978,7 +977,7 @@ onMounted(async () => {
                           :data="product"
                           :actions="getActionsConfig(column)"
                           grid-id="category-products"
-                          :confirm-group="CONFIRM_GROUP"
+                          :confirm-group="UI_GROUP"
                           @view="viewProduct"
                           @edit="editProduct"
                           @delete="deleteProduct"

--- a/vueManager/src/components/gallery/ProductGallery.vue
+++ b/vueManager/src/components/gallery/ProductGallery.vue
@@ -15,6 +15,9 @@ const { _ } = useLexicon()
 const confirm = useConfirm()
 const toast = useToast()
 
+// Isolate from ProductLinksTab ConfirmDialog on product/update (#539)
+const UI_GROUP = 'product-gallery'
+
 const props = defineProps({
   productId: {
     type: Number,
@@ -220,6 +223,7 @@ function onDeleteFiles(ids) {
       : _('ms3_gallery_file_delete_multiple_confirm')
 
   confirm.require({
+    group: UI_GROUP,
     message,
     header: ids.length === 1 ? _('ms3_gallery_file_delete') : _('ms3_gallery_file_delete_multiple'),
     icon: 'pi pi-exclamation-triangle',
@@ -265,6 +269,7 @@ async function onGenerateThumbs(ids) {
  */
 function onRegenerateAll() {
   confirm.require({
+    group: UI_GROUP,
     message: _('ms3_gallery_file_generate_thumbs_confirm'),
     header: _('ms3_gallery_file_generate_all'),
     icon: 'pi pi-refresh',
@@ -292,6 +297,7 @@ function onRegenerateAll() {
  */
 function onDeleteAll() {
   confirm.require({
+    group: UI_GROUP,
     message: _('ms3_gallery_file_delete_multiple_confirm'),
     header: _('ms3_gallery_file_delete_all'),
     icon: 'pi pi-exclamation-triangle',
@@ -320,6 +326,7 @@ function onDeleteAll() {
  */
 function onChangeSource(sourceId) {
   confirm.require({
+    group: UI_GROUP,
     message: _('ms3_product_change_source_confirm'),
     header: _('ms3_product_source'),
     icon: 'pi pi-exclamation-triangle',
@@ -352,7 +359,7 @@ onMounted(() => {
 
 <template>
   <div class="product-gallery">
-    <ConfirmDialog append-to="self" />
+    <ConfirmDialog :group="UI_GROUP" append-to="self" />
 
     <ProductGalleryToolbar
       :sources="sources"

--- a/vueManager/src/components/product/ProductLinksTab.vue
+++ b/vueManager/src/components/product/ProductLinksTab.vue
@@ -24,6 +24,9 @@ const { _ } = useLexicon()
 const toast = useToast()
 const confirm = useConfirm()
 
+// Isolate from ProductGallery ConfirmDialog on product/update (#539)
+const UI_GROUP = 'product-links'
+
 const loading = ref(false)
 const saving = ref(false)
 const rows = ref([])
@@ -184,6 +187,7 @@ async function saveLink(close = true) {
 
 function removeLink(row) {
   confirm.require({
+    group: UI_GROUP,
     message: _('ms3_menu_remove_confirm'),
     header: _('ms3_menu_remove_title'),
     icon: 'pi pi-exclamation-triangle',
@@ -214,7 +218,7 @@ onMounted(async () => {
 
 <template>
   <div class="product-links-tab">
-    <ConfirmDialog append-to="self" />
+    <ConfirmDialog :group="UI_GROUP" append-to="self" />
 
     <div class="product-links-tab__toolbar">
       <Button

--- a/vueManager/src/composables/uiGroup.js
+++ b/vueManager/src/composables/uiGroup.js
@@ -1,0 +1,91 @@
+/**
+ * App-level UI group for PrimeVue ConfirmDialog / Toast isolation.
+ *
+ * PrimeVue ConfirmationEventBus and ToastEventBus are module singletons when
+ * PrimeVue is shared via Import Map. Ungrouped dialogs/toasts on the same page
+ * (multi-app mounts or sibling tabs kept alive without lazy) all receive every
+ * ungrouped confirm.require / toast.add.
+ *
+ * Confirm matches with strict === (ungrouped dialog → group === undefined).
+ * Toast matches with loose == (ungrouped Toast → group default null; null == undefined).
+ * Always pass `toUiGroup(group)` into confirm.require / omit group on toast when ungrouped
+ * via withToastGroup — never pass null into confirm.require.
+ *
+ * @see https://github.com/modx-pro/MiniShop3/issues/539
+ */
+import { useToast } from 'primevue/usetoast'
+import { inject } from 'vue'
+
+export const MS3_UI_GROUP = Symbol('ms3UiGroup')
+
+/**
+ * @param {import('vue').App} app
+ * @param {string} group
+ */
+export function provideUiGroup(app, group) {
+  if (!group) {
+    return
+  }
+  app.provide(MS3_UI_GROUP, group)
+}
+
+/**
+ * @returns {string|null}
+ */
+export function useUiGroup() {
+  return inject(MS3_UI_GROUP, null)
+}
+
+/**
+ * Resolve explicit option or injected app group.
+ * Always calls inject (Vue composition rule).
+ *
+ * @param {string|null|undefined} explicit
+ * @returns {string|null}
+ */
+export function resolveUiGroup(explicit) {
+  const injected = useUiGroup()
+  if (explicit) {
+    return explicit
+  }
+  return injected
+}
+
+/**
+ * Normalize group for confirm.require / optional bindings.
+ * Ungrouped → undefined (ConfirmDialog strict ===; never pass null).
+ *
+ * @param {string|null|undefined} group
+ * @returns {string|undefined}
+ */
+export function toUiGroup(group) {
+  return group || undefined
+}
+
+/**
+ * @param {Object} payload
+ * @param {string|null|undefined} group
+ * @returns {Object}
+ */
+export function withToastGroup(payload, group) {
+  const g = toUiGroup(group)
+  if (!g) {
+    return payload
+  }
+  return { ...payload, group: g }
+}
+
+/**
+ * Toast facade that stamps the resolved UI group on every add().
+ *
+ * @param {string|null|undefined} explicit
+ */
+export function useGroupedToast(explicit = null) {
+  const toast = useToast()
+  const group = resolveUiGroup(explicit)
+  return {
+    add(payload) {
+      return toast.add(withToastGroup(payload, group))
+    },
+  }
+}

--- a/vueManager/src/composables/uiGroup.js
+++ b/vueManager/src/composables/uiGroup.js
@@ -4,12 +4,22 @@
  * PrimeVue ConfirmationEventBus and ToastEventBus are module singletons when
  * PrimeVue is shared via Import Map. Ungrouped dialogs/toasts on the same page
  * (multi-app mounts or sibling tabs kept alive without lazy) all receive every
- * ungrouped confirm.require / toast.add.
+ * ungrouped confirm.require / toast.add (#539).
  *
  * Confirm matches with strict === (ungrouped dialog → group === undefined).
  * Toast matches with loose == (ungrouped Toast → group default null; null == undefined).
- * Always pass `toUiGroup(group)` into confirm.require / omit group on toast when ungrouped
- * via withToastGroup — never pass null into confirm.require.
+ * Always pass `toUiGroup(group)` into confirm.require; never pass null.
+ *
+ * When to use which pattern:
+ * - One group per Vue app → `provideUiGroup(app, id)` in the entry, then
+ *   `useUiGroup()` (optional literal fallback) in the root component.
+ * - Several groups inside one app (e.g. gallery vs links) → local `UI_GROUP`
+ *   constants; provide cannot split them.
+ *
+ * `provideUiGroup` applies to the whole app subtree. A nested ungrouped
+ * `<Toast />` / `<ConfirmDialog />` that still uses `useGroupedToast` /
+ * `useActions` / `useSelection` will stamp the app group and stay silent
+ * unless its host widgets use the same `:group`.
  *
  * @see https://github.com/modx-pro/MiniShop3/issues/539
  */
@@ -76,7 +86,11 @@ export function withToastGroup(payload, group) {
 }
 
 /**
- * Toast facade that stamps the resolved UI group on every add().
+ * Toast facade: stamps the resolved UI group on every `add()`.
+ * Other ToastService methods (`remove`, `removeGroup`, …) stay available.
+ *
+ * Pass an already-resolved group string when the caller resolved once
+ * (avoids a second inject when composing with useActions / useSelection).
  *
  * @param {string|null|undefined} explicit
  */
@@ -84,6 +98,7 @@ export function useGroupedToast(explicit = null) {
   const toast = useToast()
   const group = resolveUiGroup(explicit)
   return {
+    ...toast,
     add(payload) {
       return toast.add(withToastGroup(payload, group))
     },

--- a/vueManager/src/composables/uiGroup.test.js
+++ b/vueManager/src/composables/uiGroup.test.js
@@ -1,8 +1,38 @@
-import { describe, expect, it } from 'vitest'
+/* eslint-disable vue/one-component-per-file -- inline harnesses for provide/inject */
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h } from 'vue'
 
-import { toUiGroup, withToastGroup } from './uiGroup.js'
+const add = vi.fn()
+const remove = vi.fn()
+const removeGroup = vi.fn()
+const removeAllGroups = vi.fn()
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add,
+    remove,
+    removeGroup,
+    removeAllGroups,
+  }),
+}))
+
+const {
+  provideUiGroup,
+  toUiGroup,
+  useGroupedToast,
+  useUiGroup,
+  withToastGroup,
+} = await import('./uiGroup.js')
 
 describe('uiGroup helpers (#539)', () => {
+  beforeEach(() => {
+    add.mockClear()
+    remove.mockClear()
+    removeGroup.mockClear()
+    removeAllGroups.mockClear()
+  })
+
   it('toUiGroup maps null/empty to undefined for ConfirmDialog strict ===', () => {
     expect(toUiGroup(null)).toBeUndefined()
     expect(toUiGroup('')).toBeUndefined()
@@ -15,5 +45,43 @@ describe('uiGroup helpers (#539)', () => {
       severity: 'success',
       group: 'category-options',
     })
+  })
+
+  it('provideUiGroup reaches useUiGroup in the app tree', () => {
+    let seen = null
+    const Child = defineComponent({
+      setup() {
+        seen = useUiGroup()
+        return () => null
+      },
+    })
+    const app = createApp({
+      setup() {
+        return () => h(Child)
+      },
+    })
+    provideUiGroup(app, 'category-products')
+    const el = document.createElement('div')
+    app.mount(el)
+    expect(seen).toBe('category-products')
+    app.unmount()
+  })
+
+  it('useGroupedToast stamps group on add and keeps removeGroup', () => {
+    const Comp = defineComponent({
+      setup() {
+        const toast = useGroupedToast('product-gallery')
+        toast.add({ severity: 'info', summary: 'hi' })
+        toast.removeGroup('product-gallery')
+        return () => null
+      },
+    })
+    mount(Comp)
+    expect(add).toHaveBeenCalledWith({
+      severity: 'info',
+      summary: 'hi',
+      group: 'product-gallery',
+    })
+    expect(removeGroup).toHaveBeenCalledWith('product-gallery')
   })
 })

--- a/vueManager/src/composables/uiGroup.test.js
+++ b/vueManager/src/composables/uiGroup.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { toUiGroup, withToastGroup } from './uiGroup.js'
+
+describe('uiGroup helpers (#539)', () => {
+  it('toUiGroup maps null/empty to undefined for ConfirmDialog strict ===', () => {
+    expect(toUiGroup(null)).toBeUndefined()
+    expect(toUiGroup('')).toBeUndefined()
+    expect(toUiGroup('gallery')).toBe('gallery')
+  })
+
+  it('withToastGroup only adds group when set (Toast default null uses ==)', () => {
+    expect(withToastGroup({ severity: 'success' }, null)).toEqual({ severity: 'success' })
+    expect(withToastGroup({ severity: 'success' }, 'category-options')).toEqual({
+      severity: 'success',
+      group: 'category-options',
+    })
+  })
+})

--- a/vueManager/src/composables/useActions.js
+++ b/vueManager/src/composables/useActions.js
@@ -5,9 +5,9 @@
  */
 import { useLexicon } from '@vuetools/useLexicon'
 import { useConfirm } from 'primevue/useconfirm'
-import { useToast } from 'primevue/usetoast'
 
 import actionRegistry from '../actionRegistry.js'
+import { resolveUiGroup, toUiGroup, useGroupedToast } from './uiGroup.js'
 
 /**
  * Composable for working with grid actions
@@ -22,12 +22,10 @@ import actionRegistry from '../actionRegistry.js'
  * @param {Function} options.onPublish - Callback for publishing/unpublishing
  * @param {Function} options.onDuplicate - Callback for duplicating
  * @param {Function} options.onCustomAction - Callback for custom actions (event, data)
- * @param {string} options.confirmGroup - ConfirmDialog group to target (isolates the
- *   confirm on pages where several Vue apps share one PrimeVue ConfirmationEventBus).
- *   Omit to stay ungrouped (default, backward compatible).
+ * @param {string} options.confirmGroup - ConfirmDialog/Toast group (or app provide MS3_UI_GROUP).
+ *   Omit to stay ungrouped (backward compatible).
  */
 export function useActions(options = {}) {
-  const toast = useToast()
   const confirm = useConfirm()
   const { _ } = useLexicon()
 
@@ -43,6 +41,9 @@ export function useActions(options = {}) {
     onDuplicate = () => {},
     onCustomAction = () => {},
   } = options
+
+  const uiGroup = resolveUiGroup(confirmGroup)
+  const toast = useGroupedToast(confirmGroup)
 
   /**
    * Create context for action execution
@@ -109,13 +110,7 @@ export function useActions(options = {}) {
           : _('action_confirm_title')
 
         confirm.require({
-          // `|| undefined` is load-bearing, NOT cosmetic. PrimeVue ConfirmDialog matches
-          // with strict `options.group === this.group`, and an ungrouped dialog has
-          // `this.group === undefined`. `confirmGroup` defaults to null, and
-          // `null === undefined` is false — passing null would make every ungrouped grid's
-          // confirm silently match no dialog (dead delete button). Do NOT "simplify" to
-          // `group: confirmGroup`. (Note: Toast uses loose `==`, so this trap is confirm-only.)
-          group: confirmGroup || undefined,
+          group: toUiGroup(uiGroup),
           message,
           header,
           icon: 'pi pi-exclamation-triangle',

--- a/vueManager/src/composables/useActions.js
+++ b/vueManager/src/composables/useActions.js
@@ -22,8 +22,9 @@ import { resolveUiGroup, toUiGroup, useGroupedToast } from './uiGroup.js'
  * @param {Function} options.onPublish - Callback for publishing/unpublishing
  * @param {Function} options.onDuplicate - Callback for duplicating
  * @param {Function} options.onCustomAction - Callback for custom actions (event, data)
- * @param {string} options.confirmGroup - ConfirmDialog/Toast group (or app provide MS3_UI_GROUP).
+ * @param {string} [options.uiGroup] ConfirmDialog/Toast group (or app provide MS3_UI_GROUP).
  *   Omit to stay ungrouped (backward compatible).
+ * @param {string} [options.confirmGroup] Deprecated alias of `uiGroup`.
  */
 export function useActions(options = {}) {
   const confirm = useConfirm()
@@ -31,6 +32,7 @@ export function useActions(options = {}) {
 
   const {
     gridId = 'unknown',
+    uiGroup: uiGroupOption = null,
     confirmGroup = null,
     onRefresh = () => {},
     onEdit = () => {},
@@ -42,8 +44,8 @@ export function useActions(options = {}) {
     onCustomAction = () => {},
   } = options
 
-  const uiGroup = resolveUiGroup(confirmGroup)
-  const toast = useGroupedToast(confirmGroup)
+  const uiGroup = resolveUiGroup(uiGroupOption || confirmGroup)
+  const toast = useGroupedToast(uiGroup)
 
   /**
    * Create context for action execution

--- a/vueManager/src/composables/useSelection.js
+++ b/vueManager/src/composables/useSelection.js
@@ -1,7 +1,8 @@
 import { useLexicon } from '@vuetools/useLexicon'
 import { useConfirm } from 'primevue/useconfirm'
-import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
+
+import { resolveUiGroup, toUiGroup, useGroupedToast } from './uiGroup.js'
 
 /**
  * Universal composable for managing row selection in DataTables
@@ -19,8 +20,7 @@ import { computed, ref } from 'vue'
  * @param {Function} options.onSuccess Callback after successful bulk action
  * @param {Function} options.getItemId Function to get item ID, default: (item) => item.id
  * @param {Function} options.getItemName Function to get item display name for messages
- * @param {string} options.confirmGroup ConfirmDialog group to target, isolates the bulk
- *   confirm when several Vue apps share one PrimeVue ConfirmationEventBus (default: ungrouped)
+ * @param {string} options.confirmGroup ConfirmDialog/Toast group (or app provide MS3_UI_GROUP)
  * @returns {Object} Selection state and methods
  */
 export function useSelection(options = {}) {
@@ -33,8 +33,9 @@ export function useSelection(options = {}) {
   } = options
 
   const confirm = useConfirm()
-  const toast = useToast()
+  const toast = useGroupedToast(confirmGroup)
   const { _ } = useLexicon()
+  const uiGroup = resolveUiGroup(confirmGroup)
 
   // Selected items (array of full objects for PrimeVue DataTable)
   const selectedItems = ref([])
@@ -110,11 +111,7 @@ export function useSelection(options = {}) {
     const count = selectionCount.value
 
     confirm.require({
-      // `|| undefined` is load-bearing: PrimeVue ConfirmDialog matches with strict
-      // `options.group === this.group` (ungrouped dialog => this.group === undefined).
-      // confirmGroup defaults to null, and `null === undefined` is false, so passing null
-      // would silently break ungrouped grids. Do NOT reduce to `group: confirmGroup`.
-      group: confirmGroup || undefined,
+      group: toUiGroup(uiGroup),
       message: _('bulk_delete_confirm_message').replace('{count}', count),
       header: _('bulk_delete_confirm_title'),
       icon: 'pi pi-exclamation-triangle',

--- a/vueManager/src/composables/useSelection.js
+++ b/vueManager/src/composables/useSelection.js
@@ -20,7 +20,8 @@ import { resolveUiGroup, toUiGroup, useGroupedToast } from './uiGroup.js'
  * @param {Function} options.onSuccess Callback after successful bulk action
  * @param {Function} options.getItemId Function to get item ID, default: (item) => item.id
  * @param {Function} options.getItemName Function to get item display name for messages
- * @param {string} options.confirmGroup ConfirmDialog/Toast group (or app provide MS3_UI_GROUP)
+ * @param {string} [options.uiGroup] ConfirmDialog/Toast group (or app provide MS3_UI_GROUP)
+ * @param {string} [options.confirmGroup] Deprecated alias of `uiGroup`
  * @returns {Object} Selection state and methods
  */
 export function useSelection(options = {}) {
@@ -29,13 +30,14 @@ export function useSelection(options = {}) {
     deleteBulk = null,
     onSuccess = null,
     getItemId = item => item.id,
+    uiGroup: uiGroupOption = null,
     confirmGroup = null,
   } = options
 
   const confirm = useConfirm()
-  const toast = useGroupedToast(confirmGroup)
+  const uiGroup = resolveUiGroup(uiGroupOption || confirmGroup)
+  const toast = useGroupedToast(uiGroup)
   const { _ } = useLexicon()
-  const uiGroup = resolveUiGroup(confirmGroup)
 
   // Selected items (array of full objects for PrimeVue DataTable)
   const selectedItems = ref([])

--- a/vueManager/src/entries/category-options.js
+++ b/vueManager/src/entries/category-options.js
@@ -13,6 +13,7 @@ import ToastService from 'primevue/toastservice'
 import { createApp } from 'vue'
 
 import CategoryOptionsTab from '../components/CategoryOptionsTab.vue'
+import { provideUiGroup } from '../composables/uiGroup.js'
 import { injectFormStylesOverride } from '../utils/formStyles.js'
 
 const MOUNT_ID = 'ms3-vue-category-options'
@@ -44,6 +45,7 @@ function mountApp() {
   })
   app.use(ToastService)
   app.use(ConfirmationService)
+  provideUiGroup(app, 'category-options')
 
   app.mount(container)
   injectFormStylesOverride()

--- a/vueManager/src/entries/category-products.js
+++ b/vueManager/src/entries/category-products.js
@@ -17,6 +17,7 @@ import ToastService from 'primevue/toastservice'
 import { createApp } from 'vue'
 
 import CategoryProductsGrid from '../components/CategoryProductsGrid.vue'
+import { provideUiGroup } from '../composables/uiGroup.js'
 import { injectFormStylesOverride } from '../utils/formStyles.js'
 
 let appInstance = null
@@ -45,6 +46,7 @@ function createVueApp(categoryId) {
 
   app.use(ConfirmationService)
   app.use(ToastService)
+  provideUiGroup(app, 'category-products')
 
   return app
 }


### PR DESCRIPTION
## Описание

PrimeVue в общем Import Map → один `ConfirmationEventBus` / `ToastEventBus` на страницу. Ungrouped `<ConfirmDialog>` / `<Toast>` ловят каждый `confirm.require` / `toast.add`.

Живые репро:
- `product/update`: галерея + ссылки без lazy tabs → **два** confirm при удалении файла
- `category/update`: два Vue-app → **два** toast «Удалено» (confirm уже закрыт в #540)

Фикс: `provideUiGroup` / `useGroupedToast` / `toUiGroup`, группы на product gallery vs links, namespace toast+confirm на category.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #539

## Как это было протестировано?

```bash
cd vueManager
npx eslint <touched files> --max-warnings 0   # exit 0
npm run test -- src/composables/uiGroup.test.js   # 2 tests, exit 0
npm run test:smoke   # includes check-ui-group-smoke, exit 0
npm run build   # exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (vitest + smoke)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `fix/539-primevue-ui-group`
- MODX: n/a
- PHP: n/a (Vue-only)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| два confirm / два toast | один |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы — n/a
- [ ] PHPStan — n/a
- [x] ESLint по затронутым путям
- [x] CHANGELOG — нет (политика репо)

## Дополнительные заметки

**Что сделано**
- `composables/uiGroup.js`: `MS3_UI_GROUP`, `provideUiGroup`, `useUiGroup`, `useGroupedToast`, `toUiGroup` / `withToastGroup` (Confirm `===` vs Toast `==`)
- `useActions` / `useSelection`: confirm + toast через resolved group
- ProductGallery `product-gallery`, ProductLinksTab `product-links`
- Category entries `provideUiGroup`; grids берут `useUiGroup()` (+ fallback) и группируют Toast/Confirm

**Не в этом PR (follow-up)**
- Остальные single-app гриды (`OrdersGrid`, `ProductData`, …) — баг проявляется при multi-mount / нескольких ungrouped dialogs. Паттерн готов: `provideUiGroup` + `useGroupedToast` / group на ConfirmDialog.
- Lint-rule «запрет ungrouped ConfirmDialog» — опционально позже.

**Ручная проверка**
1. product/update → удаление в галерее → один confirm
2. category/update → удаление товара → один toast