### PR TITLE
fix(mgr): токен в ms3.config — гонка HTTP_MODAUTH на Ext-less Vue-страницах (#544)

### DIFF
--- a/core/components/minishop3/controllers/manager.class.php
+++ b/core/components/minishop3/controllers/manager.class.php
@@ -51,6 +51,31 @@ class msManagerController extends \MODX\Revolution\modExtraManagerController
     }
 
     /**
+     * Emit the inline `var ms3 = { config }` block for a Vue page and inject the manager
+     * auth token synchronously.
+     *
+     * Ext-less Vue pages fire their first API requests on DOMContentLoaded, before the
+     * manager JS has populated the `MODx.siteId` global that request.js uses as
+     * HTTP_MODAUTH. Without the token the connector rejects those early requests with
+     * "Access denied" (code 401), even though the session is valid (#544). Shipping the
+     * token inside ms3.config — available before the Vue module runs — removes that race.
+     *
+     * @param array $config
+     * @return void
+     */
+    public function addVueConfig(array $config)
+    {
+        $contextKey = $this->modx->context ? (string) $this->modx->context->get('key') : 'mgr';
+        $config['token'] = $this->modx->user
+            ? (string) $this->modx->user->getUserToken($contextKey)
+            : '';
+
+        $this->addHtml(
+            '<script>var ms3 = { config: ' . json_encode($config) . ' };</script>'
+        );
+    }
+
+    /**
      * Register Vue ES module with VueTools dependency check
      *
      * @param string $src Module script URL

--- a/core/components/minishop3/controllers/mgr/customers.class.php
+++ b/core/components/minishop3/controllers/mgr/customers.class.php
@@ -28,9 +28,7 @@ class MiniShop3MgrCustomersManagerController extends msManagerController
     public function loadCustomCssJs()
     {
         // Config before Vue modules so mount sees ms3.config (#525).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($this->ms3->config) . ' };</script>'
-        );
+        $this->addVueConfig($this->ms3->config);
 
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/customers.min.css');

--- a/core/components/minishop3/controllers/mgr/notifications.class.php
+++ b/core/components/minishop3/controllers/mgr/notifications.class.php
@@ -28,9 +28,7 @@ class MiniShop3MgrNotificationsManagerController extends msManagerController
     public function loadCustomCssJs()
     {
         // Config before Vue modules so mount sees ms3.config (#525).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($this->ms3->config) . ' };</script>'
-        );
+        $this->addVueConfig($this->ms3->config);
 
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/notifications.min.css');

--- a/core/components/minishop3/controllers/mgr/order.class.php
+++ b/core/components/minishop3/controllers/mgr/order.class.php
@@ -33,9 +33,7 @@ class MiniShop3MgrOrderManagerController extends msManagerController
         $config['order_id'] = (int) ($_GET['id'] ?? 0);
 
         // Config before Vue modules so mount sees ms3.config (#526).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($config) . ' };</script>'
-        );
+        $this->addVueConfig($config);
 
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/order.min.css');

--- a/core/components/minishop3/controllers/mgr/orders.class.php
+++ b/core/components/minishop3/controllers/mgr/orders.class.php
@@ -31,9 +31,7 @@ class MiniShop3MgrOrdersManagerController extends msManagerController
         $config['order_show_drafts'] = (bool) $this->modx->getOption('ms3_order_show_drafts', null, false);
 
         // Config before Vue modules so mount sees ms3.config (#526).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($config) . ' };</script>'
-        );
+        $this->addVueConfig($config);
 
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/orders.min.css');

--- a/core/components/minishop3/controllers/mgr/settings.class.php
+++ b/core/components/minishop3/controllers/mgr/settings.class.php
@@ -29,9 +29,7 @@ class MiniShop3MgrSettingsManagerController extends msManagerController
         $config['msorder_list'] = $this->modx->hasPermission('msorder_list');
 
         // Config must precede Vue modules (#523).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($config) . ' };</script>'
-        );
+        $this->addVueConfig($config);
 
         $assetsUrl = $this->ms3->config['assetsUrl'];
         $cssBase = $assetsUrl . 'css/mgr/vue-dist/';

--- a/core/components/minishop3/controllers/mgr/utilities.class.php
+++ b/core/components/minishop3/controllers/mgr/utilities.class.php
@@ -62,9 +62,7 @@ class MiniShop3MgrUtilitiesManagerController extends msManagerController
         );
 
         // Config must precede Vue modules (#524).
-        $this->addHtml(
-            '<script>var ms3 = { config: ' . json_encode($config) . ' };</script>'
-        );
+        $this->addVueConfig($config);
 
         $cssBase = $this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/';
         foreach (['primeicons', 'utilities'] as $asset) {

--- a/core/components/minishop3/tests/CustomersNotificationsVueEntryTest.php
+++ b/core/components/minishop3/tests/CustomersNotificationsVueEntryTest.php
@@ -57,7 +57,7 @@ foreach ($pages as $name => $mountId) {
         }
     }
 
-    foreach (["{$name}\\.min\\.js", "{$name}\\.tpl", 'var ms3'] as $pattern) {
+    foreach (["{$name}\\.min\\.js", "{$name}\\.tpl", 'addVueConfig'] as $pattern) {
         if (preg_match('#' . $pattern . '#', $contents) !== 1) {
             $fail("{$name} controller must contain /{$pattern}/");
         }
@@ -75,6 +75,19 @@ foreach ($pages as $name => $mountId) {
     }
     if (str_contains($entryContents, 'waitForElement')) {
         $fail("{$entryRelative} must not use waitForElement after tpl mount (#525)");
+    }
+}
+
+// Base controller must ship ms3.config via addVueConfig() and inject the manager auth
+// token synchronously — guards the HTTP_MODAUTH cold-start race fix (#544).
+$base = "{$componentRoot}/controllers/manager.class.php";
+$baseContents = file_get_contents($base);
+if ($baseContents === false) {
+    $fail('cannot read base controllers/manager.class.php');
+}
+foreach (['function addVueConfig', 'var ms3', 'getUserToken'] as $pattern) {
+    if (!str_contains($baseContents, $pattern)) {
+        $fail("base manager controller must contain {$pattern} (#544 token injection)");
     }
 }
 

--- a/core/components/minishop3/tests/OrdersVueEntryTest.php
+++ b/core/components/minishop3/tests/OrdersVueEntryTest.php
@@ -54,7 +54,7 @@ $controllers = [
             'orders\.min\.js',
             'orders\.tpl',
             'order_show_drafts',
-            'var ms3',
+            'addVueConfig',
         ],
     ],
     'order' => [
@@ -70,7 +70,7 @@ $controllers = [
             'order\.min\.js',
             'order\.tpl',
             'order_id',
-            'var ms3',
+            'addVueConfig',
         ],
     ],
 ];

--- a/core/components/minishop3/tests/SettingsVueEntryTest.php
+++ b/core/components/minishop3/tests/SettingsVueEntryTest.php
@@ -69,7 +69,7 @@ foreach ([
 foreach ([
     'settings\.min\.js',
     'settings\.tpl',
-    'var ms3',
+    'addVueConfig',
     'getTemplateFile',
     'msorder_list',
     '\.min\.css',

--- a/core/components/minishop3/tests/UtilitiesVueEntryTest.php
+++ b/core/components/minishop3/tests/UtilitiesVueEntryTest.php
@@ -69,7 +69,7 @@ foreach ([
 foreach ([
     'utilities\.min\.js',
     'utilities\.tpl',
-    'var ms3',
+    'addVueConfig',
     'getTemplateFile',
     'mssetting_list',
     'utility_gallery_source_id',

--- a/vueManager/src/request.js
+++ b/vueManager/src/request.js
@@ -61,6 +61,13 @@ class Request {
    * Get MODAUTH token (dynamically)
    */
   getModAuthToken() {
+    // Prefer the token injected server-side into ms3.config: it is present in the initial
+    // inline <script>, before the Vue module runs, so early requests never race an unready
+    // MODx.siteId global on Ext-less pages (#544). Fall back to MODx.siteId for any page
+    // that does not ship ms3.config.token.
+    if (typeof ms3 !== 'undefined' && ms3?.config?.token) {
+      return ms3.config.token
+    }
     if (typeof MODx !== 'undefined' && MODx?.siteId) {
       return MODx.siteId
     }


### PR DESCRIPTION
Fixes #544

## Проблема

На Ext-less Vue-страницах админки (после #533/#534/#536/#537) периодически падали config-запросы с «Доступ запрещён» — заметнее всего на **Заказах**: `orders/filters` и `grid-config/orders` в консоли, при этом сессия жива и список заказов грузится.

## Причина

`getModAuthToken()` брал токен только из браузерного глобала `MODx.siteId`. Стартовый `Promise.all([loadFilters, loadGridConfig])` уходит на `DOMContentLoaded` **раньше**, чем менеджерский JS выставит `MODx.siteId` → запросы уходят **без** `HTTP_MODAUTH` → MODX-коннектор отклоняет их (HTTP 200, тело `{success:false, message:"Доступ запрещён.", object:{code:401}}`). Список уходит чуть позже, токен уже есть → 200. Отсюда интермиттентность. #533 обнажил гонку, убрав `waitForElement`.

Диагностика по Network подтвердила: у упавшего `orders/filters` в Payload только `action`+`route` (нет `HTTP_MODAUTH`), а тело — `code:401`.

## Решение

Отдать токен **синхронно** в inline-`ms3.config`, до старта Vue-модуля:

- `manager.class.php` — новый хелпер `addVueConfig()`: кладёт `token = $modx->user->getUserToken($contextKey)` в конфиг и эмитит `<script>var ms3 = { config }</script>`;
- `customers` / `notifications` / `order` / `orders` / `settings` / `utilities` — `$this->addHtml('var ms3…')` → `$this->addVueConfig($config)`;
- `request.js` `getModAuthToken()` — читать сперва `ms3.config.token`, фолбэк на `MODx.siteId`.

Токен присутствует в первом же inline-теге → гонки нет by construction. Покрыты все 6 Ext-less страниц. Права/сессия не затронуты.

## Проверка

- `php -l` ×7 ✓, ESLint ✓, `npm run build` ✓ (PHPStan не применим — `controllers/` вне анализа).
- На DEV после hard-reload: все страницы MiniShop без ошибок в консоли; ранее падавшие запросы теперь `success:true` с `HTTP_MODAUTH` в URL. Подтверждено на нескольких перезагрузках (гонка была интермиттентной).
