### PR TITLE
fix(vue): бесконечная реактивная петля в ResourceCategoryTree — фриз Настройки→Опции (#546)

### DIFF
--- a/vueManager/src/components/ResourceCategoryTree.vue
+++ b/vueManager/src/components/ResourceCategoryTree.vue
@@ -250,8 +250,18 @@ function onNodeContextMenu(event, node) {
 watch(
   () => props.modelValue,
   newIds => {
-    checkedSet.value = new Set(newIds || [])
-    ensureLockedChecked()
+    // Sync internal check state from the parent and enforce locked IDs. Emit back ONLY
+    // when locked enforcement actually added something the parent doesn't already have.
+    // Calling emitSelection() unconditionally here echoes the value we just received,
+    // which reassigns props.modelValue and retriggers this watch — an infinite recursive
+    // loop that freezes the page (#546).
+    const incoming = new Set(newIds || [])
+    const next = new Set(incoming)
+    lockedSet.value.forEach(id => next.add(id))
+    checkedSet.value = next
+    if (next.size !== incoming.size) {
+      emitSelection()
+    }
   },
   { deep: true }
 )


### PR DESCRIPTION
Fixes #546

## Проблема

Админка → **Настройки → «Опции»** намертво виснет при открытии. В Network единственный `GET /api/mgr/options` висит в `pending`.

## Причина — бесконечная реактивная петля

`ResourceCategoryTree.vue`: `watch(() => props.modelValue, …, { deep:true })` безусловно звал `ensureLockedChecked()` → `emitSelection()` эмитит `update:modelValue` **новым массивом** → родитель (`OptionsGrid.selectedCategories` через `OptionCategoryTree` v-model) обновляет модель → ссылка меняется → `watch` снова → **бесконечно**.

Петля реактивная (микротаски) — пожирает главный поток. Поэтому страница фризится, а одиночный `/api/mgr/options` висит `pending`: замороженный браузер не может обработать уже пришедший ответ.

### Доказательства (воспроизведено, не гипотеза)

- Изолированная реактивность Vue (та же схема) → `Maximum recursive updates exceeded` (guard Vue).
- Сервер невиновен: `OptionsController::getList` в CLI — **0.006с** (total=21, results=20), БД чиста (MariaDB, 21 строка).

Регрессия из `6d7a13871`.

## Решение (проверено на стенде)

`watch(modelValue)` не эхо-эмитит полученное значение — `emitSelection()` только когда locked-принуждение реально добавило ID, которого у родителя нет:

```js
watch(() => props.modelValue, newIds => {
  const incoming = new Set(newIds || [])
  const next = new Set(incoming)
  lockedSet.value.forEach(id => next.add(id))
  checkedSet.value = next
  if (next.size !== incoming.size) emitSelection()
}, { deep: true })
```

С guard'ом на изолированном стенде — 1 эмит вместо бесконечного цикла; locked-семантика сохранена.

## Радиус

Тот же `ResourceCategoryTree` — в `ProductCategoriesTab` (карточка товара → Категории) и `CategoryOptionsTab`. Фикс закрывает петлю для всех потребителей.

## Проверка

- ESLint ✅, `npm run build` ✅.
- На DEV после hard-reload: Настройки→Опции открывается без фриза, фильтр-дерево работает; карточка товара → Категории и Категория → Опции — без зависаний (подтверждено).
