### PR TITLE
fix(vue): убрать лишний confirm удаления в VendorsGrid (#551)

### DIFF
--- a/vueManager/src/components/VendorsGrid.vue
+++ b/vueManager/src/components/VendorsGrid.vue
@@ -383,7 +383,7 @@ function getActionsConfig(column) {
         icon: 'pi-trash',
         label: _('delete'),
         severity: 'danger',
-        confirm: true,
+        confirm: false,
         confirmMessage: 'vendor_delete_confirm_message',
       },
     ]
@@ -450,7 +450,7 @@ function getDefaultColumns() {
           icon: 'pi-trash',
           label: 'delete',
           severity: 'danger',
-          confirm: true,
+          confirm: false,
           confirmMessage: 'vendor_delete_confirm_message',
         },
       ],


### PR DESCRIPTION
Fixes #551

Follow-up к #548/#549. В `VendorsGrid` delete-действие `ActionsColumn` было `confirm: true` → useActions показывал confirm, затем `deleteVendor()` показывал второй. Последовательный двойной confirm независимо от группировки шины.

Выровнял на `confirm: false` (оба определения) как у остальных гридов Настроек — `deleteVendor()` остаётся единственным сгруппированным confirm. Совпадает с версией, которую тестировали на DEV.

ESLint ✅, build ✅.