### PR TITLE
fix(mgr): declare ms3 via addVueConfig on help page

### DIFF
--- a/core/components/minishop3/controllers/mgr/help.class.php
+++ b/core/components/minishop3/controllers/mgr/help.class.php
@@ -27,17 +27,12 @@ class MiniShop3MgrHelpManagerController extends msManagerController
      */
     public function loadCustomCssJs()
     {
-        // Vue CSS
+        // Config before Vue modules so mount sees ms3.config (#553).
+        $this->addVueConfig($this->ms3->config);
+
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($this->ms3->config['assetsUrl'] . 'css/mgr/vue-dist/help.min.css');
-
-        // Vue module
         $this->addVueModule($this->ms3->config['jsUrl'] . 'mgr/vue-dist/help.min.js');
-
-        // Pass config to JavaScript
-        $this->addHtml('<script>
-            ms3.config = ' . json_encode($this->ms3->config) . ';
-        </script>');
     }
 
     /**

--- a/core/components/minishop3/tests/HelpVueEntryTest.php
+++ b/core/components/minishop3/tests/HelpVueEntryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Help mgr page: Vue entry must declare `var ms3` via addVueConfig (#553).
+ *
+ * Run: php tests/HelpVueEntryTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$componentRoot = dirname(__DIR__);
+$repoRoot = dirname($componentRoot, 3);
+
+$tpl = $componentRoot . '/templates/default/help.tpl';
+$tplHtml = is_file($tpl) ? file_get_contents($tpl) : false;
+if ($tplHtml === false || !str_contains($tplHtml, 'id="ms3-vue-help"')) {
+    $fail('help.tpl must contain mount #ms3-vue-help');
+}
+
+$controllerPath = $componentRoot . '/controllers/mgr/help.class.php';
+$controller = file_get_contents($controllerPath);
+if ($controller === false) {
+    $fail('cannot read help controller');
+}
+
+foreach (['help\.min\.js', 'help\.tpl', 'addVueConfig', 'getTemplateFile'] as $pattern) {
+    if (preg_match('#' . $pattern . '#', $controller) !== 1) {
+        $fail("help controller must contain /{$pattern}/");
+    }
+}
+
+if (preg_match('#ms3\.config\s*=#', $controller) === 1) {
+    $fail('help controller must not assign ms3.config without declaring ms3 (#553)');
+}
+
+$configPos = strpos($controller, 'addVueConfig');
+$modulePos = strpos($controller, 'addVueModule');
+if ($configPos === false || $modulePos === false || $configPos > $modulePos) {
+    $fail('help controller must call addVueConfig() before addVueModule()');
+}
+
+$entry = $repoRoot . '/vueManager/src/entries/help.js';
+$entrySrc = is_file($entry) ? file_get_contents($entry) : false;
+if ($entrySrc === false || !str_contains($entrySrc, '#ms3-vue-help')) {
+    $fail('help entry must mount #ms3-vue-help');
+}
+
+fwrite(STDOUT, "OK HelpVueEntryTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Страница справки менеджера писала `ms3.config = …` без объявления `ms3`. В консоли `ReferenceError: ms3 is not defined`, Vue не видел конфиг (логотип из `ms3.config.defaultThumb`).

Теперь справка вызывает `addVueConfig()` до Vue-модуля, как orders/customers/settings: `var ms3 = { config }` плюс токен менеджера.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #553

## Как это было протестировано?

Красный → зелёный: `php tests/HelpVueEntryTest.php` сначала падал на отсутствии `addVueConfig`, после правки `OK HelpVueEntryTest` (exit 0).

```
php -l core/components/minishop3/controllers/mgr/help.class.php  # exit 0
php -l core/components/minishop3/tests/HelpVueEntryTest.php     # exit 0
cd core/components/minishop3 && composer test:smoke            # exit 0, 71 tests
```

Vue/ESLint не гонял: фронт не менялся. PHPStan не гонял: новых типов нет.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test:smoke`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.12.0-beta1
- MODX: 3.x
- PHP: 8.2+

## Скриншоты (если применимо)

—

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Ext-контроллеры товара/категории с `ms3.config =` не трогал: там Ext/`MODx.load`. Ревью [code-reviewer](2143b040-ec11-4eee-a2bc-f281eedea024) и [thermo-nuclear](524e7174-57f6-4fcd-b85e-2a85594900c9): блокеров нет.