### PR TITLE
fix(vue): space category tree checkbox from its label

### DIFF
--- a/core/components/minishop3/controllers/product/update.class.php
+++ b/core/components/minishop3/controllers/product/update.class.php
@@ -64,6 +64,8 @@ class msProductUpdateManagerController extends msResourceUpdateController
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/primeicons.min.css');
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/product-tabs.min.css');
         $this->addCss($assetsUrl . 'css/mgr/vue-dist/DynamicField.min.css');
+        // Shared Vite chunk: tree styles are not inlined into product-tabs.min.css (#555).
+        $this->addCss($assetsUrl . 'css/mgr/vue-dist/ResourceCategoryTree.min.css');
         $this->addVueModule($assetsUrl . 'js/mgr/vue-dist/product-tabs.min.js');
 
         $show_gallery = $this->getOption('ms3_product_tab_gallery', null, true);

--- a/core/components/minishop3/tests/ProductUpdateVueAssetsTest.php
+++ b/core/components/minishop3/tests/ProductUpdateVueAssetsTest.php
@@ -35,5 +35,9 @@ if (preg_match('/addCss\([^;]*primeicons\.min\.css/', $controller) !== 1) {
     $fail('product/update must still register primeicons.min.css');
 }
 
+if (preg_match('/addCss\([^;]*ResourceCategoryTree\.min\.css/', $controller) !== 1) {
+    $fail('product/update must load ResourceCategoryTree.min.css (shared Vite chunk, #555)');
+}
+
 fwrite(STDOUT, "OK ProductUpdateVueAssetsTest\n");
 exit(0);

--- a/core/components/minishop3/tests/ResourceCategoryTreeCheckboxGapTest.php
+++ b/core/components/minishop3/tests/ResourceCategoryTreeCheckboxGapTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Category tree: space between PrimeVue checkbox and node label (#555).
+ *
+ * Run: php tests/ResourceCategoryTreeCheckboxGapTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$vue = dirname(__DIR__, 4) . '/vueManager/src/components/ResourceCategoryTree.vue';
+$src = is_file($vue) ? file_get_contents($vue) : false;
+if ($src === false) {
+    $fail('cannot read vueManager/src/components/ResourceCategoryTree.vue');
+}
+
+if (!str_contains($src, 'class="tree-node-check"') || !str_contains($src, 'class="tree-node-label"')) {
+    $fail('tree node must keep Checkbox.tree-node-check and label.tree-node-label');
+}
+
+if (preg_match('/\.tree-node-check\s*\+\s*\.tree-node-label\s*\{[^}]*margin-inline-start:\s*0\.5rem/', $src) !== 1) {
+    $fail('checkbox + label must set margin-inline-start: 0.5rem (#555)');
+}
+
+if (preg_match('/\.tree-node-check\s*\{[^}]*flex-shrink:\s*0/', $src) !== 1) {
+    $fail('tree-node-check must set flex-shrink: 0 so the box keeps its width');
+}
+
+fwrite(STDOUT, "OK ResourceCategoryTreeCheckboxGapTest\n");
+exit(0);

--- a/core/components/minishop3/tests/ResourceCategoryTreeCheckboxGapTest.php
+++ b/core/components/minishop3/tests/ResourceCategoryTreeCheckboxGapTest.php
@@ -31,5 +31,14 @@ if (preg_match('/\.tree-node-check\s*\{[^}]*flex-shrink:\s*0/', $src) !== 1) {
     $fail('tree-node-check must set flex-shrink: 0 so the box keeps its width');
 }
 
+$update = dirname(__DIR__) . '/controllers/product/update.class.php';
+$updateSrc = is_file($update) ? file_get_contents($update) : false;
+if ($updateSrc === false) {
+    $fail('cannot read controllers/product/update.class.php');
+}
+if (preg_match('/addCss\([^;]*ResourceCategoryTree\.min\.css/', $updateSrc) !== 1) {
+    $fail('product/update must load ResourceCategoryTree.min.css (Vite shared chunk, #555)');
+}
+
 fwrite(STDOUT, "OK ResourceCategoryTreeCheckboxGapTest\n");
 exit(0);

--- a/vueManager/src/components/ResourceCategoryTree.vue
+++ b/vueManager/src/components/ResourceCategoryTree.vue
@@ -339,12 +339,21 @@ defineExpose({
 .vueApp .resource-category-tree .tree-node-row {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
+}
+
+.vueApp .resource-category-tree .tree-node-check {
+  flex-shrink: 0;
 }
 
 .vueApp .resource-category-tree .tree-node-label {
   cursor: pointer;
   user-select: none;
+}
+
+/* PrimeVue Checkbox box can overflow the flex item, so gap alone is not enough (#555). */
+.vueApp .resource-category-tree .tree-node-check + .tree-node-label {
+  margin-inline-start: 0.5rem;
 }
 
 .vueApp .resource-category-tree .tree-node-label-locked {


### PR DESCRIPTION
## Описание

Во вкладке «Категории» товара подпись стояла вплотную к чекбоксу. У строки уже был `gap: 0.4rem`, визуально его съедал бокс PrimeVue Checkbox.

Отступ `0.5rem` на `label` сразу после чекбокса (`+` селектор), `flex-shrink: 0` на чекбоксе. Строки без галочки не сдвигаются. Тот же виджет в дереве опций.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #555

## Как это было протестировано?

Красный → зелёный: `php tests/ResourceCategoryTreeCheckboxGapTest.php` падал без `margin-inline-start`, после правки exit 0.

```
php tests/ResourceCategoryTreeCheckboxGapTest.php   # exit 0
php -l tests/ResourceCategoryTreeCheckboxGapTest.php  # exit 0
npx eslint src/components/ResourceCategoryTree.vue    # exit 0
composer test:smoke                                   # exit 0, 71 tests
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test:smoke`, `npx eslint` на изменённом Vue)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.12.0-beta1
- MODX: 3.x
- PHP: 8.2+

## Скриншоты (если применимо)

<img width="913" height="754" alt="image" src="https://github.com/user-attachments/assets/4adedca3-41d2-46f2-9704-75f7a3f75ca3" />

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npx eslint` на `ResourceCategoryTree.vue`)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Refactoring UI: отступ 0.5rem (8px) вместо произвольных 0.4rem. Ревью [code-reviewer](8c05604e-c8e8-4aa5-959e-6c14fe004836) и [thermo-nuclear](8fa8cf30-01b7-451f-88ba-1f5062221ebe): блокеров нет. После ревью margin только на `checkbox + label`.