### PR TITLE
fix(vue): reuse ms3_menu_remove for product link confirm header

### DIFF
--- a/core/components/minishop3/tests/ProductLinksVueTabTest.php
+++ b/core/components/minishop3/tests/ProductLinksVueTabTest.php
@@ -86,6 +86,14 @@ $linksTab = (string) file_get_contents($vue . '/components/product/ProductLinksT
 $assertTrue(is_file($vue . '/components/product/ProductLinksTab.vue'), 'ProductLinksTab.vue missing');
 $assertTrue(str_contains($linksTab, 'ConfirmDialog'), 'ConfirmDialog belongs in ProductLinksTab');
 $assertTrue(str_contains($linksTab, '/api/mgr/references/link-types'), 'link-types via references');
+$assertTrue(
+    !str_contains($linksTab, 'ms3_menu_remove_title'),
+    'confirm header must not use missing ms3_menu_remove_title (#556)'
+);
+$assertTrue(
+    str_contains($linksTab, "header: _('ms3_menu_remove')"),
+    'confirm header must reuse existing ms3_menu_remove (#556)'
+);
 
 $updateCtrl = (string) file_get_contents($root . '/controllers/product/update.class.php');
 $assertTrue(

--- a/vueManager/src/components/product/ProductLinksTab.vue
+++ b/vueManager/src/components/product/ProductLinksTab.vue
@@ -185,7 +185,7 @@ async function saveLink(close = true) {
 function removeLink(row) {
   confirm.require({
     message: _('ms3_menu_remove_confirm'),
-    header: _('ms3_menu_remove_title'),
+    header: _('ms3_menu_remove'),
     icon: 'pi pi-exclamation-triangle',
     acceptLabel: _('delete'),
     rejectLabel: _('cancel'),


### PR DESCRIPTION
## Описание

Заголовок confirm удаления связи показывал ключ `ms3_menu_remove_title`. Такого ключа в лексиконах нет. Текст вопроса уже переведён через `ms3_menu_remove_confirm`.

Header берёт существующий `ms3_menu_remove` («Удалить» / «Remove») — тот же ключ, что toast и aria-label. Новых строк в lexicon нет.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #556

## Как это было протестировано?

Красный → зелёный: `ProductLinksVueTabTest` падал на `ms3_menu_remove_title`, после замены exit 0.

```
php tests/ProductLinksVueTabTest.php                         # exit 0
php -l tests/ProductLinksVueTabTest.php                      # exit 0
npx eslint src/components/product/ProductLinksTab.vue        # exit 0
composer test:smoke                                          # exit 0, 70 tests
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer test:smoke`, ESLint на изменённом Vue)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: 1.12.0-beta1
- MODX: 3.x
- PHP: 8.2+

## Скриншоты (если применимо)

—

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npx eslint` на `ProductLinksTab.vue`)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Новый ключ `ms3_menu_remove_title` не добавлял: в `manager.inc.php` уже есть `ms3_menu_remove`. Ревью [code-reviewer](e691804e-c69a-41a5-8090-ee4965ad7f07) и [thermo-nuclear](ef480341-7b2a-4510-9300-5e5fcbc3af9d): блокеров нет.