### PR TITLE
fix(schema): добавить idempotency_key в schema.xml msOrder

### DIFF
--- a/core/components/minishop3/schema/minishop3.mysql.schema.xml
+++ b/core/components/minishop3/schema/minishop3.mysql.schema.xml
@@ -240,6 +240,7 @@
         <field key="customer_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"/>
         <field key="token" dbtype="varchar" precision="128" phptype="string" null="false" default=""/>
         <field key="uuid" dbtype="char" precision="36" phptype="string" null="false" default=""/>
+        <field key="idempotency_key" dbtype="varchar" precision="128" phptype="string" null="true"/>
         <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="updatedon" dbtype="datetime" phptype="datetime" null="true" />
         <field key="num" dbtype="varchar" precision="20" phptype="string" null="true"/>
@@ -268,6 +269,9 @@
         </index>
         <index alias="uuid" name="uuid" primary="false" unique="true" type="BTREE">
             <column key="uuid" length="" collation="A" null="false"/>
+        </index>
+        <index alias="idempotency_key" name="idempotency_key" primary="false" unique="true" type="BTREE">
+            <column key="idempotency_key" length="" collation="A" null="true"/>
         </index>
         <index alias="num" name="num" primary="false" unique="true" type="BTREE">
             <column key="num" length="" collation="A" null="true"/>


### PR DESCRIPTION
Найдено при сверке документации/кода перед релизом 1.13.0-beta1.

Миграция `20260809140000_add_order_idempotency_key.php` и сгенерированный map (`src/Model/mysql/msOrder.php`) содержат уникальную nullable колонку `idempotency_key varchar(128)` на `ms3_orders`, но `schema.xml` — источник, из которого xPDO регенерирует модель — её не содержал. Соседние поля этого же цикла (`preview_file_id`, `key_value_config`) в схему добавлены корректно, это осталось незамеченным.

Без фикса: будущая регенерация модели из schema.xml молча потеряла бы колонку из map.

Изменение чисто декларативное — только добавляет field + unique index по паттерну соседнего `uuid`. Поведение не меняется, миграция и текущий map уже содержат это поле.