### PR TITLE
feat(web-api): публичный Category API (list / get / tree)

### DIFF
--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -272,6 +272,25 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             return $controller->getList($params);
         });
     });
+
+    // Public category catalog — no TokenMiddleware (headless nav / PLP)
+    $router->group('/category', function ($router) use ($modx) {
+        $router->get('/get/{id}', function ($params) use ($modx) {
+            $controller = new \MiniShop3\Controllers\Api\Web\CategoryController($modx);
+            return $controller->get($params);
+        });
+
+        $router->get('/list', function ($params) use ($modx) {
+            $controller = new \MiniShop3\Controllers\Api\Web\CategoryController($modx);
+            return $controller->getList($params);
+        });
+
+        $router->get('/tree', function ($params) use ($modx) {
+            $controller = new \MiniShop3\Controllers\Api\Web\CategoryController($modx);
+            return $controller->getTree($params);
+        });
+    });
+
     $router->get('/health', function () use ($modx) {
         return Response::success([
             'status' => 'ok',

--- a/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Controllers\Api\Web;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+use MiniShop3\Services\Category\CategoryCatalogService;
+use MODX\Revolution\modX;
+
+/**
+ * Public category catalog endpoints for Web API.
+ *
+ * No customer token required — same public surface as product catalog.
+ */
+class CategoryController
+{
+    protected modX $modx;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+        $this->modx->lexicon->load('minishop3:default');
+    }
+
+    /**
+     * GET /api/v1/category/get/{id}
+     *
+     * @param array<string, mixed> $params
+     */
+    public function get(array $params = []): Response
+    {
+        $categoryId = (int) ($params['id'] ?? 0);
+
+        if ($categoryId <= 0) {
+            return Response::error(
+                $this->modx->lexicon('ms3_err_category_id_required'),
+                HttpStatus::BAD_REQUEST
+            );
+        }
+
+        $category = $this->catalog()->getById($categoryId, $params);
+
+        if ($category === null) {
+            return Response::error(
+                $this->modx->lexicon('ms3_err_category_nf'),
+                HttpStatus::NOT_FOUND
+            );
+        }
+
+        return Response::success($category);
+    }
+
+    /**
+     * GET /api/v1/category/list
+     *
+     * Query: parent, limit, offset|page, sort, dir, context,
+     *        include_hidden, include_content
+     *
+     * @param array<string, mixed> $params
+     */
+    public function getList(array $params = []): Response
+    {
+        return Response::success($this->catalog()->getList($params));
+    }
+
+    /**
+     * GET /api/v1/category/tree
+     *
+     * Query: parent, depth, context, include_hidden, sort, dir
+     *
+     * @param array<string, mixed> $params
+     */
+    public function getTree(array $params = []): Response
+    {
+        return Response::success($this->catalog()->getTree($params));
+    }
+
+    private function catalog(): CategoryCatalogService
+    {
+        /** @var CategoryCatalogService $service */
+        $service = $this->modx->services->get('ms3_category_catalog');
+
+        return $service;
+    }
+}

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -32,6 +32,9 @@ class TokenMiddleware implements MiddlewareInterface
     private array $publicRoutes = [
         '/api/v1/product/get/',
         '/api/v1/product/list',
+        '/api/v1/category/get/',
+        '/api/v1/category/list',
+        '/api/v1/category/tree',
         '/api/v1/customer/token/get',
         '/api/v1/customer/logout',
         '/api/v1/health',

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -158,6 +158,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\Product\ProductCatalogService::class,
             'interface' => null,
         ],
+        'ms3_category_catalog' => [
+            'class' => \MiniShop3\Services\Category\CategoryCatalogService::class,
+            'interface' => null,
+        ],
         'ms3_repeater_field' => [
             'class' => \MiniShop3\Services\ExtraFields\RepeaterFieldService::class,
             'interface' => null,

--- a/core/components/minishop3/src/ServiceRegistryFactories.php
+++ b/core/components/minishop3/src/ServiceRegistryFactories.php
@@ -39,6 +39,7 @@ class ServiceRegistryFactories
             'ms3_product_category_tree' => $modxOnly(),
             'ms3_product_link_service' => $modxOnly(),
             'ms3_product_catalog' => $modxOnly(),
+            'ms3_category_catalog' => $modxOnly(),
             'ms3_repeater_field' => $modxOnly(),
             'ms3_extra_fields' => $modxOnly(),
             'ms3_key_value_field' => $modxOnly(),

--- a/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Catalog;
+
+/**
+ * Shared query-param helpers for public Web API catalog services (product / category).
+ */
+final class CatalogQuery
+{
+    public const DEFAULT_LIMIT = 20;
+    public const MAX_LIMIT = 100;
+    public const DEFAULT_DEPTH = 5;
+    public const MAX_DEPTH = 10;
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function resolveLimit(array $params): int
+    {
+        $limit = (int) ($params['limit'] ?? self::DEFAULT_LIMIT);
+        if ($limit < 1) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        return min($limit, self::MAX_LIMIT);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function resolveOffset(array $params, int $limit): int
+    {
+        if (isset($params['offset']) && $params['offset'] !== '') {
+            return max(0, (int) $params['offset']);
+        }
+
+        $page = (int) ($params['page'] ?? 1);
+        if ($page < 1) {
+            $page = 1;
+        }
+
+        return ($page - 1) * $limit;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, string> $sortMap request key => SQL expression
+     * @return array{0: string, 1: string} SQL field, ASC|DESC
+     */
+    public static function resolveSort(array $params, array $sortMap, string $defaultKey = 'menuindex'): array
+    {
+        $sortKey = strtolower(trim((string) ($params['sort'] ?? $defaultKey)));
+        $sortField = $sortMap[$sortKey] ?? ($sortMap[$defaultKey] ?? reset($sortMap));
+        if (!is_string($sortField) || $sortField === '') {
+            $sortField = $defaultKey;
+        }
+
+        $dir = strtoupper(trim((string) ($params['dir'] ?? $params['sortdir'] ?? 'ASC')));
+        if ($dir !== 'DESC') {
+            $dir = 'ASC';
+        }
+
+        return [$sortField, $dir];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function resolveDepth(array $params): int
+    {
+        $depth = (int) ($params['depth'] ?? self::DEFAULT_DEPTH);
+        if ($depth < 1) {
+            return self::DEFAULT_DEPTH;
+        }
+
+        return min($depth, self::MAX_DEPTH);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function resolveContext(array $params, string $fallback = 'web'): string
+    {
+        return trim((string) ($params['context'] ?? $fallback));
+    }
+
+    public static function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return in_array(strtolower((string) $value), ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
@@ -36,10 +36,7 @@ final class CatalogQuery
             return max(0, (int) $params['offset']);
         }
 
-        $page = (int) ($params['page'] ?? 1);
-        if ($page < 1) {
-            $page = 1;
-        }
+        $page = max(1, (int) ($params['page'] ?? 1));
 
         return ($page - 1) * $limit;
     }
@@ -52,7 +49,7 @@ final class CatalogQuery
     public static function resolveSort(array $params, array $sortMap, string $defaultKey = 'menuindex'): array
     {
         $sortKey = strtolower(trim((string) ($params['sort'] ?? $defaultKey)));
-        $sortField = $sortMap[$sortKey] ?? ($sortMap[$defaultKey] ?? reset($sortMap));
+        $sortField = $sortMap[$sortKey] ?? $sortMap[$defaultKey] ?? reset($sortMap);
         if (!is_string($sortField) || $sortField === '') {
             $sortField = $defaultKey;
         }
@@ -79,11 +76,20 @@ final class CatalogQuery
     }
 
     /**
+     * Empty / whitespace context falls back (avoids unscoped cross-context reads).
+     *
      * @param array<string, mixed> $params
      */
     public static function resolveContext(array $params, string $fallback = 'web'): string
     {
-        return trim((string) ($params['context'] ?? $fallback));
+        $context = trim((string) ($params['context'] ?? ''));
+        if ($context !== '') {
+            return $context;
+        }
+
+        $fallback = trim($fallback);
+
+        return $fallback !== '' ? $fallback : 'web';
     }
 
     public static function toBool(mixed $value): bool

--- a/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MiniShop3\Services\Category;
 
 use MiniShop3\Model\msCategory;
-use MiniShop3\Services\Product\ProductCatalogService;
+use MiniShop3\Services\Catalog\CatalogQuery;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOQuery;
 
@@ -17,9 +17,6 @@ use xPDO\Om\xPDOQuery;
  */
 class CategoryCatalogService
 {
-    private const DEFAULT_DEPTH = 5;
-    private const MAX_DEPTH = 10;
-
     /** @var list<string> */
     private const RESOURCE_FIELDS = [
         'id',
@@ -69,12 +66,7 @@ class CategoryCatalogService
      */
     public static function resolveDepth(array $params): int
     {
-        $depth = (int) ($params['depth'] ?? self::DEFAULT_DEPTH);
-        if ($depth < 1) {
-            return self::DEFAULT_DEPTH;
-        }
-
-        return min($depth, self::MAX_DEPTH);
+        return CatalogQuery::resolveDepth($params);
     }
 
     /**
@@ -83,15 +75,7 @@ class CategoryCatalogService
      */
     public static function resolveSort(array $params): array
     {
-        $sortKey = strtolower(trim((string) ($params['sort'] ?? 'menuindex')));
-        $sortField = self::SORT_MAP[$sortKey] ?? self::SORT_MAP['menuindex'];
-
-        $dir = strtoupper(trim((string) ($params['dir'] ?? $params['sortdir'] ?? 'ASC')));
-        if ($dir !== 'DESC') {
-            $dir = 'ASC';
-        }
-
-        return [$sortField, $dir];
+        return CatalogQuery::resolveSort($params, self::SORT_MAP);
     }
 
     /**
@@ -155,22 +139,22 @@ class CategoryCatalogService
             return null;
         }
 
-        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
+        $includeHidden = CatalogQuery::toBool($params['include_hidden'] ?? false);
         $category = $this->findVisibleCategory($categoryId, $params, $includeHidden);
         if ($category === null) {
             return null;
         }
 
-        $includeContent = ProductCatalogService::toBool($params['include_content'] ?? false);
+        $includeContent = CatalogQuery::toBool($params['include_content'] ?? false);
         $payload = $this->formatCategory($category, $includeContent);
 
         $includeBreadcrumbs = !isset($params['include_breadcrumbs'])
-            || ProductCatalogService::toBool($params['include_breadcrumbs']);
+            || CatalogQuery::toBool($params['include_breadcrumbs']);
         if ($includeBreadcrumbs) {
             $payload['breadcrumbs'] = $this->buildBreadcrumbs($category, $params, $includeHidden);
         }
 
-        if (ProductCatalogService::toBool($params['include_children'] ?? false)) {
+        if (CatalogQuery::toBool($params['include_children'] ?? false)) {
             $payload['children'] = $this->listDirectChildrenPayloads($categoryId, $params, $includeHidden, false);
         }
 
@@ -183,10 +167,10 @@ class CategoryCatalogService
      */
     public function getList(array $params): array
     {
-        $limit = ProductCatalogService::resolveLimit($params);
-        $offset = ProductCatalogService::resolveOffset($params, $limit);
-        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
-        $includeContent = ProductCatalogService::toBool($params['include_content'] ?? false);
+        $limit = CatalogQuery::resolveLimit($params);
+        $offset = CatalogQuery::resolveOffset($params, $limit);
+        $includeHidden = CatalogQuery::toBool($params['include_hidden'] ?? false);
+        $includeContent = CatalogQuery::toBool($params['include_content'] ?? false);
         $parent = (int) ($params['parent'] ?? 0);
 
         if ($parent > 0 && $this->findVisibleCategory($parent, $params, $includeHidden) === null) {
@@ -221,7 +205,7 @@ class CategoryCatalogService
     {
         $parent = (int) ($params['parent'] ?? 0);
         $depth = self::resolveDepth($params);
-        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
+        $includeHidden = CatalogQuery::toBool($params['include_hidden'] ?? false);
 
         if ($parent > 0 && $this->findVisibleCategory($parent, $params, $includeHidden) === null) {
             return ['items' => []];
@@ -253,7 +237,10 @@ class CategoryCatalogService
      */
     private function resolveContext(array $params): string
     {
-        return trim((string) ($params['context'] ?? $this->modx->context->key ?? 'web'));
+        return CatalogQuery::resolveContext(
+            $params,
+            (string) ($this->modx->context->key ?? 'web'),
+        );
     }
 
     /**

--- a/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
@@ -56,17 +56,12 @@ class CategoryCatalogService
         'menuindex' => 'msCategory.menuindex',
     ];
 
+    /** Hard cap for nodes loaded into a tree response (depth window still applied). */
+    private const MAX_TREE_NODES = 500;
+
     public function __construct(
         private modX $modx,
     ) {
-    }
-
-    /**
-     * @param array<string, mixed> $params
-     */
-    public static function resolveDepth(array $params): int
-    {
-        return CatalogQuery::resolveDepth($params);
     }
 
     /**
@@ -155,7 +150,12 @@ class CategoryCatalogService
         }
 
         if (CatalogQuery::toBool($params['include_children'] ?? false)) {
-            $payload['children'] = $this->listDirectChildrenPayloads($categoryId, $params, $includeHidden, false);
+            $payload['children'] = $this->listDirectChildrenPayloads(
+                $categoryId,
+                $params,
+                $includeHidden,
+                CatalogQuery::resolveLimit($params),
+            );
         }
 
         return $payload;
@@ -185,8 +185,7 @@ class CategoryCatalogService
         $total = $this->countList($params, $parent, $includeHidden);
 
         $listQuery = $this->buildListQuery($params, $parent, $includeHidden);
-        [$sortField, $dir] = self::resolveSort($params);
-        $listQuery->sortby($sortField, $dir);
+        $this->applySort($listQuery, $params);
         $listQuery->limit($limit, $offset);
 
         return [
@@ -204,14 +203,14 @@ class CategoryCatalogService
     public function getTree(array $params): array
     {
         $parent = (int) ($params['parent'] ?? 0);
-        $depth = self::resolveDepth($params);
+        $depth = CatalogQuery::resolveDepth($params);
         $includeHidden = CatalogQuery::toBool($params['include_hidden'] ?? false);
 
         if ($parent > 0 && $this->findVisibleCategory($parent, $params, $includeHidden) === null) {
             return ['items' => []];
         }
 
-        $rows = $this->loadVisibleCategoryRows($params, $includeHidden);
+        $rows = $this->loadTreeWindowRows($params, $includeHidden, $parent, $depth);
         [$byId, $childrenByParent] = $this->indexCategoryRows($rows);
 
         return [
@@ -282,16 +281,67 @@ class CategoryCatalogService
     }
 
     /**
+     * Load only categories inside the parent + depth window (BFS), capped at MAX_TREE_NODES.
+     *
      * @param array<string, mixed> $params
      * @return list<array<string, mixed>>
      */
-    private function loadVisibleCategoryRows(array $params, bool $includeHidden): array
-    {
-        $c = $this->createVisibleCategoriesQuery($params, $includeHidden);
+    private function loadTreeWindowRows(
+        array $params,
+        bool $includeHidden,
+        int $rootParent,
+        int $depth,
+    ): array {
+        if ($depth < 1) {
+            return [];
+        }
 
-        [$sortField, $dir] = self::resolveSort($params);
-        $c->sortby($sortField, $dir);
+        $rows = [];
+        $parentIds = [$rootParent];
+        $remaining = self::MAX_TREE_NODES;
+
+        for ($level = 0; $level < $depth && $parentIds !== [] && $remaining > 0; $level++) {
+            $levelRows = $this->loadChildrenRowsForParents($params, $includeHidden, $parentIds, $remaining);
+            if ($levelRows === []) {
+                break;
+            }
+
+            $nextParents = [];
+            foreach ($levelRows as $row) {
+                $rows[] = $row;
+                $remaining--;
+                $id = (int) ($row['id'] ?? 0);
+                if ($id > 0) {
+                    $nextParents[] = $id;
+                }
+            }
+            $parentIds = $nextParents;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param list<int> $parentIds
+     * @return list<array<string, mixed>>
+     */
+    private function loadChildrenRowsForParents(
+        array $params,
+        bool $includeHidden,
+        array $parentIds,
+        int $limit,
+    ): array {
+        if ($parentIds === [] || $limit < 1) {
+            return [];
+        }
+
+        $c = $this->createVisibleCategoriesQuery($params, $includeHidden, [
+            'parent:IN' => $parentIds,
+        ]);
+        $this->applySort($c, $params);
         $c->select($this->modx->getSelectColumns(msCategory::class, 'msCategory', '', self::RESOURCE_FIELDS));
+        $c->limit($limit);
 
         if (!$c->prepare() || !$c->stmt->execute()) {
             return [];
@@ -316,7 +366,7 @@ class CategoryCatalogService
             if ($id <= 0) {
                 continue;
             }
-            $payload = $this->normalizeRowPayload($row, false);
+            $payload = $this->normalizeRowPayload($row);
             $byId[$id] = $payload;
             $parentId = (int) ($payload['parent'] ?? 0);
             $childrenByParent[$parentId][] = $id;
@@ -333,13 +383,22 @@ class CategoryCatalogService
         int $parentId,
         array $params,
         bool $includeHidden,
-        bool $includeContent,
+        int $limit,
     ): array {
         $listQuery = $this->buildListQuery($params, $parentId, $includeHidden);
-        [$sortField, $dir] = self::resolveSort($params);
-        $listQuery->sortby($sortField, $dir);
+        $this->applySort($listQuery, $params);
+        $listQuery->limit(max(1, $limit));
 
-        return $this->fetchFormattedCategories($listQuery, $includeContent);
+        return $this->fetchFormattedCategories($listQuery, false);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function applySort(xPDOQuery $query, array $params): void
+    {
+        [$sortField, $dir] = self::resolveSort($params);
+        $query->sortby($sortField, $dir);
     }
 
     /**
@@ -350,7 +409,7 @@ class CategoryCatalogService
     {
         $context = $this->resolveContext($params);
         $ids = $this->modx->getParentIds((int) $category->get('id'), 10, [
-            'context' => $context !== '' ? $context : (string) $category->get('context_key'),
+            'context' => $context,
         ]);
 
         if (!is_array($ids)) {
@@ -375,7 +434,7 @@ class CategoryCatalogService
             while ($row = $query->stmt->fetch(\PDO::FETCH_ASSOC)) {
                 $id = (int) ($row['id'] ?? 0);
                 if ($id > 0) {
-                    $byId[$id] = $this->formatBreadcrumbPayload($this->normalizeRowPayload($row, false));
+                    $byId[$id] = $this->formatBreadcrumbPayload($this->normalizeRowPayload($row));
                 }
             }
         }
@@ -489,7 +548,7 @@ class CategoryCatalogService
      * @param array<string, mixed> $row
      * @return array<string, mixed>
      */
-    private function normalizeRowPayload(array $row, bool $includeContent): array
+    private function normalizeRowPayload(array $row): array
     {
         $payload = [];
         foreach (self::RESOURCE_FIELDS as $field) {
@@ -499,11 +558,7 @@ class CategoryCatalogService
             $payload[$field] = $this->castResourceField($field, $row[$field]);
         }
 
-        if ($includeContent && array_key_exists('content', $row)) {
-            $payload['content'] = $row['content'];
-        }
-
-        return self::whitelistPublicPayload($payload, $includeContent);
+        return self::whitelistPublicPayload($payload, false);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
@@ -374,10 +374,6 @@ class CategoryCatalogService
         $ids = array_reverse($ids);
         $ids[] = (int) $category->get('id');
 
-        if ($ids === []) {
-            return [$this->formatBreadcrumbPayload($this->formatCategory($category, false))];
-        }
-
         $criteria = $this->publicCriteria(array_merge(
             ['id:IN' => $ids],
             $this->visibilityCriteria($params, $includeHidden),

--- a/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
@@ -1,0 +1,541 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Category;
+
+use MiniShop3\Model\msCategory;
+use MiniShop3\Services\Product\ProductCatalogService;
+use MODX\Revolution\modX;
+use xPDO\Om\xPDOQuery;
+
+/**
+ * Public category catalog for Web API (headless / SPA).
+ *
+ * Scopes to published, non-deleted msCategory rows in the requested context.
+ * Navigation lists/trees hide hidemenu=1 unless include_hidden is set.
+ */
+class CategoryCatalogService
+{
+    private const DEFAULT_DEPTH = 5;
+    private const MAX_DEPTH = 10;
+
+    /** @var list<string> */
+    private const RESOURCE_FIELDS = [
+        'id',
+        'pagetitle',
+        'longtitle',
+        'menutitle',
+        'description',
+        'introtext',
+        'alias',
+        'uri',
+        'parent',
+        'menuindex',
+        'hidemenu',
+        'context_key',
+        'publishedon',
+        'createdon',
+        'editedon',
+    ];
+
+    /** @var list<string> */
+    private const BREADCRUMB_FIELDS = [
+        'id',
+        'pagetitle',
+        'menutitle',
+        'alias',
+        'uri',
+        'parent',
+    ];
+
+    /** @var list<string> */
+    private const INT_FIELDS = ['id', 'parent', 'menuindex'];
+
+    /** @var array<string, string> */
+    private const SORT_MAP = [
+        'id' => 'msCategory.id',
+        'pagetitle' => 'msCategory.pagetitle',
+        'menuindex' => 'msCategory.menuindex',
+    ];
+
+    public function __construct(
+        private modX $modx,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function resolveDepth(array $params): int
+    {
+        $depth = (int) ($params['depth'] ?? self::DEFAULT_DEPTH);
+        if ($depth < 1) {
+            return self::DEFAULT_DEPTH;
+        }
+
+        return min($depth, self::MAX_DEPTH);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array{0: string, 1: string}
+     */
+    public static function resolveSort(array $params): array
+    {
+        $sortKey = strtolower(trim((string) ($params['sort'] ?? 'menuindex')));
+        $sortField = self::SORT_MAP[$sortKey] ?? self::SORT_MAP['menuindex'];
+
+        $dir = strtoupper(trim((string) ($params['dir'] ?? $params['sortdir'] ?? 'ASC')));
+        if ($dir !== 'DESC') {
+            $dir = 'ASC';
+        }
+
+        return [$sortField, $dir];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
+     */
+    public static function whitelistPublicPayload(array $payload, bool $includeContent): array
+    {
+        $allowed = self::RESOURCE_FIELDS;
+        if ($includeContent) {
+            $allowed[] = 'content';
+        }
+
+        $result = [];
+        foreach ($allowed as $field) {
+            if (array_key_exists($field, $payload)) {
+                $result[$field] = $payload[$field];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Build nested tree from a flat id→node map (nodes already filtered for visibility).
+     *
+     * @param array<int, array<string, mixed>> $byId
+     * @param array<int, list<int>> $childrenByParent
+     * @return list<array<string, mixed>>
+     */
+    public static function buildTreeNodes(
+        array $byId,
+        array $childrenByParent,
+        int $parentId,
+        int $depth,
+    ): array {
+        if ($depth < 1) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($childrenByParent[$parentId] ?? [] as $childId) {
+            if (!isset($byId[$childId])) {
+                continue;
+            }
+            $node = $byId[$childId];
+            $node['children'] = self::buildTreeNodes($byId, $childrenByParent, $childId, $depth - 1);
+            $items[] = $node;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>|null
+     */
+    public function getById(int $categoryId, array $params = []): ?array
+    {
+        if ($categoryId <= 0) {
+            return null;
+        }
+
+        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
+        $category = $this->findVisibleCategory($categoryId, $params, $includeHidden);
+        if ($category === null) {
+            return null;
+        }
+
+        $includeContent = ProductCatalogService::toBool($params['include_content'] ?? false);
+        $payload = $this->formatCategory($category, $includeContent);
+
+        $includeBreadcrumbs = !isset($params['include_breadcrumbs'])
+            || ProductCatalogService::toBool($params['include_breadcrumbs']);
+        if ($includeBreadcrumbs) {
+            $payload['breadcrumbs'] = $this->buildBreadcrumbs($category, $params, $includeHidden);
+        }
+
+        if (ProductCatalogService::toBool($params['include_children'] ?? false)) {
+            $payload['children'] = $this->listDirectChildrenPayloads($categoryId, $params, $includeHidden, false);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array{items: list<array<string, mixed>>, total: int, limit: int, offset: int}
+     */
+    public function getList(array $params): array
+    {
+        $limit = ProductCatalogService::resolveLimit($params);
+        $offset = ProductCatalogService::resolveOffset($params, $limit);
+        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
+        $includeContent = ProductCatalogService::toBool($params['include_content'] ?? false);
+        $parent = (int) ($params['parent'] ?? 0);
+
+        if ($parent > 0 && $this->findVisibleCategory($parent, $params, $includeHidden) === null) {
+            return [
+                'items' => [],
+                'total' => 0,
+                'limit' => $limit,
+                'offset' => $offset,
+            ];
+        }
+
+        $total = $this->countList($params, $parent, $includeHidden);
+
+        $listQuery = $this->buildListQuery($params, $parent, $includeHidden);
+        [$sortField, $dir] = self::resolveSort($params);
+        $listQuery->sortby($sortField, $dir);
+        $listQuery->limit($limit, $offset);
+
+        return [
+            'items' => $this->fetchFormattedCategories($listQuery, $includeContent),
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array{items: list<array<string, mixed>>}
+     */
+    public function getTree(array $params): array
+    {
+        $parent = (int) ($params['parent'] ?? 0);
+        $depth = self::resolveDepth($params);
+        $includeHidden = ProductCatalogService::toBool($params['include_hidden'] ?? false);
+
+        if ($parent > 0 && $this->findVisibleCategory($parent, $params, $includeHidden) === null) {
+            return ['items' => []];
+        }
+
+        $rows = $this->loadVisibleCategoryRows($params, $includeHidden);
+        [$byId, $childrenByParent] = $this->indexCategoryRows($rows);
+
+        return [
+            'items' => self::buildTreeNodes($byId, $childrenByParent, $parent, $depth),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     * @return array<string, mixed>
+     */
+    private function publicCriteria(array $extra = []): array
+    {
+        return array_merge([
+            'class_key' => msCategory::class,
+            'published' => 1,
+            'deleted' => 0,
+        ], $extra);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function resolveContext(array $params): string
+    {
+        return trim((string) ($params['context'] ?? $this->modx->context->key ?? 'web'));
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function findVisibleCategory(int $categoryId, array $params, bool $includeHidden): ?msCategory
+    {
+        $criteria = $this->publicCriteria(array_merge(
+            ['id' => $categoryId],
+            $this->visibilityCriteria($params, $includeHidden),
+        ));
+
+        /** @var msCategory|null $category */
+        $category = $this->modx->getObject(msCategory::class, $criteria);
+
+        return $category ?: null;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function countList(array $params, int $parent, bool $includeHidden): int
+    {
+        $countQuery = $this->buildListQuery($params, $parent, $includeHidden);
+        $countQuery->select('COUNT(msCategory.id)');
+        if (!$countQuery->prepare() || !$countQuery->stmt->execute()) {
+            return 0;
+        }
+
+        return (int) $countQuery->stmt->fetchColumn();
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function buildListQuery(array $params, int $parent, bool $includeHidden): xPDOQuery
+    {
+        return $this->createVisibleCategoriesQuery($params, $includeHidden, ['parent' => $parent]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
+    private function loadVisibleCategoryRows(array $params, bool $includeHidden): array
+    {
+        $c = $this->createVisibleCategoriesQuery($params, $includeHidden);
+
+        [$sortField, $dir] = self::resolveSort($params);
+        $c->sortby($sortField, $dir);
+        $c->select($this->modx->getSelectColumns(msCategory::class, 'msCategory', '', self::RESOURCE_FIELDS));
+
+        if (!$c->prepare() || !$c->stmt->execute()) {
+            return [];
+        }
+
+        $rows = $c->stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        return is_array($rows) ? $rows : [];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @return array{0: array<int, array<string, mixed>>, 1: array<int, list<int>>}
+     */
+    private function indexCategoryRows(array $rows): array
+    {
+        $byId = [];
+        $childrenByParent = [];
+
+        foreach ($rows as $row) {
+            $id = (int) ($row['id'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+            $payload = $this->normalizeRowPayload($row, false);
+            $byId[$id] = $payload;
+            $parentId = (int) ($payload['parent'] ?? 0);
+            $childrenByParent[$parentId][] = $id;
+        }
+
+        return [$byId, $childrenByParent];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
+    private function listDirectChildrenPayloads(
+        int $parentId,
+        array $params,
+        bool $includeHidden,
+        bool $includeContent,
+    ): array {
+        $listQuery = $this->buildListQuery($params, $parentId, $includeHidden);
+        [$sortField, $dir] = self::resolveSort($params);
+        $listQuery->sortby($sortField, $dir);
+
+        return $this->fetchFormattedCategories($listQuery, $includeContent);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
+    private function buildBreadcrumbs(msCategory $category, array $params, bool $includeHidden): array
+    {
+        $context = $this->resolveContext($params);
+        $ids = $this->modx->getParentIds((int) $category->get('id'), 10, [
+            'context' => $context !== '' ? $context : (string) $category->get('context_key'),
+        ]);
+
+        if (!is_array($ids)) {
+            $ids = [];
+        }
+
+        $ids = array_values(array_filter(array_map('intval', $ids), static fn (int $id): bool => $id > 0));
+        $ids = array_reverse($ids);
+        $ids[] = (int) $category->get('id');
+
+        if ($ids === []) {
+            return [$this->formatBreadcrumbPayload($this->formatCategory($category, false))];
+        }
+
+        $criteria = $this->publicCriteria(array_merge(
+            ['id:IN' => $ids],
+            $this->visibilityCriteria($params, $includeHidden),
+        ));
+
+        $query = $this->modx->newQuery(msCategory::class, $criteria);
+        $query->select($this->modx->getSelectColumns(msCategory::class, 'msCategory', '', self::RESOURCE_FIELDS));
+
+        /** @var array<int, array<string, mixed>> $byId */
+        $byId = [];
+        if ($query->prepare() && $query->stmt->execute()) {
+            while ($row = $query->stmt->fetch(\PDO::FETCH_ASSOC)) {
+                $id = (int) ($row['id'] ?? 0);
+                if ($id > 0) {
+                    $byId[$id] = $this->formatBreadcrumbPayload($this->normalizeRowPayload($row, false));
+                }
+            }
+        }
+
+        $crumbs = [];
+        foreach ($ids as $id) {
+            if (isset($byId[$id])) {
+                $crumbs[] = $byId[$id];
+            }
+        }
+
+        return $crumbs;
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     */
+    private function createVisibleCategoriesQuery(
+        array $params,
+        bool $includeHidden,
+        array $extra = [],
+    ): xPDOQuery {
+        $c = $this->modx->newQuery(msCategory::class);
+        $c->where($this->publicCriteria($extra));
+        $this->applyVisibilityFilters($c, $params, $includeHidden);
+
+        return $c;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchFormattedCategories(xPDOQuery $query, bool $includeContent): array
+    {
+        /** @var list<msCategory> $categories */
+        $categories = $this->modx->getCollection(msCategory::class, $query) ?: [];
+
+        $items = [];
+        foreach ($categories as $category) {
+            $items[] = $this->formatCategory($category, $includeContent);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    private function visibilityCriteria(array $params, bool $includeHidden): array
+    {
+        $criteria = $this->contextCriteria($params);
+        if (!$includeHidden) {
+            $criteria['hidemenu'] = 0;
+        }
+
+        return $criteria;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    private function contextCriteria(array $params): array
+    {
+        $context = $this->resolveContext($params);
+
+        return $context !== '' ? ['context_key' => $context] : [];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function applyVisibilityFilters(xPDOQuery $query, array $params, bool $includeHidden): void
+    {
+        foreach ($this->visibilityCriteria($params, $includeHidden) as $field => $value) {
+            $query->where(["msCategory.{$field}" => $value]);
+        }
+    }
+
+    private function castResourceField(string $field, mixed $value): mixed
+    {
+        if ($field === 'hidemenu') {
+            return (bool) $value;
+        }
+        if (in_array($field, self::INT_FIELDS, true)) {
+            return (int) $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatCategory(msCategory $category, bool $includeContent): array
+    {
+        $payload = [];
+        foreach (self::RESOURCE_FIELDS as $field) {
+            $payload[$field] = $this->castResourceField($field, $category->get($field));
+        }
+
+        if ($includeContent) {
+            $payload['content'] = $category->get('content');
+        }
+
+        return self::whitelistPublicPayload($payload, $includeContent);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function normalizeRowPayload(array $row, bool $includeContent): array
+    {
+        $payload = [];
+        foreach (self::RESOURCE_FIELDS as $field) {
+            if (!array_key_exists($field, $row)) {
+                continue;
+            }
+            $payload[$field] = $this->castResourceField($field, $row[$field]);
+        }
+
+        if ($includeContent && array_key_exists('content', $row)) {
+            $payload['content'] = $row['content'];
+        }
+
+        return self::whitelistPublicPayload($payload, $includeContent);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
+     */
+    private function formatBreadcrumbPayload(array $payload): array
+    {
+        $result = [];
+        foreach (self::BREADCRUMB_FIELDS as $field) {
+            if (array_key_exists($field, $payload)) {
+                $result[$field] = $payload[$field];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/core/components/minishop3/src/Services/Product/ProductCatalogService.php
+++ b/core/components/minishop3/src/Services/Product/ProductCatalogService.php
@@ -6,6 +6,7 @@ namespace MiniShop3\Services\Product;
 
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
+use MiniShop3\Services\Catalog\CatalogQuery;
 use MiniShop3\Services\Option\OptionService;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOQuery;
@@ -19,9 +20,6 @@ use xPDO\Om\xPDOQuery;
  */
 class ProductCatalogService
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     /** @var list<string> */
     private const RESOURCE_FIELDS = [
         'id',
@@ -78,12 +76,7 @@ class ProductCatalogService
      */
     public static function resolveLimit(array $params): int
     {
-        $limit = (int) ($params['limit'] ?? self::DEFAULT_LIMIT);
-        if ($limit < 1) {
-            return self::DEFAULT_LIMIT;
-        }
-
-        return min($limit, self::MAX_LIMIT);
+        return CatalogQuery::resolveLimit($params);
     }
 
     /**
@@ -93,16 +86,7 @@ class ProductCatalogService
      */
     public static function resolveOffset(array $params, int $limit): int
     {
-        if (isset($params['offset']) && $params['offset'] !== '') {
-            return max(0, (int) $params['offset']);
-        }
-
-        $page = (int) ($params['page'] ?? 1);
-        if ($page < 1) {
-            $page = 1;
-        }
-
-        return ($page - 1) * $limit;
+        return CatalogQuery::resolveOffset($params, $limit);
     }
 
     /**
@@ -113,15 +97,7 @@ class ProductCatalogService
      */
     public static function resolveSort(array $params): array
     {
-        $sortKey = strtolower(trim((string) ($params['sort'] ?? 'menuindex')));
-        $sortField = self::SORT_MAP[$sortKey] ?? self::SORT_MAP['menuindex'];
-
-        $dir = strtoupper(trim((string) ($params['dir'] ?? $params['sortdir'] ?? 'ASC')));
-        if ($dir !== 'DESC') {
-            $dir = 'ASC';
-        }
-
-        return [$sortField, $dir];
+        return CatalogQuery::resolveSort($params, self::SORT_MAP);
     }
 
     /**
@@ -175,11 +151,7 @@ class ProductCatalogService
 
     public static function toBool(mixed $value): bool
     {
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        return in_array(strtolower((string) $value), ['1', 'true', 'yes', 'on'], true);
+        return CatalogQuery::toBool($value);
     }
 
     /**
@@ -285,7 +257,10 @@ class ProductCatalogService
      */
     private function resolveContext(array $params): string
     {
-        return trim((string) ($params['context'] ?? $this->modx->context->key ?? 'web'));
+        return CatalogQuery::resolveContext(
+            $params,
+            (string) ($this->modx->context->key ?? 'web'),
+        );
     }
 
     /**

--- a/core/components/minishop3/tests/CatalogQueryTest.php
+++ b/core/components/minishop3/tests/CatalogQueryTest.php
@@ -30,6 +30,9 @@ $assertSame(5, CatalogQuery::resolveDepth([]), 'default depth');
 $assertSame(10, CatalogQuery::resolveDepth(['depth' => 99]), 'depth cap');
 $assertSame('web', CatalogQuery::resolveContext([], 'web'), 'context fallback');
 $assertSame('shop', CatalogQuery::resolveContext(['context' => ' shop '], 'web'), 'context trim');
+$assertSame('web', CatalogQuery::resolveContext(['context' => ''], 'web'), 'empty context → fallback');
+$assertSame('web', CatalogQuery::resolveContext(['context' => '   '], 'web'), 'whitespace context → fallback');
+$assertSame('web', CatalogQuery::resolveContext([], ''), 'empty fallback → web');
 
 $map = [
     'id' => 't.id',

--- a/core/components/minishop3/tests/CatalogQueryTest.php
+++ b/core/components/minishop3/tests/CatalogQueryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Static checks for shared CatalogQuery helpers.
+ *
+ * Run: php tests/CatalogQueryTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Catalog\CatalogQuery;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertSame(20, CatalogQuery::resolveLimit([]), 'default limit');
+$assertSame(100, CatalogQuery::resolveLimit(['limit' => 500]), 'limit cap');
+$assertSame(40, CatalogQuery::resolveOffset(['page' => 3], 20), 'page offset');
+$assertSame(5, CatalogQuery::resolveDepth([]), 'default depth');
+$assertSame(10, CatalogQuery::resolveDepth(['depth' => 99]), 'depth cap');
+$assertSame('web', CatalogQuery::resolveContext([], 'web'), 'context fallback');
+$assertSame('shop', CatalogQuery::resolveContext(['context' => ' shop '], 'web'), 'context trim');
+
+$map = [
+    'id' => 't.id',
+    'menuindex' => 't.menuindex',
+];
+[$field, $dir] = CatalogQuery::resolveSort(['sort' => 'id', 'dir' => 'desc'], $map);
+$assertSame('t.id', $field, 'sort field');
+$assertSame('DESC', $dir, 'sort dir');
+
+[$field, $dir] = CatalogQuery::resolveSort(['sort' => 'nope'], $map);
+$assertSame('t.menuindex', $field, 'unknown sort → default');
+$assertSame('ASC', $dir, 'default dir');
+
+$assertSame(true, CatalogQuery::toBool('yes'), 'toBool yes');
+$assertSame(false, CatalogQuery::toBool('0'), 'toBool 0');
+
+fwrite(STDOUT, "OK CatalogQueryTest\n");
+exit(0);

--- a/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
+++ b/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
@@ -65,6 +65,14 @@ if (!preg_match('/function getTree.*?findVisibleCategory\s*\(/s', $serviceSrc)) 
     $fail('getTree must refuse invisible parent');
 }
 
+if (!preg_match('/function getTree.*?loadTreeWindowRows\s*\(/s', $serviceSrc)) {
+    $fail('getTree must load a parent+depth window, not the full context');
+}
+
+if (!str_contains($serviceSrc, 'MAX_TREE_NODES') || !str_contains($serviceSrc, 'parent:IN')) {
+    $fail('tree loader must cap nodes and filter by parent:IN levels');
+}
+
 foreach (
     [
         "'published' => 1",

--- a/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
+++ b/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Smoke: public category routes registered in web.php (#563).
+ *
+ * Run: php tests/CategoryCatalogRoutesTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$webRoutes = file_get_contents(__DIR__ . '/../config/routes/web.php');
+$controllerSrc = file_get_contents(__DIR__ . '/../src/Controllers/Api/Web/CategoryController.php');
+$serviceSrc = file_get_contents(__DIR__ . '/../src/Services/Category/CategoryCatalogService.php');
+
+if ($webRoutes === false || $controllerSrc === false || $serviceSrc === false) {
+    $fail('unable to read source files');
+}
+
+foreach (
+    [
+        "group('/category'",
+        "get('/get/{id}'",
+        "get('/list'",
+        "get('/tree'",
+        'CategoryController',
+    ] as $needle
+) {
+    if (!str_contains($webRoutes, $needle)) {
+        $fail("web.php missing: {$needle}");
+    }
+}
+
+foreach (['function get(', 'function getList(', 'function getTree('] as $method) {
+    if (!str_contains($controllerSrc, $method)) {
+        $fail("CategoryController missing {$method}");
+    }
+}
+
+if (!str_contains($controllerSrc, 'ms3_category_catalog')) {
+    $fail('CategoryController must resolve ms3_category_catalog');
+}
+
+if (!str_contains($serviceSrc, 'class_key') || !str_contains($serviceSrc, 'published')) {
+    $fail('CategoryCatalogService must scope published msCategory');
+}
+
+if (!str_contains($serviceSrc, 'hidemenu')) {
+    $fail('CategoryCatalogService must handle hidemenu / include_hidden');
+}
+
+if (!preg_match('/function buildBreadcrumbs.*?visibilityCriteria\s*\(/s', $serviceSrc)) {
+    $fail('buildBreadcrumbs must apply visibilityCriteria (hidemenu + context)');
+}
+
+if (!preg_match('/function getList.*?findVisibleCategory\s*\(/s', $serviceSrc)) {
+    $fail('getList must refuse invisible parent');
+}
+
+if (!preg_match('/function getTree.*?findVisibleCategory\s*\(/s', $serviceSrc)) {
+    $fail('getTree must refuse invisible parent');
+}
+
+foreach (
+    [
+        "'published' => 1",
+        "'deleted' => 0",
+        'msCategory::class',
+    ] as $needle
+) {
+    if (!str_contains($serviceSrc, $needle)) {
+        $fail("visibility criteria missing: {$needle}");
+    }
+}
+
+fwrite(STDOUT, "OK CategoryCatalogRoutesTest\n");
+exit(0);

--- a/core/components/minishop3/tests/CategoryCatalogServiceTest.php
+++ b/core/components/minishop3/tests/CategoryCatalogServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Static checks for public category catalog helpers (without MODX).
+ *
+ * Run: php tests/CategoryCatalogServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Category\CategoryCatalogService;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertSame(5, CategoryCatalogService::resolveDepth([]), 'default depth');
+$assertSame(5, CategoryCatalogService::resolveDepth(['depth' => 0]), 'invalid depth falls back');
+$assertSame(3, CategoryCatalogService::resolveDepth(['depth' => 3]), 'custom depth');
+$assertSame(10, CategoryCatalogService::resolveDepth(['depth' => 50]), 'depth capped at 10');
+
+[$field, $dir] = CategoryCatalogService::resolveSort([]);
+$assertSame('msCategory.menuindex', $field, 'default sort field');
+$assertSame('ASC', $dir, 'default sort dir');
+
+[$field, $dir] = CategoryCatalogService::resolveSort(['sort' => 'pagetitle', 'dir' => 'desc']);
+$assertSame('msCategory.pagetitle', $field, 'pagetitle sort');
+$assertSame('DESC', $dir, 'desc dir');
+
+[$field, $dir] = CategoryCatalogService::resolveSort(['sort' => 'unknown', 'sortdir' => 'DESC']);
+$assertSame('msCategory.menuindex', $field, 'unknown sort → menuindex');
+$assertSame('DESC', $dir, 'sortdir alias');
+
+$assertSame(
+    [
+        'id' => 12,
+        'pagetitle' => 'Tea',
+        'menutitle' => 'Tea',
+        'alias' => 'tea',
+        'uri' => 'catalog/tea/',
+        'parent' => 5,
+        'menuindex' => 2,
+        'hidemenu' => false,
+        'content' => '<p>x</p>',
+    ],
+    CategoryCatalogService::whitelistPublicPayload([
+        'id' => 12,
+        'pagetitle' => 'Tea',
+        'menutitle' => 'Tea',
+        'alias' => 'tea',
+        'uri' => 'catalog/tea/',
+        'parent' => 5,
+        'menuindex' => 2,
+        'hidemenu' => false,
+        'content' => '<p>x</p>',
+        'template' => 5,
+        'internal' => 'leak',
+    ], true),
+    'whitelist keeps content, drops template'
+);
+
+$assertSame(
+    [
+        'id' => 12,
+        'pagetitle' => 'Tea',
+    ],
+    CategoryCatalogService::whitelistPublicPayload([
+        'id' => 12,
+        'pagetitle' => 'Tea',
+        'content' => '<p>hidden</p>',
+        'template' => 5,
+    ], false),
+    'whitelist omits content when flag off'
+);
+
+$byId = [
+    5 => ['id' => 5, 'pagetitle' => 'Catalog', 'parent' => 0],
+    12 => ['id' => 12, 'pagetitle' => 'Tea', 'parent' => 5],
+    13 => ['id' => 13, 'pagetitle' => 'Coffee', 'parent' => 5],
+    20 => ['id' => 20, 'pagetitle' => 'Green', 'parent' => 12],
+];
+$childrenByParent = [
+    0 => [5],
+    5 => [12, 13],
+    12 => [20],
+];
+
+$tree = CategoryCatalogService::buildTreeNodes($byId, $childrenByParent, 0, 2);
+$assertSame(1, count($tree), 'root has one child');
+$assertSame(5, $tree[0]['id'], 'root child is catalog');
+$assertSame(2, count($tree[0]['children']), 'depth 2 includes tea+coffee');
+$assertSame([], $tree[0]['children'][0]['children'], 'depth 2 does not include green');
+
+$deep = CategoryCatalogService::buildTreeNodes($byId, $childrenByParent, 5, 2);
+$assertSame(2, count($deep), 'subtree under catalog');
+$assertSame(1, count($deep[0]['children']), 'tea has green at depth 2 from parent 5');
+$assertSame(20, $deep[0]['children'][0]['id'], 'green leaf');
+
+$empty = CategoryCatalogService::buildTreeNodes($byId, $childrenByParent, 0, 0);
+$assertSame([], $empty, 'depth 0 → empty');
+
+fwrite(STDOUT, "OK CategoryCatalogServiceTest\n");
+exit(0);

--- a/core/components/minishop3/tests/CategoryCatalogServiceTest.php
+++ b/core/components/minishop3/tests/CategoryCatalogServiceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Services\Catalog\CatalogQuery;
 use MiniShop3\Services\Category\CategoryCatalogService;
 
 $fail = static function (string $message): never {
@@ -23,10 +24,10 @@ $assertSame = static function ($expected, $actual, string $case) use ($fail): vo
     }
 };
 
-$assertSame(5, CategoryCatalogService::resolveDepth([]), 'default depth');
-$assertSame(5, CategoryCatalogService::resolveDepth(['depth' => 0]), 'invalid depth falls back');
-$assertSame(3, CategoryCatalogService::resolveDepth(['depth' => 3]), 'custom depth');
-$assertSame(10, CategoryCatalogService::resolveDepth(['depth' => 50]), 'depth capped at 10');
+$assertSame(5, CatalogQuery::resolveDepth([]), 'default depth');
+$assertSame(5, CatalogQuery::resolveDepth(['depth' => 0]), 'invalid depth falls back');
+$assertSame(3, CatalogQuery::resolveDepth(['depth' => 3]), 'custom depth');
+$assertSame(10, CatalogQuery::resolveDepth(['depth' => 50]), 'depth capped at 10');
 
 [$field, $dir] = CategoryCatalogService::resolveSort([]);
 $assertSame('msCategory.menuindex', $field, 'default sort field');

--- a/core/components/minishop3/tests/TokenMiddlewarePublicRoutesTest.php
+++ b/core/components/minishop3/tests/TokenMiddlewarePublicRoutesTest.php
@@ -39,6 +39,9 @@ foreach (
     [
         '/api/v1/product/get/',
         '/api/v1/product/list',
+        '/api/v1/category/get/',
+        '/api/v1/category/list',
+        '/api/v1/category/tree',
         '/api/v1/customer/token/get',
         '/api/v1/health',
     ] as $prefix


### PR DESCRIPTION
## Описание

Публичный Category API (`/api/v1/category/list|get/{id}|tree`) для headless Nuxt: меню, страница категории, breadcrumbs. Product endpoints не менялись.

Общий `CatalogQuery` для limit/offset/sort/depth/context (product + category).

## Тип изменений

- [x] Новая функциональность (non-breaking change)
- [x] Рефакторинг (без изменения функциональности) — extract `CatalogQuery`

## Связанные Issues

Closes #563

Refs #577 (RFC), #574 (runtime fixtures), #579 (alias/uri resolve + cache)

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Catalog/CatalogQuery.php
php -l src/Services/Category/CategoryCatalogService.php
php -l src/Controllers/Api/Web/CategoryController.php
php tests/CatalogQueryTest.php                 # exit 0
php tests/CategoryCatalogServiceTest.php       # exit 0
php tests/CategoryCatalogRoutesTest.php        # exit 0
php tests/TokenMiddlewarePublicRoutesTest.php  # exit 0
php tests/ProductCatalogServiceTest.php        # exit 0
composer stan                                  # exit 0
composer ci:php                                # exit 0 (smoke + PHPUnit)
```

- [x] Автоматические тесты
- [ ] Ручное тестирование на живом MODX (нужен published msCategory)

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-563-category-web-api`
- PHP: 8.4 CLI (syntax + smoke + stan)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы: `ms3_err_category_id_required` / `ms3_err_category_nf` (ru/en уже есть)
- [x] PHPStan без новых ошибок
- [ ] CHANGELOG.md — не трогали (релиз)
- [x] Product API контракт без изменений

## Дополнительные заметки

### Контракт

| Метод | Endpoint | Token |
|-------|----------|-------|
| GET | `/api/v1/category/list` | не нужен |
| GET | `/api/v1/category/get/{id}` | не нужен |
| GET | `/api/v1/category/tree` | не нужен |

Видимость: `published=1`, `deleted=0`, `class_key=msCategory`, context; по умолчанию `hidemenu=0` (`include_hidden=1` для sitemap). Breadcrumbs с тем же filter. List/tree с невидимым `parent` → пустой `items` (как soft-empty у product list).

### Review fixes в этом PR

- `?context=` / whitespace → fallback (не снятие `context_key`)
- Tree: BFS по `parent:IN` + depth, cap `MAX_TREE_NODES=500`
- `include_children` capped через `resolveLimit`
- Убран identity-wrapper `resolveDepth`

### Out of scope

- Alias/uri resolve + cache → #579
- Runtime MODX fixtures / HTTP journey → #574
- Nested/`msCategoryMember` в `product/list` → #564
- 404 на неизвестный `parent` в list/tree (сейчас пустой success, зеркало product)