### PR TITLE
fix(events): регистрация msOnBeforeUpdateCustomer / msOnUpdateCustomer

### DIFF
--- a/_build/elements/events.php
+++ b/_build/elements/events.php
@@ -68,6 +68,8 @@ return [
     'msOnErrorValidateCustomerValue',
     'msOnBeforeCreateCustomer',
     'msOnCreateCustomer',
+    'msOnBeforeUpdateCustomer',
+    'msOnUpdateCustomer',
     'msOnBeforeAddCustomerAddress',
     'msOnAddCustomerAddress',
 


### PR DESCRIPTION
Найдено при полной сверке реестра событий с реальными вызовами в коде (перед релизом 1.13.0-beta1).

`MiniShop3\Processors\Customer\Update` объявляет `$beforeSaveEvent = 'msOnBeforeUpdateCustomer'` и `$afterSaveEvent = 'msOnUpdateCustomer'`, но обоих событий не было в `_build/elements/events.php` — а это единственный источник, из которого `build.php` пакует записи `modEvent` в транспорт. Незарегистрированное событие нельзя подключить плагином через стандартный интерфейс.

Документация по обоим событиям уже влита в modx-pro/Docs#1012 (включая честную оговорку, что сам процессор пока не вызывается ни из одного UI/API MS3 — событие существует как точка расширения).

Изменение декларативное: две строки в реестре.