### PR TITLE
feat(web-api): единый контракт ошибок и HTTP-статусов

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/CartController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CartController.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3\Controllers\Api\Web;
 
+use MiniShop3\Router\ApiErrorCode;
+use MiniShop3\Router\DomainMs2Response;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Api\WebApiContextResolver;
@@ -30,9 +32,9 @@ class CartController
      * POST /api/v1/cart/add
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function add(array $params = []): array
+    public function add(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -59,9 +61,9 @@ class CartController
      * POST /api/v1/cart/change
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function change(array $params = []): array
+    public function change(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -77,7 +79,7 @@ class CartController
             return Response::error(
                 $this->modx->lexicon('ms3_err_product_key_required'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -94,9 +96,9 @@ class CartController
      * POST /api/v1/cart/change-option
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function changeOption(array $params = []): array
+    public function changeOption(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -112,14 +114,14 @@ class CartController
             return Response::error(
                 $this->modx->lexicon('ms3_err_product_key_required'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         if (!is_array($options) || $options === []) {
             return Response::error(
                 $this->modx->lexicon('ms3_cart_change_options_error'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -136,9 +138,9 @@ class CartController
      * POST /api/v1/cart/remove
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function remove(array $params = []): array
+    public function remove(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -153,7 +155,7 @@ class CartController
             return Response::error(
                 $this->modx->lexicon('ms3_err_product_key_required'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -170,9 +172,9 @@ class CartController
      * GET /api/v1/cart/get
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function get(array $params = []): array
+    public function get(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -194,9 +196,9 @@ class CartController
      * POST /api/v1/cart/clean
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function clean(array $params = []): array
+    public function clean(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -214,14 +216,15 @@ class CartController
     }
 
     /**
-     * @return array{success: bool, message: string, code: int, errors: mixed}
+     * @return Response
      */
-    private function tokenRequiredError(): array
+    private function tokenRequiredError(): Response
     {
-        return Response::error(
+        return Response::errorWithCode(
+            ApiErrorCode::TOKEN_REQUIRED,
             $this->modx->lexicon('ms3_customer_err_token_required'),
             HttpStatus::UNAUTHORIZED
-        )->getData();
+        );
     }
 
     /**
@@ -251,17 +254,16 @@ class CartController
     }
 
     /**
-     * Transform Cart response to API format
+     * Transform Cart domain MS2-array to Web API Response (#572).
      *
-     * @param array $result Response from Cart controller
-     * @return array Response in API format ['success' => bool, 'message' => '', 'data' => [...]]
+     * @param array<string, mixed> $result
      */
-    protected function transformResponse(array $result): array
+    protected function transformResponse(array $result): Response
     {
         $input = $this->getRequestData();
         $renderTokens = $input['render'] ?? null;
 
-        if (!empty($renderTokens) && $result['success']) {
+        if (!empty($renderTokens) && !empty($result['success'])) {
             $customerToken = $_REQUEST['ms3_token'] ?? '';
 
             $renderedHtml = $this->renderSnippets($renderTokens, $customerToken);
@@ -270,15 +272,14 @@ class CartController
             }
         }
 
-        if ($result['success']) {
-            return Response::success($result['data'], $result['message'] ?? '')->getData();
-        } else {
-            return Response::error(
-                $result['message'] ?? $this->modx->lexicon('ms3_err_unknown'),
-                HttpStatus::BAD_REQUEST,
-                $result['data'] ?? []
-            )->getData();
+        if (!empty($result['success'])) {
+            return Response::success($result['data'] ?? null, $result['message'] ?? '');
         }
+
+        return DomainMs2Response::failure(
+            (string) ($result['message'] ?? $this->modx->lexicon('ms3_err_unknown')),
+            $result['data'] ?? null,
+        );
     }
 
     /**

--- a/core/components/minishop3/src/Controllers/Api/Web/CartController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CartController.php
@@ -257,6 +257,7 @@ class CartController
      * Transform Cart domain MS2-array to Web API Response (#572).
      *
      * @param array<string, mixed> $result
+     * @return Response
      */
     protected function transformResponse(array $result): Response
     {
@@ -267,18 +268,14 @@ class CartController
             $customerToken = $_REQUEST['ms3_token'] ?? '';
 
             $renderedHtml = $this->renderSnippets($renderTokens, $customerToken);
-            if (!empty($renderedHtml)) {
+            if (!empty($renderedHtml) && is_array($result['data'] ?? null)) {
                 $result['data']['render'] = $renderedHtml;
             }
         }
 
-        if (!empty($result['success'])) {
-            return Response::success($result['data'] ?? null, $result['message'] ?? '');
-        }
-
-        return DomainMs2Response::failure(
-            (string) ($result['message'] ?? $this->modx->lexicon('ms3_err_unknown')),
-            $result['data'] ?? null,
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
         );
     }
 

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAddressController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAddressController.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\Model\msCustomer;
 use MiniShop3\Model\msCustomerAddress;
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MODX\Revolution\modX;
@@ -33,14 +34,14 @@ class CustomerAddressController
      * GET /api/v1/customer/addresses
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getList(array $params = []): array
+    public function getList(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $addresses = $this->modx->getIterator(msCustomerAddress::class, [
@@ -53,7 +54,10 @@ class CustomerAddressController
             $data[] = $this->formatAddress($address);
         }
 
-        return Response::success($data)->getData();
+        return Response::success([
+            'items' => $data,
+            'total' => count($data),
+        ]);
     }
 
     /**
@@ -61,20 +65,20 @@ class CustomerAddressController
      * GET /api/v1/customer/addresses/{id}
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function get(array $params = []): array
+    public function get(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST);
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -83,10 +87,10 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND);
         }
 
-        return Response::success($this->formatAddress($address))->getData();
+        return Response::success($this->formatAddress($address));
     }
 
     /**
@@ -94,23 +98,32 @@ class CustomerAddressController
      * POST /api/v1/customer/addresses
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function create(array $params = []): array
+    public function create(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $input = $this->getRequestData();
 
         $required = ['name', 'city', 'street'];
+        $missing = [];
         foreach ($required as $field) {
             if (empty($input[$field])) {
-                return Response::error($this->modx->lexicon('ms3_customer_err_field_required'), HttpStatus::BAD_REQUEST)->getData();
+                $missing[$field] = $this->modx->lexicon('ms3_customer_err_field_required');
             }
+        }
+        if ($missing !== []) {
+            return Response::errorWithCode(
+                ApiErrorCode::VALIDATION_FAILED,
+                $this->modx->lexicon('ms3_customer_err_field_required'),
+                HttpStatus::UNPROCESSABLE_ENTITY,
+                $missing,
+            );
         }
 
         $addressHash = $this->generateAddressHash($input);
@@ -120,9 +133,12 @@ class CustomerAddressController
         ]);
 
         if ($exists) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_already_exists'), HttpStatus::CONFLICT, [
-                'existing_id' => $exists->get('id')
-            ])->getData();
+            return Response::errorWithCode(
+                ApiErrorCode::CONFLICT,
+                $this->modx->lexicon('ms3_customer_address_already_exists'),
+                HttpStatus::CONFLICT,
+                data: ['existing_id' => $exists->get('id')],
+            );
         }
 
         $address = $this->modx->newObject(msCustomerAddress::class);
@@ -138,12 +154,12 @@ class CustomerAddressController
         }
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_creation_error'), HttpStatus::INTERNAL_SERVER_ERROR)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_creation_error'), HttpStatus::INTERNAL_SERVER_ERROR);
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Created customer address: ' . $addressHash . ' for customer #' . $customer->get('id'));
 
-        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_added'), HttpStatus::CREATED)->getData();
+        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_added'), HttpStatus::CREATED);
     }
 
     /**
@@ -151,20 +167,20 @@ class CustomerAddressController
      * PUT /api/v1/customer/addresses/{id}
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function update(array $params = []): array
+    public function update(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST);
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -173,7 +189,7 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND);
         }
 
         $input = $this->getRequestData();
@@ -194,13 +210,13 @@ class CustomerAddressController
             $address->set('updatedon', date('Y-m-d H:i:s'));
 
             if (!$address->save()) {
-                return Response::error($this->modx->lexicon('ms3_customer_address_update_error'), HttpStatus::INTERNAL_SERVER_ERROR)->getData();
+                return Response::error($this->modx->lexicon('ms3_customer_address_update_error'), HttpStatus::INTERNAL_SERVER_ERROR);
             }
 
             $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Updated customer address #' . $addressId);
         }
 
-        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_updated'))->getData();
+        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_updated'));
     }
 
     /**
@@ -208,20 +224,20 @@ class CustomerAddressController
      * PUT /api/v1/customer/addresses/{id}/set-default
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function setDefault(array $params = []): array
+    public function setDefault(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST);
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -231,7 +247,7 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND);
         }
 
         $table = $this->modx->getTableName(msCustomerAddress::class);
@@ -243,12 +259,12 @@ class CustomerAddressController
         $address->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_default_error'), HttpStatus::INTERNAL_SERVER_ERROR)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_default_error'), HttpStatus::INTERNAL_SERVER_ERROR);
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Set default address #' . $addressId . ' for customer #' . $customer->get('id'));
 
-        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_default_set'))->getData();
+        return Response::success($this->formatAddress($address), $this->modx->lexicon('ms3_customer_address_default_set'));
     }
 
     /**
@@ -256,20 +272,20 @@ class CustomerAddressController
      * DELETE /api/v1/customer/addresses/{id}
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function delete(array $params = []): array
+    public function delete(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_not_authorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $addressId = (int)($params['id'] ?? 0);
 
         if (!$addressId) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_id_not_specified'), HttpStatus::BAD_REQUEST);
         }
 
         $address = $this->modx->getObject(msCustomerAddress::class, [
@@ -278,26 +294,25 @@ class CustomerAddressController
         ]);
 
         if (!$address) {
-            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_err_address_not_found'), HttpStatus::NOT_FOUND);
         }
 
         $address->set('active', 0);
         $address->set('updatedon', date('Y-m-d H:i:s'));
 
         if (!$address->save()) {
-            return Response::error($this->modx->lexicon('ms3_customer_address_delete_error'), HttpStatus::INTERNAL_SERVER_ERROR)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_address_delete_error'), HttpStatus::INTERNAL_SERVER_ERROR);
         }
 
         $this->modx->log(modX::LOG_LEVEL_INFO, '[MS3] Deleted customer address #' . $addressId);
 
-        return Response::success(null, $this->modx->lexicon('ms3_customer_address_deleted'))->getData();
+        return Response::success(null, $this->modx->lexicon('ms3_customer_address_deleted'));
     }
 
     /**
      * Format address for API response
      *
-     * @param msCustomerAddress $address
-     * @return array
+     * @return array<string, mixed>
      */
     protected function formatAddress(msCustomerAddress $address): array
     {
@@ -352,20 +367,5 @@ class CustomerAddressController
         $data = json_decode($input, true);
 
         return is_array($data) ? $data : [];
-    }
-
-    /**
-     * Transform response from old format to new
-     *
-     * @param array $result
-     * @return array
-     */
-    protected function transformResponse(array $result): array
-    {
-        if (isset($result['success'])) {
-            return $result;
-        }
-
-        return Response::success($result)->getData();
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -52,7 +52,7 @@ class CustomerEmailController
      *
      * POST /api/v1/customer/email/resend-verification
      *
-     * @return Response ['success' => bool, 'message' => string]
+     * @return Response
      */
     public function resendVerification(): Response
     {

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\MiniShop3;
@@ -15,29 +17,20 @@ use MODX\Revolution\modX;
 /**
  * CustomerEmailController - Email verification API controller
  *
- * Handles sending and verification of email confirmation.
- *
  * Endpoints:
- * - POST /api/v1/customer/email/resend-verification - resend verification email
- * - GET /api/v1/customer/email/verify - verify token from email
+ * - POST /api/v1/customer/email/resend-verification
+ * - GET /api/v1/customer/email/verify
  *
  * @package MiniShop3\Controllers\Api\Web
  */
 class CustomerEmailController
 {
-    /** @var modX */
     protected modX $modx;
 
-    /** @var MiniShop3 */
     protected MiniShop3 $ms3;
 
-    /** @var EmailVerificationService */
     protected EmailVerificationService $emailVerification;
 
-    /**
-     * @param modX $modx
-     * @param MiniShop3 $ms3
-     */
     public function __construct(modX $modx, MiniShop3 $ms3)
     {
         $this->modx = $modx;
@@ -48,11 +41,7 @@ class CustomerEmailController
     }
 
     /**
-     * Resend verification email
-     *
      * POST /api/v1/customer/email/resend-verification
-     *
-     * @return Response
      */
     public function resendVerification(): Response
     {
@@ -63,12 +52,12 @@ class CustomerEmailController
             );
         }
 
-        $customerId = (int)$_SESSION['ms3']['customer_id'];
+        $customerId = (int) $_SESSION['ms3']['customer_id'];
 
-        /** @var msCustomer $customer */
+        /** @var msCustomer|null $customer */
         $customer = $this->modx->getObject(msCustomer::class, $customerId);
 
-        if (!$customer) {
+        if (!$customer instanceof msCustomer) {
             return Response::error(
                 $this->modx->lexicon('ms3_err_customer_nf'),
                 HttpStatus::UNAUTHORIZED
@@ -85,7 +74,7 @@ class CustomerEmailController
 
             return Response::success(
                 $result['data'] ?? null,
-                $result['message'] ?? ''
+                isset($result['message']) ? (string) $result['message'] : ''
             );
         }
 
@@ -96,15 +85,12 @@ class CustomerEmailController
     }
 
     /**
-     * Verify confirmation token from email
-     *
      * GET /api/v1/customer/email/verify?token={token}
      *
      * - `format=json` — всегда JSON (интеграции, отладка).
      * - `html=1` (как в ссылке из письма) — после успеха/ошибки HTTP 302 на сайт (см. GH-226).
      *
-     * @param array $params Request parameters
-     * @return Response
+     * @param array<string, mixed> $params
      */
     public function verify(array $params): Response
     {
@@ -113,7 +99,7 @@ class CustomerEmailController
 
         $token = $params['token'] ?? '';
 
-        if (empty($token)) {
+        if ($token === '') {
             if ($htmlFlow && !$formatJson) {
                 return Response::redirect($this->buildEmailVerificationFailedRedirectUrl(), 302);
             }
@@ -125,7 +111,7 @@ class CustomerEmailController
             );
         }
 
-        $customer = $this->emailVerification->verifyToken($token);
+        $customer = $this->emailVerification->verifyToken((string) $token);
 
         if (!$customer) {
             if ($htmlFlow && !$formatJson) {

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -154,14 +154,14 @@ class CustomerEmailController
             }
 
             // Email is verified; auto-login failed (same UX as html=1 redirect without session)
-            return $this->success(
-                $this->modx->lexicon('ms3_customer_email_verified'),
+            return Response::success(
                 [
                     'customer_id' => $customer->id,
                     'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3),
                     'token' => null,
                     'expires_at' => null,
-                ]
+                ],
+                $this->modx->lexicon('ms3_customer_email_verified')
             );
         }
 
@@ -174,14 +174,14 @@ class CustomerEmailController
             return Response::redirect($this->buildEmailVerificationSuccessRedirectUrl(), 302);
         }
 
-        return $this->success(
-            $this->modx->lexicon('ms3_customer_email_verified'),
+        return Response::success(
             [
                 'customer_id' => $customer->id,
                 'customer' => CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3),
                 'token' => $session['token'],
                 'expires_at' => $session['expires_at'],
-            ]
+            ],
+            $this->modx->lexicon('ms3_customer_email_verified')
         );
     }
 
@@ -207,27 +207,5 @@ class CustomerEmailController
         $base = rtrim((string) $this->modx->getOption('site_url', null, '/'), '/');
 
         return $base . '?ms3_email_verified=0';
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    protected function success(string $message = '', array $data = []): Response
-    {
-        return Response::success($data, $message);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    protected function error(string $message, array $data = []): Response
-    {
-        return Response::error(
-            $message,
-            HttpStatus::BAD_REQUEST,
-            null,
-            null,
-            $data !== [] ? $data : null,
-        );
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerEmailController.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Customer\AuthManager;
@@ -51,15 +52,15 @@ class CustomerEmailController
      *
      * POST /api/v1/customer/email/resend-verification
      *
-     * @return array ['success' => bool, 'message' => string]
+     * @return Response ['success' => bool, 'message' => string]
      */
-    public function resendVerification(): array
+    public function resendVerification(): Response
     {
         if (empty($_SESSION['ms3']['customer_id'])) {
             return Response::error(
                 $this->modx->lexicon('ms3_customer_err_login_required'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         $customerId = (int)$_SESSION['ms3']['customer_id'];
@@ -71,23 +72,27 @@ class CustomerEmailController
             return Response::error(
                 $this->modx->lexicon('ms3_err_customer_nf'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         $result = $this->emailVerification->resendVerificationEmail($customer);
 
-        if ($result['success']) {
+        if (!empty($result['success'])) {
             $this->modx->log(
                 modX::LOG_LEVEL_INFO,
                 "[CustomerEmailController] Verification email resent to customer #{$customerId}"
             );
-            return $result;
+
+            return Response::success(
+                $result['data'] ?? null,
+                $result['message'] ?? ''
+            );
         }
 
         return Response::error(
-            $result['message'],
+            (string) ($result['message'] ?? $this->modx->lexicon('ms3_err_unknown')),
             Response::statusFromProcessorObject($result)
-        )->getData();
+        );
     }
 
     /**
@@ -99,9 +104,9 @@ class CustomerEmailController
      * - `html=1` (как в ссылке из письма) — после успеха/ошибки HTTP 302 на сайт (см. GH-226).
      *
      * @param array $params Request parameters
-     * @return array|Response
+     * @return Response
      */
-    public function verify(array $params): array|Response
+    public function verify(array $params): Response
     {
         $formatJson = ($params['format'] ?? '') === 'json';
         $htmlFlow = ($params['html'] ?? '') === '1';
@@ -113,7 +118,11 @@ class CustomerEmailController
                 return Response::redirect($this->buildEmailVerificationFailedRedirectUrl(), 302);
             }
 
-            return $this->error($this->modx->lexicon('ms3_customer_err_token_required'));
+            return Response::errorWithCode(
+                ApiErrorCode::BAD_REQUEST,
+                $this->modx->lexicon('ms3_customer_err_token_required'),
+                HttpStatus::BAD_REQUEST
+            );
         }
 
         $customer = $this->emailVerification->verifyToken($token);
@@ -123,7 +132,11 @@ class CustomerEmailController
                 return Response::redirect($this->buildEmailVerificationFailedRedirectUrl(), 302);
             }
 
-            return $this->error($this->modx->lexicon('ms3_customer_err_email_verification_invalid'));
+            return Response::errorWithCode(
+                ApiErrorCode::BAD_REQUEST,
+                $this->modx->lexicon('ms3_customer_err_email_verification_invalid'),
+                HttpStatus::BAD_REQUEST
+            );
         }
 
         /** @var AuthManager $authManager */
@@ -197,34 +210,24 @@ class CustomerEmailController
     }
 
     /**
-     * Success response
-     *
-     * @param string $message
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
      */
-    protected function success(string $message = '', array $data = []): array
+    protected function success(string $message = '', array $data = []): Response
     {
-        return [
-            'success' => true,
-            'message' => $message,
-            'data' => $data,
-        ];
+        return Response::success($data, $message);
     }
 
     /**
-     * Error response
-     *
-     * @param string $message
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
      */
-    protected function error(string $message, array $data = []): array
+    protected function error(string $message, array $data = []): Response
     {
-        return [
-            'success' => false,
-            'message' => $message,
-            'data' => $data,
-        ];
+        return Response::error(
+            $message,
+            HttpStatus::BAD_REQUEST,
+            null,
+            null,
+            $data !== [] ? $data : null,
+        );
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerOrderController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerOrderController.php
@@ -31,26 +31,30 @@ class CustomerOrderController
      * GET /api/v1/customer/orders?limit=&offset=&status=
      *
      * @param array $params URL parameters
-     * @return array
+     * @return Response
      */
-    public function getList(array $params = []): array
+    public function getList(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_err_unauthorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_err_unauthorized'), HttpStatus::UNAUTHORIZED);
         }
 
         /** @var CustomerOrderService $service */
         $service = $this->modx->services->get('ms3_customer_order');
         $query = CustomerOrderService::normalizeListParams($_GET, $service->getDraftStatusId());
 
-        return Response::success($service->listForCustomer(
+        $payload = $service->listForCustomer(
             (int)$customer->get('id'),
             $query['limit'],
             $query['offset'],
             $query['status_id']
-        ))->getData();
+        );
+        // Additive alias for pagination convention (#572); keep `orders` for BC.
+        $payload['items'] = $payload['orders'] ?? [];
+
+        return Response::success($payload);
     }
 
     /**
@@ -58,20 +62,20 @@ class CustomerOrderController
      * GET /api/v1/customer/orders/{id}
      *
      * @param array $params URL parameters (id = order ID)
-     * @return array
+     * @return Response
      */
-    public function get(array $params = []): array
+    public function get(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_err_unauthorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_err_unauthorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $orderId = (int)($params['id'] ?? 0);
 
         if ($orderId < 1) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_err_no_id'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_err_no_id'), HttpStatus::BAD_REQUEST);
         }
 
         /** @var CustomerOrderService $service */
@@ -79,10 +83,10 @@ class CustomerOrderController
         $detail = $service->getForCustomer((int)$customer->get('id'), $orderId);
 
         if ($detail === null) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_err_not_found'), HttpStatus::NOT_FOUND)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_err_not_found'), HttpStatus::NOT_FOUND);
         }
 
-        return Response::success($detail)->getData();
+        return Response::success($detail);
     }
 
     /**
@@ -90,20 +94,20 @@ class CustomerOrderController
      * POST /api/v1/customer/orders/{id}/cancel
      *
      * @param array $params URL parameters (id = order ID)
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function cancel(array $params = []): array
+    public function cancel(array $params = []): Response
     {
         $customer = $this->getAuthorizedCustomer();
 
         if (!$customer) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_unauthorized'), HttpStatus::UNAUTHORIZED)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_unauthorized'), HttpStatus::UNAUTHORIZED);
         }
 
         $orderId = (int)($params['id'] ?? 0);
 
         if ($orderId < 1) {
-            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_no_order'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_customer_order_cancel_err_no_order'), HttpStatus::BAD_REQUEST);
         }
 
         /** @var CustomerOrderService $service */
@@ -115,21 +119,21 @@ class CustomerOrderController
                 'not_found' => Response::error(
                     $this->modx->lexicon('ms3_customer_order_cancel_err_not_found'),
                     HttpStatus::NOT_FOUND
-                )->getData(),
+                ),
                 'status' => Response::error(
                     $this->modx->lexicon('ms3_customer_order_cancel_err_status'),
                     HttpStatus::BAD_REQUEST
-                )->getData(),
+                ),
                 default => Response::error(
                     $result['message'] ?? $this->modx->lexicon('ms3_customer_order_cancel_err_failed'),
                     HttpStatus::BAD_REQUEST
-                )->getData(),
+                ),
             };
         }
 
         return Response::success(
             ['order_id' => $result['order_id'], 'status_id' => $result['status_id']],
             $this->modx->lexicon('ms3_customer_order_cancelled')
-        )->getData();
+        );
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\Model\msCustomer;
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Customer\CustomerPublicDto;
@@ -45,15 +46,15 @@ class CustomerProfileController
      * PUT /api/v1/customer/profile
      *
      * @param array $data Form data
-     * @return array ['success' => bool, 'message' => string, 'data' => array]
+     * @return Response ['success' => bool, 'message' => string, 'data' => array]
      */
-    public function update(array $data): array
+    public function update(array $data): Response
     {
         if (empty($_SESSION['ms3']['customer_id'])) {
             return Response::error(
                 $this->modx->lexicon('ms3_customer_err_login_required'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         /** @var msCustomer $customer */
@@ -63,7 +64,7 @@ class CustomerProfileController
             return Response::error(
                 $this->modx->lexicon('ms3_err_customer_nf'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         $customerId = (int)$customer->get('id');
@@ -102,11 +103,12 @@ class CustomerProfileController
             if ($key === 'email') {
                 $newEmail = trim((string) $rawValue);
                 if (!$this->isEmailAvailable($customer, $newEmail)) {
+                    $emailError = $this->modx->lexicon('ms3_customer_err_email_exists');
                     $_SESSION['ms3']['customer_profile_errors'] = [
-                        'email' => $this->modx->lexicon('ms3_customer_err_email_exists'),
+                        'email' => $emailError,
                     ];
 
-                    return $this->error($this->modx->lexicon('ms3_customer_err_email_exists'));
+                    return $this->error($emailError, ['errors' => ['email' => $emailError]]);
                 }
                 $this->resetEmailVerificationIfChanged($customer, $newEmail);
                 $customer->set('email', $newEmail);
@@ -144,15 +146,15 @@ class CustomerProfileController
      * POST /api/v1/customer/add
      *
      * @param array $data Request data with key and value
-     * @return array ['success' => bool, 'message' => string, 'data' => array]
+     * @return Response ['success' => bool, 'message' => string, 'data' => array]
      */
-    public function updateField(array $data): array
+    public function updateField(array $data): Response
     {
         if (empty($_SESSION['ms3']['customer_id'])) {
             return Response::error(
                 $this->modx->lexicon('ms3_customer_err_login_required'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         $customer = $this->getCurrentCustomer();
@@ -160,7 +162,7 @@ class CustomerProfileController
             return Response::error(
                 $this->modx->lexicon('ms3_err_customer_nf'),
                 HttpStatus::UNAUTHORIZED
-            )->getData();
+            );
         }
 
         $key = trim((string) ($data['key'] ?? ''));
@@ -198,7 +200,9 @@ class CustomerProfileController
         }
 
         if ($key === 'email' && !$this->isEmailAvailable($customer, (string) $value)) {
-            return $this->error($this->modx->lexicon('ms3_customer_err_email_exists'));
+            $emailError = $this->modx->lexicon('ms3_customer_err_email_exists');
+
+            return $this->error($emailError, ['errors' => ['email' => $emailError]]);
         }
 
         if ($key === 'email') {
@@ -308,34 +312,30 @@ class CustomerProfileController
     }
 
     /**
-     * Success response
-     *
-     * @param string $message
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
      */
-    protected function success(string $message = '', array $data = []): array
+    protected function success(string $message = '', array $data = []): Response
     {
-        return [
-            'success' => true,
-            'message' => $message,
-            'data' => $data,
-        ];
+        return Response::success($data, $message);
     }
 
     /**
-     * Error response
+     * Profile validation / business errors.
+     * Field map goes to top-level `errors`; also mirrored in `data.errors` for one-release BC (#572).
      *
-     * @param string $message
-     * @param array $data
-     * @return array
+     * @param array<string, mixed> $data
      */
-    protected function error(string $message, array $data = []): array
+    protected function error(string $message, array $data = []): Response
     {
-        return [
-            'success' => false,
-            'message' => $message,
-            'data' => $data,
-        ];
+        $fieldErrors = (isset($data['errors']) && is_array($data['errors'])) ? $data['errors'] : null;
+        $isValidation = $fieldErrors !== null;
+
+        return Response::errorWithCode(
+            $isValidation ? ApiErrorCode::VALIDATION_FAILED : ApiErrorCode::BUSINESS_RULE,
+            $message,
+            $isValidation ? HttpStatus::UNPROCESSABLE_ENTITY : HttpStatus::BAD_REQUEST,
+            $fieldErrors,
+            $data !== [] ? $data : null,
+        );
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerProfileController.php
@@ -46,7 +46,7 @@ class CustomerProfileController
      * PUT /api/v1/customer/profile
      *
      * @param array $data Form data
-     * @return Response ['success' => bool, 'message' => string, 'data' => array]
+     * @return Response
      */
     public function update(array $data): Response
     {
@@ -146,7 +146,7 @@ class CustomerProfileController
      * POST /api/v1/customer/add
      *
      * @param array $data Request data with key and value
-     * @return Response ['success' => bool, 'message' => string, 'data' => array]
+     * @return Response
      */
     public function updateField(array $data): Response
     {

--- a/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
@@ -2,6 +2,8 @@
 
 namespace MiniShop3\Controllers\Api\Web;
 
+use MiniShop3\Router\ApiErrorCode;
+use MiniShop3\Router\DomainMs2Response;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MODX\Revolution\modX;
@@ -29,9 +31,9 @@ class OrderController
      * GET /api/v1/order/get
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function get(array $params = []): array
+    public function get(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -53,9 +55,9 @@ class OrderController
      * POST /api/v1/order/add
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function add(array $params = []): array
+    public function add(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -71,7 +73,7 @@ class OrderController
             return Response::error(
                 $this->modx->lexicon('ms3_err_field_key_required'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -88,9 +90,9 @@ class OrderController
      * POST /api/v1/order/set
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function set(array $params = []): array
+    public function set(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -102,7 +104,7 @@ class OrderController
         }
 
         if (empty($fields) || !is_array($fields)) {
-            return Response::error($this->modx->lexicon('ms3_err_fields_required'), HttpStatus::BAD_REQUEST)->getData();
+            return Response::error($this->modx->lexicon('ms3_err_fields_required'), HttpStatus::BAD_REQUEST);
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -119,9 +121,9 @@ class OrderController
      * POST /api/v1/order/remove
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function remove(array $params = []): array
+    public function remove(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -136,7 +138,7 @@ class OrderController
             return Response::error(
                 $this->modx->lexicon('ms3_err_field_key_required'),
                 HttpStatus::BAD_REQUEST
-            )->getData();
+            );
         }
 
         $ms3 = $this->modx->services->get('ms3');
@@ -146,10 +148,10 @@ class OrderController
         $exists = $order->remove($key);
 
         if ($exists) {
-            return Response::success(['removed' => $key], $this->modx->lexicon('ms3_order_remove_success'))->getData();
+            return Response::success(['removed' => $key], $this->modx->lexicon('ms3_order_remove_success'));
         }
 
-        return Response::error($this->modx->lexicon('ms3_err_field_nf'), HttpStatus::NOT_FOUND)->getData();
+        return Response::error($this->modx->lexicon('ms3_err_field_nf'), HttpStatus::NOT_FOUND);
     }
 
     /**
@@ -157,9 +159,9 @@ class OrderController
      * POST /api/v1/order/submit
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function submit(array $params = []): array
+    public function submit(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -184,9 +186,9 @@ class OrderController
      * POST /api/v1/order/clean
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function clean(array $params = []): array
+    public function clean(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -208,9 +210,9 @@ class OrderController
      * GET /api/v1/order/cost
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getCost(array $params = []): array
+    public function getCost(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -232,9 +234,9 @@ class OrderController
      * GET /api/v1/order/cost/cart
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getCartCost(array $params = []): array
+    public function getCartCost(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -256,9 +258,9 @@ class OrderController
      * GET /api/v1/order/cost/delivery
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getDeliveryCost(array $params = []): array
+    public function getDeliveryCost(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -280,9 +282,9 @@ class OrderController
      * GET /api/v1/order/cost/payment
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getPaymentCost(array $params = []): array
+    public function getPaymentCost(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -304,9 +306,9 @@ class OrderController
      * POST /api/v1/order/address/set
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function setCustomerAddress(array $params = []): array
+    public function setCustomerAddress(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -319,9 +321,9 @@ class OrderController
      * POST /api/v1/customer/changeAddress
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function changeCustomerAddress(array $params = []): array
+    public function changeCustomerAddress(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -329,7 +331,7 @@ class OrderController
         return $this->setCustomerAddressByHash($addressHash);
     }
 
-    protected function setCustomerAddressByHash(?string $addressHash = null): array
+    protected function setCustomerAddressByHash(?string $addressHash = null): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -351,9 +353,9 @@ class OrderController
      * POST /api/v1/order/address/clean
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function cleanCustomerAddress(array $params = []): array
+    public function cleanCustomerAddress(array $params = []): Response
     {
         $token = $_REQUEST['ms3_token'] ?? '';
 
@@ -375,9 +377,9 @@ class OrderController
      * GET /api/v1/order/delivery/validation-rules
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getDeliveryValidationRules(array $params = []): array
+    public function getDeliveryValidationRules(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -402,9 +404,9 @@ class OrderController
      * GET /api/v1/order/delivery/required-fields
      *
      * @param array $params URL parameters
-     * @return array Response ['success' => bool, 'message' => '', 'data' => [...]]
+     * @return Response
      */
-    public function getDeliveryRequiresFields(array $params = []): array
+    public function getDeliveryRequiresFields(array $params = []): Response
     {
         $input = $this->getRequestData();
 
@@ -425,14 +427,15 @@ class OrderController
     }
 
     /**
-     * @return array{success: bool, message: string, code: int, errors: mixed}
+     * @return Response
      */
-    private function tokenRequiredError(): array
+    private function tokenRequiredError(): Response
     {
-        return Response::error(
+        return Response::errorWithCode(
+            ApiErrorCode::TOKEN_REQUIRED,
             $this->modx->lexicon('ms3_customer_err_token_required'),
             HttpStatus::UNAUTHORIZED
-        )->getData();
+        );
     }
 
     /**
@@ -454,21 +457,19 @@ class OrderController
     }
 
     /**
-     * Transform Order response to API format
+     * Transform Order domain MS2-array to Web API Response (#572).
      *
-     * @param array $result Response from Order controller
-     * @return array Response in API format ['success' => bool, 'message' => '', 'data' => [...]]
+     * @param array<string, mixed> $result
      */
-    protected function transformResponse(array $result): array
+    protected function transformResponse(array $result): Response
     {
-        if ($result['success']) {
-            return Response::success($result['data'], $result['message'] ?? '')->getData();
-        } else {
-            return Response::error(
-                $result['message'] ?? $this->modx->lexicon('ms3_err_unknown'),
-                HttpStatus::BAD_REQUEST,
-                $result['data'] ?? []
-            )->getData();
+        if (!empty($result['success'])) {
+            return Response::success($result['data'] ?? null, $result['message'] ?? '');
         }
+
+        return DomainMs2Response::failure(
+            (string) ($result['message'] ?? $this->modx->lexicon('ms3_err_unknown')),
+            $result['data'] ?? null,
+        );
     }
 }

--- a/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/OrderController.php
@@ -47,7 +47,10 @@ class OrderController
 
         $result = $order->get();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -82,7 +85,10 @@ class OrderController
 
         $result = $order->add($key, $value);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -113,7 +119,10 @@ class OrderController
 
         $result = $order->set($fields);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -178,7 +187,10 @@ class OrderController
 
         $result = $order->submit($data);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -202,7 +214,10 @@ class OrderController
 
         $result = $order->clean();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -226,7 +241,10 @@ class OrderController
 
         $result = $order->getCost(false);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -250,7 +268,10 @@ class OrderController
 
         $result = $order->getCartCost();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -274,7 +295,10 @@ class OrderController
 
         $result = $order->getDeliveryCost();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -298,7 +322,10 @@ class OrderController
 
         $result = $order->getPaymentCost();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -345,7 +372,10 @@ class OrderController
 
         $result = $order->setCustomerAddress($addressHash);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -369,7 +399,10 @@ class OrderController
 
         $result = $order->cleanCustomerAddress();
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -396,7 +429,10 @@ class OrderController
 
         $result = $order->getDeliveryValidationRules($delivery_id);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -423,7 +459,10 @@ class OrderController
 
         $result = $order->getDeliveryRequiresFields($delivery_id);
 
-        return $this->transformResponse($result);
+        return DomainMs2Response::fromDomain(
+            $result,
+            $this->modx->lexicon('ms3_err_unknown')
+        );
     }
 
     /**
@@ -456,20 +495,4 @@ class OrderController
         return array_merge($_GET, $_POST);
     }
 
-    /**
-     * Transform Order domain MS2-array to Web API Response (#572).
-     *
-     * @param array<string, mixed> $result
-     */
-    protected function transformResponse(array $result): Response
-    {
-        if (!empty($result['success'])) {
-            return Response::success($result['data'] ?? null, $result['message'] ?? '');
-        }
-
-        return DomainMs2Response::failure(
-            (string) ($result['message'] ?? $this->modx->lexicon('ms3_err_unknown')),
-            $result['data'] ?? null,
-        );
-    }
 }

--- a/core/components/minishop3/src/Middleware/RateLimitMiddleware.php
+++ b/core/components/minishop3/src/Middleware/RateLimitMiddleware.php
@@ -3,6 +3,7 @@
 namespace MiniShop3\Middleware;
 
 use MiniShop3\Router\Middleware\MiddlewareInterface;
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\RateLimit\FileRateLimitStore;
@@ -61,7 +62,11 @@ class RateLimitMiddleware implements MiddlewareInterface
             $retryAfter = max(0, $state['reset_at'] - time());
             header("Retry-After: $retryAfter");
 
-            return Response::error('ms3_err_rate_limit', HttpStatus::TOO_MANY_REQUESTS);
+            return Response::errorWithCode(
+                ApiErrorCode::RATE_LIMITED,
+                'ms3_err_rate_limit',
+                HttpStatus::TOO_MANY_REQUESTS
+            );
         }
 
         $this->setRateLimitHeaders($state['attempts'], $state['reset_at']);

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -3,6 +3,7 @@
 namespace MiniShop3\Middleware;
 
 use MiniShop3\Router\Middleware\MiddlewareInterface;
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\TokenService;
@@ -118,7 +119,7 @@ class TokenMiddleware implements MiddlewareInterface
                         modX::LOG_LEVEL_INFO,
                         '[TokenMiddleware] Rejected expired API token: ' . substr($token, 0, 16) . '...'
                     );
-                    return Response::error('ms3_err_token_expired', HttpStatus::UNAUTHORIZED);
+                    return $this->unauthorizedError(ApiErrorCode::TOKEN_EXPIRED, 'ms3_err_token_expired');
                 }
             } elseif (!$isPublic) {
                 $this->modx->log(
@@ -126,7 +127,7 @@ class TokenMiddleware implements MiddlewareInterface
                     '[TokenMiddleware] Token not found in database. Token: ' . substr($token, 0, 16) . '...'
                 );
                 // Keep machine-stable keys in message — ApiClient.isTokenError() matches them
-                return Response::error('ms3_err_token_invalid', HttpStatus::UNAUTHORIZED);
+                return $this->unauthorizedError(ApiErrorCode::TOKEN_INVALID, 'ms3_err_token_invalid');
             }
         } elseif (!$isPublic && !empty($_SESSION['ms3']['customer_id'])) {
             // Stale session identity without a resolvable token must not bypass revoke.
@@ -142,10 +143,22 @@ class TokenMiddleware implements MiddlewareInterface
                 return null;
             }
 
-            return Response::error('ms3_customer_err_token_create', HttpStatus::UNAUTHORIZED);
+            return Response::errorWithCode(
+                ApiErrorCode::INTERNAL_ERROR,
+                'ms3_customer_err_token_create',
+                HttpStatus::INTERNAL_SERVER_ERROR
+            );
         }
 
         return null;
+    }
+
+    /**
+     * Token reject / mint failure (401 + machine error_code).
+     */
+    private function unauthorizedError(string $errorCode, string $message): Response
+    {
+        return Response::errorWithCode($errorCode, $message, HttpStatus::UNAUTHORIZED);
     }
 
     /**

--- a/core/components/minishop3/src/Router/ApiErrorCode.php
+++ b/core/components/minishop3/src/Router/ApiErrorCode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Router;
+
+/**
+ * Stable machine-readable error_code values for Web API (#572).
+ *
+ * Additive on error envelope; clients may ignore unknown codes.
+ */
+final class ApiErrorCode
+{
+    public const VALIDATION_FAILED = 'validation_failed';
+    public const UNAUTHORIZED = 'unauthorized';
+    public const TOKEN_REQUIRED = 'token_required';
+    public const TOKEN_EXPIRED = 'token_expired';
+    public const TOKEN_INVALID = 'token_invalid';
+    public const NOT_FOUND = 'not_found';
+    public const CONFLICT = 'conflict';
+    public const RATE_LIMITED = 'rate_limited';
+    public const BUSINESS_RULE = 'business_rule';
+    public const BAD_REQUEST = 'bad_request';
+    public const FORBIDDEN = 'forbidden';
+    public const INTERNAL_ERROR = 'internal_error';
+
+    public static function fromHttpStatus(int $statusCode): string
+    {
+        return match ($statusCode) {
+            HttpStatus::UNAUTHORIZED => self::UNAUTHORIZED,
+            HttpStatus::FORBIDDEN => self::FORBIDDEN,
+            HttpStatus::NOT_FOUND => self::NOT_FOUND,
+            HttpStatus::CONFLICT => self::CONFLICT,
+            HttpStatus::TOO_MANY_REQUESTS => self::RATE_LIMITED,
+            HttpStatus::UNPROCESSABLE_ENTITY => self::VALIDATION_FAILED,
+            HttpStatus::INTERNAL_SERVER_ERROR,
+            HttpStatus::SERVICE_UNAVAILABLE => self::INTERNAL_ERROR,
+            HttpStatus::BAD_REQUEST => self::BAD_REQUEST,
+            default => self::BAD_REQUEST,
+        };
+    }
+}

--- a/core/components/minishop3/src/Router/DomainMs2Response.php
+++ b/core/components/minishop3/src/Router/DomainMs2Response.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Router;
+
+/**
+ * Maps domain MS2-array `{success,message,data}` failures to Web API Response (#572).
+ */
+final class DomainMs2Response
+{
+    /**
+     * @param array<string, mixed> $result
+     */
+    public static function fromDomain(array $result, string $fallbackMessage): Response
+    {
+        if (!empty($result['success'])) {
+            return Response::success($result['data'] ?? null, $result['message'] ?? '');
+        }
+
+        return self::failure(
+            (string) ($result['message'] ?? $fallbackMessage),
+            $result['data'] ?? null,
+        );
+    }
+
+    public static function failure(string $message, mixed $data = null): Response
+    {
+        $fieldErrors = null;
+        $context = $data;
+
+        if (is_array($data) && self::isFieldErrorMap($data['errors'] ?? null)) {
+            /** @var array<string, mixed> $fieldErrors */
+            $fieldErrors = $data['errors'];
+            $context = $data;
+            unset($context['errors']);
+            if ($context === []) {
+                $context = null;
+            }
+        }
+
+        if ($fieldErrors !== null) {
+            return Response::errorWithCode(
+                ApiErrorCode::VALIDATION_FAILED,
+                $message,
+                HttpStatus::UNPROCESSABLE_ENTITY,
+                $fieldErrors,
+                $context,
+            );
+        }
+
+        if (self::looksLikeTokenError($message)) {
+            return Response::errorWithCode(
+                ApiErrorCode::TOKEN_REQUIRED,
+                $message,
+                HttpStatus::UNAUTHORIZED,
+                null,
+                $context,
+            );
+        }
+
+        if (self::looksLikeNotFound($message)) {
+            return Response::errorWithCode(
+                ApiErrorCode::NOT_FOUND,
+                $message,
+                HttpStatus::NOT_FOUND,
+                null,
+                $context,
+            );
+        }
+
+        return Response::errorWithCode(
+            ApiErrorCode::BUSINESS_RULE,
+            $message,
+            HttpStatus::BAD_REQUEST,
+            null,
+            $context,
+        );
+    }
+
+    private static function isFieldErrorMap(mixed $errors): bool
+    {
+        if (!is_array($errors) || $errors === []) {
+            return false;
+        }
+
+        // MODX processor list: [{id, msg}, ...] — not a field map
+        if (array_is_list($errors)) {
+            $first = $errors[0] ?? null;
+            if (is_array($first) && (isset($first['id']) || isset($first['msg']))) {
+                return false;
+            }
+        }
+
+        foreach ($errors as $value) {
+            if (!is_string($value) && !is_array($value) && !is_numeric($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function looksLikeTokenError(string $message): bool
+    {
+        $normalized = strtolower($message);
+
+        return str_contains($normalized, 'ms3_err_token')
+            || str_contains($normalized, 'ms3_customer_err_token');
+    }
+
+    private static function looksLikeNotFound(string $message): bool
+    {
+        $normalized = strtolower($message);
+
+        return str_contains($normalized, '_nf')
+            || str_contains($normalized, 'not found')
+            || str_contains($normalized, 'не найден');
+    }
+}

--- a/core/components/minishop3/src/Router/DomainMs2Response.php
+++ b/core/components/minishop3/src/Router/DomainMs2Response.php
@@ -24,6 +24,9 @@ final class DomainMs2Response
         );
     }
 
+    /**
+     * @return Response
+     */
     public static function failure(string $message, mixed $data = null): Response
     {
         $fieldErrors = null;

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -34,7 +34,7 @@ class Response
     /**
      * Redirect response (e.g. email verification in browser; api.php sends Location)
      */
-    public static function redirect(string $url, int $statusCode = 302): self
+    public static function redirect(string $url, int $statusCode = 302): Response
     {
         $r = new self(null, $statusCode);
         $r->redirectUrl = $url;
@@ -50,7 +50,7 @@ class Response
     /**
      * Create success response
      */
-    public static function success(mixed $data = null, ?string $message = null, int $statusCode = HttpStatus::OK): self
+    public static function success(mixed $data = null, ?string $message = null, int $statusCode = HttpStatus::OK): Response
     {
         return new self([
             'success' => true,
@@ -76,7 +76,7 @@ class Response
         mixed $errors = null,
         ?string $errorCode = null,
         mixed $data = null,
-    ): self {
+    ): Response {
         $body = [
             'success' => false,
             'message' => $message,
@@ -100,7 +100,7 @@ class Response
         int $statusCode = HttpStatus::BAD_REQUEST,
         mixed $errors = null,
         mixed $data = null,
-    ): self {
+    ): Response {
         return self::error($message, $statusCode, $errors, $errorCode, $data);
     }
 
@@ -119,7 +119,7 @@ class Response
      *
      * @param object $processorResponse modProcessorResponse (isError/getMessage/getObject)
      */
-    public static function fromProcessor(object $processorResponse): self
+    public static function fromProcessor(object $processorResponse): Response
     {
         if (!$processorResponse->isError()) {
             return self::success($processorResponse->getObject(), $processorResponse->getMessage());

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -60,16 +60,48 @@ class Response
     }
 
     /**
-     * Create error response
+     * Create error response.
+     *
+     * Envelope (#341 + #572):
+     * `{ success:false, message, code, errors, error_code?, data? }`
+     *
+     * - `code` — HTTP status (int), same as response status
+     * - `error_code` — optional stable snake_case machine key (additive)
+     * - `errors` — field-level map only (string|string[]|MODX {msg}); not arbitrary payload
+     * - `data` — optional non-field context (e.g. conflict existing_id, cart status)
      */
-    public static function error(string $message, int $statusCode = HttpStatus::BAD_REQUEST, mixed $errors = null): self
-    {
-        return new self([
+    public static function error(
+        string $message,
+        int $statusCode = HttpStatus::BAD_REQUEST,
+        mixed $errors = null,
+        ?string $errorCode = null,
+        mixed $data = null,
+    ): self {
+        $body = [
             'success' => false,
             'message' => $message,
             'code' => $statusCode,
-            'errors' => $errors
-        ], $statusCode);
+            'errors' => $errors,
+            'error_code' => self::resolveErrorCode($errorCode, $statusCode, $errors),
+        ];
+        if ($data !== null) {
+            $body['data'] = $data;
+        }
+
+        return new self($body, $statusCode);
+    }
+
+    /**
+     * Error with required machine `error_code` (Web API / Nuxt).
+     */
+    public static function errorWithCode(
+        string $errorCode,
+        string $message,
+        int $statusCode = HttpStatus::BAD_REQUEST,
+        mixed $errors = null,
+        mixed $data = null,
+    ): self {
+        return self::error($message, $statusCode, $errors, $errorCode, $data);
     }
 
     /**
@@ -101,26 +133,40 @@ class Response
             $message = self::messageFromFieldErrors($fieldErrors);
         }
 
-        $data = null;
-        if (is_array($object)) {
-            $data = $object;
-            unset($data['code']);
-            if ($data === []) {
-                $data = null;
-            }
+        return self::error(
+            $message,
+            $status,
+            $fieldErrors,
+            $fieldErrors !== null ? ApiErrorCode::VALIDATION_FAILED : null,
+            self::dataFromProcessorObject($object),
+        );
+    }
+
+    /**
+     * Processor failure object minus transport-only `code`.
+     */
+    private static function dataFromProcessorObject(mixed $object): mixed
+    {
+        if (!is_array($object)) {
+            return null;
         }
 
-        $body = [
-            'success' => false,
-            'message' => $message,
-            'code' => $status,
-            'errors' => $fieldErrors,
-        ];
-        if ($data !== null) {
-            $body['data'] = $data;
+        $data = $object;
+        unset($data['code']);
+
+        return $data !== [] ? $data : null;
+    }
+
+    private static function resolveErrorCode(?string $errorCode, int $statusCode, mixed $errors = null): string
+    {
+        if ($errorCode !== null && $errorCode !== '') {
+            return $errorCode;
+        }
+        if (is_array($errors) && $errors !== []) {
+            return ApiErrorCode::VALIDATION_FAILED;
         }
 
-        return new self($body, $status);
+        return ApiErrorCode::fromHttpStatus($statusCode);
     }
 
     /**
@@ -204,6 +250,7 @@ class Response
         return in_array($code, [
             HttpStatus::BAD_REQUEST,
             HttpStatus::UNAUTHORIZED,
+            HttpStatus::FORBIDDEN,
             HttpStatus::NOT_FOUND,
             HttpStatus::CONFLICT,
             HttpStatus::UNPROCESSABLE_ENTITY,

--- a/core/components/minishop3/tests/ResponseFromProcessorTest.php
+++ b/core/components/minishop3/tests/ResponseFromProcessorTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 
@@ -149,6 +150,15 @@ if ($unauth->getStatusCode() !== HttpStatus::UNAUTHORIZED) {
 }
 if (($unauth->getData()['code'] ?? null) !== HttpStatus::UNAUTHORIZED) {
     $fail('Response::error body must include code 401');
+}
+if (($unauth->getData()['error_code'] ?? null) !== ApiErrorCode::UNAUTHORIZED) {
+    $fail('Response::error must include additive error_code');
+}
+if (($fieldError->getData()['error_code'] ?? null) !== ApiErrorCode::VALIDATION_FAILED) {
+    $fail('fromProcessor field errors must set error_code=validation_failed');
+}
+if (($throttle->getData()['error_code'] ?? null) !== ApiErrorCode::RATE_LIMITED) {
+    $fail('fromProcessor 429 must set error_code=rate_limited');
 }
 
 fwrite(STDOUT, "OK ResponseFromProcessorTest\n");

--- a/core/components/minishop3/tests/TokenMiddlewarePublicRoutesTest.php
+++ b/core/components/minishop3/tests/TokenMiddlewarePublicRoutesTest.php
@@ -67,12 +67,36 @@ if (str_contains($middlewareSrc, "lexicon('ms3_err_token_invalid')")) {
     $fail('TokenMiddleware must return raw key ms3_err_token_invalid (ApiClient contract)');
 }
 
-if (!str_contains($middlewareSrc, "Response::error('ms3_err_token_invalid'")) {
-    $fail('TokenMiddleware must Response::error with raw ms3_err_token_invalid');
+if (
+    !str_contains($middlewareSrc, "'ms3_err_token_invalid'")
+    && !str_contains($middlewareSrc, '"ms3_err_token_invalid"')
+) {
+    $fail('TokenMiddleware must pass raw ms3_err_token_invalid as message');
 }
 
-if (!str_contains($middlewareSrc, "Response::error('ms3_customer_err_token_create'")) {
+if (
+    !str_contains($middlewareSrc, "ApiErrorCode::TOKEN_INVALID")
+    && !str_contains($middlewareSrc, "Response::error('ms3_err_token_invalid'")
+) {
+    $fail('TokenMiddleware must expose token_invalid via errorWithCode or Response::error');
+}
+
+if (
+    !str_contains($middlewareSrc, "'ms3_customer_err_token_create'")
+    && !str_contains($middlewareSrc, '"ms3_customer_err_token_create"')
+) {
     $fail('TokenMiddleware mint failure must use ms3_customer_err_token_create');
+}
+
+if (!str_contains($middlewareSrc, 'ApiErrorCode::INTERNAL_ERROR')) {
+    $fail('TokenMiddleware mint failure must use internal_error (not token_required)');
+}
+
+if (
+    !str_contains($middlewareSrc, "'ms3_err_token_expired'")
+    && !str_contains($middlewareSrc, '"ms3_err_token_expired"')
+) {
+    $fail('TokenMiddleware expired path must keep raw ms3_err_token_expired');
 }
 
 fwrite(STDOUT, "OK TokenMiddlewarePublicRoutesTest\n");

--- a/core/components/minishop3/tests/WebApiErrorContractTest.php
+++ b/core/components/minishop3/tests/WebApiErrorContractTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Web API error envelope contract (#572).
+ *
+ * Run: php tests/WebApiErrorContractTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Router\ApiErrorCode;
+use MiniShop3\Router\DomainMs2Response;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+// Address create pattern: Response object keeps HTTP 201
+$created = Response::success(['id' => 1], 'created', HttpStatus::CREATED);
+if ($created->getStatusCode() !== HttpStatus::CREATED) {
+    $fail('create address must preserve HTTP 201 on Response object');
+}
+if (($created->getData()['success'] ?? false) !== true) {
+    $fail('create success envelope broken');
+}
+
+// Product 404 → code + error_code
+$notFound = Response::error('not found', HttpStatus::NOT_FOUND);
+if ($notFound->getStatusCode() !== HttpStatus::NOT_FOUND) {
+    $fail('product 404 status');
+}
+$body = $notFound->getData();
+if (($body['code'] ?? null) !== HttpStatus::NOT_FOUND) {
+    $fail('product 404 body code');
+}
+if (($body['error_code'] ?? null) !== ApiErrorCode::NOT_FOUND) {
+    $fail('product 404 error_code must be not_found');
+}
+
+// Profile validation → top-level errors + 422 + validation_failed
+$validation = Response::errorWithCode(
+    ApiErrorCode::VALIDATION_FAILED,
+    'validation failed',
+    HttpStatus::UNPROCESSABLE_ENTITY,
+    ['email' => ['Invalid email']],
+    ['errors' => ['email' => ['Invalid email']]],
+);
+$vBody = $validation->getData();
+if ($validation->getStatusCode() !== HttpStatus::UNPROCESSABLE_ENTITY) {
+    $fail('profile validation HTTP must be 422');
+}
+if (($vBody['error_code'] ?? null) !== ApiErrorCode::VALIDATION_FAILED) {
+    $fail('profile validation error_code');
+}
+if (($vBody['errors']['email'][0] ?? null) !== 'Invalid email') {
+    $fail('profile validation top-level errors');
+}
+if (($vBody['data']['errors']['email'][0] ?? null) !== 'Invalid email') {
+    $fail('profile validation BC data.errors mirror');
+}
+
+// Cart/order domain: business_rule + payload in data (not errors)
+$cartFail = Response::errorWithCode(
+    ApiErrorCode::BUSINESS_RULE,
+    'cart rule',
+    HttpStatus::BAD_REQUEST,
+    null,
+    ['status' => 'empty'],
+);
+$cBody = $cartFail->getData();
+if (($cBody['error_code'] ?? null) !== ApiErrorCode::BUSINESS_RULE) {
+    $fail('cart domain error_code');
+}
+if (!array_key_exists('errors', $cBody) || $cBody['errors'] !== null) {
+    $fail('cart domain must keep errors null');
+}
+if (($cBody['data']['status'] ?? null) !== 'empty') {
+    $fail('cart domain payload must live in data');
+}
+
+// Domain MS2 transform: lift data.errors → top-level errors + 422
+$orderValidation = DomainMs2Response::failure(
+    'validation failed',
+    ['order' => ['id' => 1], 'errors' => ['email' => 'Required']],
+);
+$ov = $orderValidation->getData();
+if ($orderValidation->getStatusCode() !== HttpStatus::UNPROCESSABLE_ENTITY) {
+    $fail('domain field map must be HTTP 422');
+}
+if (($ov['error_code'] ?? null) !== ApiErrorCode::VALIDATION_FAILED) {
+    $fail('domain field map error_code');
+}
+if (($ov['errors']['email'] ?? null) !== 'Required') {
+    $fail('domain field map must lift to top-level errors');
+}
+if (isset($ov['data']['errors'])) {
+    $fail('lifted field map must not remain in data.errors');
+}
+if (($ov['data']['order']['id'] ?? null) !== 1) {
+    $fail('domain context must remain in data');
+}
+
+$orderNotFound = DomainMs2Response::failure('ms3_err_order_nf', null);
+if ($orderNotFound->getStatusCode() !== HttpStatus::NOT_FOUND) {
+    $fail('domain _nf message must map to HTTP 404');
+}
+if (($orderNotFound->getData()['error_code'] ?? null) !== ApiErrorCode::NOT_FOUND) {
+    $fail('domain not found error_code');
+}
+
+// Conflict: existing_id in data
+$conflict = Response::errorWithCode(
+    ApiErrorCode::CONFLICT,
+    'exists',
+    HttpStatus::CONFLICT,
+    null,
+    ['existing_id' => 42],
+);
+if ($conflict->getStatusCode() !== HttpStatus::CONFLICT) {
+    $fail('address conflict status');
+}
+if (($conflict->getData()['data']['existing_id'] ?? null) !== 42) {
+    $fail('address conflict existing_id in data');
+}
+if (!array_key_exists('errors', $conflict->getData()) || $conflict->getData()['errors'] !== null) {
+    $fail('conflict must not stuff payload into errors');
+}
+
+// Token / rate-limit machine codes
+$tokenExpired = Response::errorWithCode(
+    ApiErrorCode::TOKEN_EXPIRED,
+    'ms3_err_token_expired',
+    HttpStatus::UNAUTHORIZED
+);
+if (($tokenExpired->getData()['error_code'] ?? null) !== ApiErrorCode::TOKEN_EXPIRED) {
+    $fail('token_expired error_code');
+}
+
+$rateLimited = Response::errorWithCode(
+    ApiErrorCode::RATE_LIMITED,
+    'ms3_err_rate_limit',
+    HttpStatus::TOO_MANY_REQUESTS
+);
+if ($rateLimited->getStatusCode() !== HttpStatus::TOO_MANY_REQUESTS) {
+    $fail('rate limit status');
+}
+if (($rateLimited->getData()['error_code'] ?? null) !== ApiErrorCode::RATE_LIMITED) {
+    $fail('rate_limited error_code');
+}
+
+// ApiErrorCode::fromHttpStatus mapping
+$maps = [
+    HttpStatus::UNAUTHORIZED => ApiErrorCode::UNAUTHORIZED,
+    HttpStatus::FORBIDDEN => ApiErrorCode::FORBIDDEN,
+    HttpStatus::NOT_FOUND => ApiErrorCode::NOT_FOUND,
+    HttpStatus::CONFLICT => ApiErrorCode::CONFLICT,
+    HttpStatus::TOO_MANY_REQUESTS => ApiErrorCode::RATE_LIMITED,
+    HttpStatus::UNPROCESSABLE_ENTITY => ApiErrorCode::VALIDATION_FAILED,
+    HttpStatus::BAD_REQUEST => ApiErrorCode::BAD_REQUEST,
+    HttpStatus::INTERNAL_SERVER_ERROR => ApiErrorCode::INTERNAL_ERROR,
+];
+foreach ($maps as $status => $expected) {
+    if (ApiErrorCode::fromHttpStatus($status) !== $expected) {
+        $fail("fromHttpStatus({$status}) expected {$expected}");
+    }
+}
+
+fwrite(STDOUT, "OK WebApiErrorContractTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Единый success/error envelope Web API `/api/v1` для TypeScript/Nuxt: HTTP status больше не теряется через `->getData()`, field errors живут в top-level `errors`, additive `error_code` (snake_case).

Envelope `#341` сохранён. Nested `{ error: {…} }` не вводим.

### Ключевые изменения

- `ApiErrorCode` + `Response::error` / `errorWithCode` / `fromProcessor` с `error_code`
- Web-контроллеры возвращают `Response` (create address → HTTP 201)
- Profile validation → top-level `errors` + HTTP 422 + зеркало `data.errors` (BC)
- Address conflict: `existing_id` в `data`; list → `{items, total}`
- Orders list: additive `items` (= `orders`)
- Cart/Order: `DomainMs2Response` поднимает field map в `errors`/422, `_nf` → 404, иначе `business_rule`
- Token/RateLimit middleware: `token_expired` / `token_invalid` / `rate_limited`; mint fail → 500/`internal_error`

## Тип изменений

- [x] Новая функциональность (non-breaking change)
- [x] Breaking change (частично: addresses list shape, conflict payload path, HTTP 201/404/422 точнее)

## Связанные Issues

Closes #572

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0
composer stan     # exit 0
php tests/WebApiErrorContractTest.php
php tests/ResponseFromProcessorTest.php
```

- [x] Автоматические тесты (`composer ci:php`, `composer stan`)
- [ ] Ручное тестирование против live MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-572-web-api-error-contract`
- PHP: 8.4

## Чеклист

- [x] Код соответствует стилю проекта
- [x] PHPStan проходит без новых ошибок
- [x] Лексиконы не требовались (machine codes + существующие ключи)
- [ ] CHANGELOG.md — на релизе (по политике репо)

## Wire contract (кратко)

| Ситуация | HTTP | error_code |
|----------|------|------------|
| validation fields | 422 | validation_failed |
| auth / token | 401 | unauthorized / token_* |
| not found | 404 | not_found |
| conflict | 409 | conflict |
| rate limit | 429 | rate_limited |
| cart/order domain | 400 | business_rule |
| mint token fail | 500 | internal_error |

Success: `{ success, message, data }` — без изменений ключей.

## Дополнительные заметки

- Addresses: `data` был голым массивом → `{items,total}` (breaking для клиентов с `Array.isArray(data)`).
- Conflict: `errors.existing_id` → `data.existing_id`.
- Email verify success при сбое session bind (token:null) оставлен как pre-existing UX (#226); machine codes для verification token не пересекаются с API `token_*`.
- Docs на docs.modx.pro можно синхронизировать отдельно.