### PR TITLE
feat(grid): фильтрация товаров категории по relation-колонкам

### DIFF
--- a/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
@@ -226,6 +226,13 @@ final class CategoryProductsListService
             }
         }
 
+        foreach ($relationSpecs as $spec) {
+            $paramKey = 'filter_' . $spec->fieldName;
+            if (isset($params[$paramKey]) && $params[$paramKey] !== '') {
+                $c->where([$spec->sortExpression() . ':LIKE' => "%{$params[$paramKey]}%"]);
+            }
+        }
+
         if (!isset($params['deleted']) || $params['deleted'] === '') {
             $c->where(['msProduct.deleted' => 0]);
         }

--- a/core/components/minishop3/tests/CategoryProductsRelationFilterTest.php
+++ b/core/components/minishop3/tests/CategoryProductsRelationFilterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * #582: relation column filters use filter_{field} (PHP + Vue grid contract).
+ *
+ * Run: php tests/CategoryProductsRelationFilterTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$listSrc = file_get_contents(__DIR__ . '/../src/Services/Category/CategoryProductsListService.php');
+$vueSrc = file_get_contents(__DIR__ . '/../../../../vueManager/src/components/CategoryProductsGrid.vue');
+
+if ($listSrc === false) {
+    $fail('unable to read CategoryProductsListService.php');
+}
+if ($vueSrc === false) {
+    $fail('unable to read CategoryProductsGrid.vue');
+}
+
+if (!str_contains($listSrc, 'foreach ($optionSpecs as $spec)')) {
+    $fail('optionSpecs filter loop missing (regression)');
+}
+
+if (!preg_match(
+    '/foreach\s*\(\s*\$relationSpecs\s+as\s+\$spec\s*\)\s*\{[^}]*filter_[^}]*sortExpression\(\)[^}]*:LIKE/s',
+    $listSrc
+)) {
+    $fail('relationSpecs foreach must apply filter_{field} via sortExpression() LIKE');
+}
+
+// Manager grid must prefix both option and relation filters for the backend contract.
+if (!preg_match(
+    "/col\.type\s*===\s*'option'\s*\|\|\s*col\.type\s*===\s*'relation'/",
+    $vueSrc
+) || !str_contains($vueSrc, 'filter_${key}')) {
+    $fail('CategoryProductsGrid must send filter_{key} for option and relation columns');
+}
+
+fwrite(STDOUT, "OK CategoryProductsRelationFilterTest\n");
+exit(0);

--- a/core/components/minishop3/tests/RelationColumnSpecTest.php
+++ b/core/components/minishop3/tests/RelationColumnSpecTest.php
@@ -63,6 +63,11 @@ $assertSame(
     $spec->selectExpression(),
     'vendor select expression'
 );
+$assertSame(
+    '`rel_msVendor_vendor_id`.address',
+    $spec->sortExpression(),
+    'vendor sort/filter expression'
+);
 
 $assertNull(
     RelationColumnSpec::fromGroupField($group, [

--- a/vueManager/src/components/CategoryProductsGrid.vue
+++ b/vueManager/src/components/CategoryProductsGrid.vue
@@ -143,7 +143,7 @@ async function loadProducts() {
         nested: nested.value ? 1 : 0,
       }
 
-      // Apply filter values. Option-type columns are JOIN-ed at runtime — backend
+      // Apply filter values. Option/relation columns are JOIN-ed at runtime — backend
       // reads their filters as `filter_{fieldName}` (see CategoryProductsListService).
       // Builtin product/data filters keep the original direct-param contract.
       Object.keys(filterValues.value).forEach(key => {
@@ -152,7 +152,7 @@ async function loadProducts() {
           return
         }
         const col = columns.value.find(c => c.name === key)
-        if (col && col.type === 'option') {
+        if (col && (col.type === 'option' || col.type === 'relation')) {
           params[`filter_${key}`] = value
         } else {
           params[key] = value


### PR DESCRIPTION
## Описание

В гриде товаров категории relation-колонки уже JOIN/SELECT/sort, но `filter_{fieldName}` обрабатывался только для option. Фильтр по адресу вендора и подобным полям молча игнорировался.

Теперь `CategoryProductsListService` применяет LIKE по display-полю связанной таблицы (тот же JOIN и `sortExpression()`, что для сортировки). `CategoryProductsGrid` шлёт `filter_*` и для `type === 'relation'`.

## Тип изменений

- [x] Новая функциональность (non-breaking change)

## Связанные Issues

Closes #582

## Как это было протестировано?

Gate E:

```bash
php -l core/components/minishop3/src/Services/Category/CategoryProductsListService.php
# exit 0
php core/components/minishop3/tests/RelationColumnSpecTest.php
# OK, exit 0
php core/components/minishop3/tests/CategoryProductsRelationFilterTest.php
# OK (red-green: FAIL без PHP-цикла), exit 0
cd core/components/minishop3 && composer test:smoke
# OK smoke tests (77), exit 0
cd vueManager && npx eslint src/components/CategoryProductsGrid.vue
# exit 0
```

- [x] Автоматические тесты (`composer test:smoke`, focused smoke, eslint path)
- [ ] Ручное тестирование в Manager (фильтр по relation-колонке после очистки кэша)

**Конфигурация тестирования:**
- MiniShop3: ветка `feat/issue-582-relation-column-filter` от `beta`
- PHP: 8.x локально

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы не нужны (без новых UI-строк)
- [ ] PHPStan — CI job
- [x] ESLint по затронутому Vue-файлу
- [ ] CHANGELOG — не трогали (релизный процесс)

## Дополнительные заметки

Review: Vue-префикс `filter_` для relation был обязателен; без него PHP-only не закрывал симптом из #328. Source-contract smoke для PHP+Vue — в духе существующих smoke-тестов репозитория.