### PR TITLE
perf(web-api): ускорение product/list (Data prefetch, COUNT, content)

### DIFF
--- a/core/components/minishop3/src/Services/Product/ProductCatalogService.php
+++ b/core/components/minishop3/src/Services/Product/ProductCatalogService.php
@@ -211,20 +211,21 @@ class ProductCatalogService
         $total = $this->countList($params);
 
         $listQuery = $this->buildListQuery($params);
+        $this->applyListSelect($listQuery, $includeContent);
         $this->applySort($listQuery, $params);
         $listQuery->limit($limit, $offset);
 
-        /** @var list<msProduct> $products */
+        /** @var array<int|string, msProduct> $products */
         $products = $this->modx->getCollection(msProduct::class, $listQuery) ?: [];
+        $productList = array_values($products);
+        $ids = $this->prefetchAndAttachProductData($productList);
 
-        $optionsByProduct = [];
-        if ($includeOptions && $products !== []) {
-            $ids = array_map(static fn (msProduct $p) => (int) $p->get('id'), array_values($products));
-            $optionsByProduct = $this->loadOptionsForProducts($ids);
-        }
+        $optionsByProduct = ($includeOptions && $ids !== [])
+            ? $this->loadOptionsForProducts($ids)
+            : [];
 
         $items = [];
-        foreach ($products as $product) {
+        foreach ($productList as $product) {
             $productId = (int) $product->get('id');
             $options = $includeOptions ? ($optionsByProduct[$productId] ?? []) : null;
             $items[] = $this->formatProduct($product, $includeContent, $options);
@@ -269,7 +270,8 @@ class ProductCatalogService
     private function countList(array $params): int
     {
         $countQuery = $this->buildListQuery($params);
-        $countQuery->select('COUNT(DISTINCT msProduct.id)');
+        // 1:1 join on Data — DISTINCT is unnecessary until many-joins are added.
+        $countQuery->select('COUNT(msProduct.id)');
         if (!$countQuery->prepare() || !$countQuery->stmt->execute()) {
             return 0;
         }
@@ -305,6 +307,60 @@ class ProductCatalogService
         }
 
         return $c;
+    }
+
+    /**
+     * Limit selected resource columns; skip content blob on PLP when not requested.
+     * Same pattern as ms3_products snippet.
+     */
+    private function applyListSelect(xPDOQuery $query, bool $includeContent): void
+    {
+        $query->select(
+            $includeContent
+                ? $this->modx->getSelectColumns(msProduct::class, 'msProduct')
+                : $this->modx->getSelectColumns(msProduct::class, 'msProduct', '', ['content'], true)
+        );
+    }
+
+    /**
+     * Batch-load msProductData and attach via addOne so loadData() skips getOne N+1.
+     *
+     * List query already JOINs Data for WHERE/ORDER only (no related hydrate from that JOIN).
+     * One IN-query here is O(1) vs L× getOne; total SQL ≈ count + list + data (+ options).
+     *
+     * @param list<msProduct> $products
+     * @return list<int>
+     */
+    private function prefetchAndAttachProductData(array $products): array
+    {
+        $byId = [];
+        foreach ($products as $product) {
+            $id = (int) $product->get('id');
+            if ($id > 0) {
+                $byId[$id] = $product;
+            }
+        }
+
+        if ($byId === []) {
+            return [];
+        }
+
+        $ids = array_keys($byId);
+        $c = $this->modx->newQuery(msProductData::class);
+        $c->where(['id:IN' => $ids]);
+
+        /** @var msProductData $data */
+        foreach ($this->modx->getCollection(msProductData::class, $c) ?: [] as $data) {
+            $id = (int) $data->get('id');
+            if (!isset($byId[$id])) {
+                continue;
+            }
+            // addOne requires a by-ref argument (xPDO signature).
+            $attached = $data;
+            $byId[$id]->addOne($attached, 'Data');
+        }
+
+        return $ids;
     }
 
     /**

--- a/core/components/minishop3/tests/ProductCatalogPerfTest.php
+++ b/core/components/minishop3/tests/ProductCatalogPerfTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * #575: ProductCatalogService list avoids N+1 Data and useless COUNT DISTINCT.
+ *
+ * Run: php tests/ProductCatalogPerfTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$src = file_get_contents(__DIR__ . '/../src/Services/Product/ProductCatalogService.php');
+$modelSrc = file_get_contents(__DIR__ . '/../src/Model/msProduct.php');
+if ($src === false || $modelSrc === false) {
+    $fail('unable to read source files');
+}
+
+if (str_contains($modelSrc, 'function attachData')) {
+    $fail('do not add attachData on msProduct — use addOne($data, \'Data\')');
+}
+
+if (!str_contains($src, "addOne(\$attached, 'Data')") && !str_contains($src, 'addOne($attached, "Data")')) {
+    $fail('prefetch must attach Data via addOne(..., Data)');
+}
+
+if (!str_contains($src, "where(['id:IN'")) {
+    $fail('Data prefetch must use id:IN batch query');
+}
+
+if (str_contains($src, 'COUNT(DISTINCT msProduct.id)')) {
+    $fail('countList must not use COUNT(DISTINCT) for 1:1 Data join');
+}
+
+if (!str_contains($src, "select('COUNT(msProduct.id)')")) {
+    $fail('countList must COUNT(msProduct.id)');
+}
+
+if (!preg_match(
+    "/getSelectColumns\(\s*msProduct::class\s*,\s*'msProduct'\s*,\s*''\s*,\s*\['content'\]\s*,\s*true\s*\)/",
+    $src
+)) {
+    $fail('include_content=0 must exclude content via getSelectColumns(..., [content], true)');
+}
+
+// Prefetch must run on getList path before format (batch, not per-row getOne).
+if (!preg_match('/function getList[\s\S]*?id:IN[\s\S]*?formatProduct/m', $src)
+    && !preg_match('/function getList[\s\S]*?prefetchAndAttachProductData[\s\S]*?formatProduct/m', $src)
+) {
+    $fail('getList must batch-load Data before formatProduct');
+}
+
+fwrite(STDOUT, "OK ProductCatalogPerfTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Hot path `GET /api/v1/product/list` больше не делает N× `getOne('Data')` на страницу.

- После `getCollection` — один batch `msProductData` (`id:IN`) + `addOne(..., 'Data')`, чтобы `loadData()` брал кэш.
- `COUNT(msProduct.id)` вместо `COUNT(DISTINCT …)` при 1:1 JOIN.
- При `include_content=0` list-select исключает колонку `content` (как `ms3_products`).
- Хуки `msOnGetProductPrice|Weight|Fields` и JSON-контракт без изменений.

## Тип изменений

- [x] Исправление бага / tech-debt (non-breaking)
- [x] Другое: performance

## Связанные Issues

Closes #575

## Как это было протестировано?

Gate E:

```bash
php -l src/Services/Product/ProductCatalogService.php   # exit 0
php tests/ProductCatalogServiceTest.php                 # OK
php tests/ProductCatalogPerfTest.php                    # OK
composer stan -- src/Services/Product/ProductCatalogService.php  # OK
composer test:smoke                                     # OK (includes new perf smoke)
```

- [x] Автоматические тесты
- [ ] Ручной bench на живой БД (опционально в issue)

**Конфигурация:** ветка от `beta`, PHP 8.x

## Чеклист

- [x] JSON list/get без breaking changes
- [x] Лексиконы не нужны
- [x] PHPStan локально по затронутому файлу — OK
- [ ] CHANGELOG — не трогали

## Дополнительные заметки

JOIN Data в list-query по-прежнему для WHERE/ORDER; hydrate related из JOIN в xPDO `getCollection` нет, поэтому отдельный IN-prefetch в бюджете AC (≈2–4 SQL: count + list + data). Runtime query-counter на stub xPDO — follow-up к #574.