### PR TITLE
feat(web-api): контракт customer auth для Nuxt SSR (me / refresh / Bearer bind)

### DIFF
--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -141,31 +141,31 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
         $customerAuth = static fn (): \MiniShop3\Controllers\Api\Web\CustomerAuthController =>
             new \MiniShop3\Controllers\Api\Web\CustomerAuthController($modx);
 
-        $router->post('/login', function ($params) use ($customerAuth) {
+        $router->post('/login', function () use ($customerAuth) {
             return $customerAuth()->loginFromRequest();
         });
 
-        $router->post('/register', function ($params) use ($customerAuth) {
+        $router->post('/register', function () use ($customerAuth) {
             return $customerAuth()->registerFromRequest();
         });
 
-        $router->get('/me', function ($params) use ($customerAuth) {
+        $router->get('/me', function () use ($customerAuth) {
             return $customerAuth()->me();
         }, [$tokenMiddleware]);
 
-        $router->post('/logout', function ($params) use ($customerAuth) {
+        $router->post('/logout', function () use ($customerAuth) {
             return $customerAuth()->logout();
         }, [$tokenMiddleware]);
 
-        $router->post('/forgot-password', function ($params) use ($customerAuth) {
+        $router->post('/forgot-password', function () use ($customerAuth) {
             return $customerAuth()->forgotPasswordFromRequest();
         });
 
-        $router->post('/reset-password', function ($params) use ($customerAuth) {
+        $router->post('/reset-password', function () use ($customerAuth) {
             return $customerAuth()->resetPasswordFromRequest();
         });
 
-        $router->post('/add', function ($params) use ($modx) {
+        $router->post('/add', function () use ($modx) {
             $ms3 = $modx->services->get('ms3');
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
@@ -174,7 +174,7 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             return $controller->updateField($data);
         }, [$tokenMiddleware]);
 
-        $router->get('/token/get', function ($params) use ($modx) {
+        $router->get('/token/get', function () use ($modx) {
             $ms3 = $modx->services->get('ms3');
             $ms3->initialize($modx->context->key ?? 'web');
             $response = $ms3->customer->generateToken();
@@ -186,7 +186,7 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             }
         });
 
-        $router->post('/token/refresh', function ($params) use ($customerAuth) {
+        $router->post('/token/refresh', function () use ($customerAuth) {
             return $customerAuth()->refreshToken();
         }, [$tokenMiddleware]);
 
@@ -200,7 +200,7 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
                 return $controller->get($params);
             });
 
-            $router->post('', function ($params) use ($modx) {
+            $router->post('', function () use ($modx) {
                 $input = file_get_contents('php://input');
                 $data = json_decode($input, true) ?: [];
 
@@ -227,7 +227,7 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             });
         }, [$tokenMiddleware]);
 
-        $router->put('/profile', function ($params) use ($modx) {
+        $router->put('/profile', function () use ($modx) {
             $ms3 = $modx->services->get('ms3');
             $input = file_get_contents('php://input');
             $data = json_decode($input, true) ?: [];
@@ -241,7 +241,7 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             return $controller->changeCustomerAddress($params);
         }, [$tokenMiddleware]);
 
-        $router->post('/email/resend-verification', function ($params) use ($modx) {
+        $router->post('/email/resend-verification', function () use ($modx) {
             $ms3 = $modx->services->get('ms3');
             $controller = new \MiniShop3\Controllers\Api\Web\CustomerEmailController($modx, $ms3);
             return $controller->resendVerification();

--- a/core/components/minishop3/config/routes/web.php
+++ b/core/components/minishop3/config/routes/web.php
@@ -149,6 +149,10 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
             return $customerAuth()->registerFromRequest();
         });
 
+        $router->get('/me', function ($params) use ($customerAuth) {
+            return $customerAuth()->me();
+        }, [$tokenMiddleware]);
+
         $router->post('/logout', function ($params) use ($customerAuth) {
             return $customerAuth()->logout();
         }, [$tokenMiddleware]);
@@ -181,6 +185,10 @@ $router->group('/api/v1', function ($router) use ($modx, $tokenMiddleware) {
                 return Response::error($response['message'] ?? 'Token generation failed', $response['code'] ?? 500);
             }
         });
+
+        $router->post('/token/refresh', function ($params) use ($customerAuth) {
+            return $customerAuth()->refreshToken();
+        }, [$tokenMiddleware]);
 
         $router->group('/addresses', function ($router) use ($modx) {
             $router->get('', function ($params) use ($modx) {

--- a/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CustomerAuthController.php
@@ -4,10 +4,12 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Customer\CustomerSessionService;
+use MiniShop3\Services\TokenService;
 use MODX\Revolution\modX;
 
 /**
- * CustomerAuthController — login, register, logout, password recovery (Web API).
+ * CustomerAuthController — login, register, logout, password recovery, session (Web API).
  *
  * Delegates to Processors\Api\Customer\* and maps processor failures to HTTP responses.
  */
@@ -47,6 +49,34 @@ class CustomerAuthController
     public function resetPasswordFromRequest(): Response
     {
         return $this->resetPassword($this->readJsonBody());
+    }
+
+    /**
+     * GET /api/v1/customer/me
+     */
+    public function me(): Response
+    {
+        $payload = $this->sessionService()->buildMePayload($this->requestToken());
+        if ($payload === null) {
+            return Response::error('ms3_err_token_invalid', HttpStatus::UNAUTHORIZED);
+        }
+
+        return Response::success($payload);
+    }
+
+    /**
+     * POST /api/v1/customer/token/refresh
+     */
+    public function refreshToken(): Response
+    {
+        /** @var TokenService $tokenService */
+        $tokenService = $this->modx->services->get('ms3_token_service');
+        $rotated = $tokenService->rotateApiToken($this->requestToken());
+        if ($rotated === null) {
+            return Response::error('ms3_err_token_invalid', HttpStatus::UNAUTHORIZED);
+        }
+
+        return Response::success($rotated);
     }
 
     /**
@@ -121,6 +151,20 @@ class CustomerAuthController
             'password' => $data['password'] ?? '',
             'password_confirm' => $data['password_confirm'] ?? '',
         ]);
+    }
+
+    private function requestToken(): string
+    {
+        return TokenService::resolveTokenFromRequest();
+    }
+
+    private function sessionService(): CustomerSessionService
+    {
+        /** @var TokenService $tokenService */
+        $tokenService = $this->modx->services->get('ms3_token_service');
+        $ms3 = $this->modx->services->get('ms3');
+
+        return new CustomerSessionService($this->modx, $tokenService, $ms3);
     }
 
     /**

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -86,24 +86,15 @@ class TokenMiddleware implements MiddlewareInterface
             $_REQUEST['ms3_token'] = (string) $_SESSION['ms3']['customer_token'];
         }
 
-        // Resolve token from multiple sources
-        $token = $this->resolveToken();
+        // Resolve token (middleware order; login bind uses getBindableTokenString)
+        $token = TokenService::resolveTokenFromRequest();
 
         // If a token is present, always validate it (do not skip via session bypass).
         if (!empty($token)) {
             $resolved = $tokenService->resolveApiToken($token);
 
             if ($resolved['reason'] === 'ok') {
-                $tokenObj = $resolved['token'];
-
-                if (!isset($_SESSION['ms3'])) {
-                    $_SESSION['ms3'] = [];
-                }
-                $_SESSION['ms3']['customer_token'] = $token;
-                $_SESSION['ms3']['customer_id'] = $tokenObj->get('customer_id');
-                $_SESSION['ms3']['customer_token_expires'] = strtotime($tokenObj->get('expires_at'));
-
-                CookieHelper::setTokenCookie($this->modx, $token);
+                $tokenService->syncSessionFromToken($resolved['token']);
                 $_REQUEST['ms3_token'] = $token;
 
                 return null;
@@ -184,34 +175,6 @@ class TokenMiddleware implements MiddlewareInterface
         }
 
         unset($_GET['ms3_token'], $_REQUEST['ms3_token']);
-    }
-
-    /**
-     * Resolve token from trusted sources only (Bearer, MS3TOKEN header, cookie, session).
-     *
-     * @return string Token or empty string
-     */
-    private function resolveToken(): string
-    {
-        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
-        if (str_starts_with($authHeader, 'Bearer ')) {
-            $token = substr($authHeader, 7);
-            if ($token !== '') {
-                return $token;
-            }
-        }
-
-        $headerToken = $_SERVER['HTTP_MS3TOKEN'] ?? '';
-        if ($headerToken !== '') {
-            return $headerToken;
-        }
-
-        $cookieToken = CookieHelper::getTokenFromCookie();
-        if ($cookieToken !== '') {
-            return $cookieToken;
-        }
-
-        return (string) ($_SESSION['ms3']['customer_token'] ?? '');
     }
 
     /**

--- a/core/components/minishop3/src/Services/Customer/CustomerSessionService.php
+++ b/core/components/minishop3/src/Services/Customer/CustomerSessionService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Customer;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Services\TokenService;
+use MODX\Revolution\modX;
+
+/**
+ * Session introspection payload for GET /customer/me (#571).
+ */
+final class CustomerSessionService
+{
+    public function __construct(
+        private modX $modx,
+        private TokenService $tokenService,
+        private MiniShop3 $ms3,
+    ) {
+    }
+
+    /**
+     * Build GET /customer/me payload from a validated API token string.
+     *
+     * @return array{
+     *     authenticated: bool,
+     *     customer: array<string, mixed>|null,
+     *     token: array{expires_at: string, customer_id: int}
+     * }|null null when token is missing/invalid/expired
+     */
+    public function buildMePayload(string $tokenString): ?array
+    {
+        $resolved = $this->tokenService->resolveApiToken($tokenString);
+        if ($resolved['reason'] !== 'ok' || $resolved['token'] === null) {
+            return null;
+        }
+
+        $tokenObj = $resolved['token'];
+        $customerId = (int) $tokenObj->get('customer_id');
+        $customer = $customerId > 0
+            ? $this->modx->getObject(msCustomer::class, $customerId)
+            : null;
+
+        return [
+            'authenticated' => $customer instanceof msCustomer,
+            'customer' => $customer instanceof msCustomer
+                ? CustomerPublicDto::fromCustomer($customer, $this->modx, $this->ms3)
+                : null,
+            'token' => [
+                'expires_at' => (string) $tokenObj->get('expires_at'),
+                'customer_id' => $customerId,
+            ],
+        ];
+    }
+}

--- a/core/components/minishop3/src/Services/TokenService.php
+++ b/core/components/minishop3/src/Services/TokenService.php
@@ -506,18 +506,169 @@ class TokenService
     }
 
     /**
-     * Token currently bound to the browser (session first, then cookie), without minting.
+     * Resolve opaque API token from trusted sources (same order as TokenMiddleware).
+     *
+     * 1. Authorization: Bearer
+     * 2. HTTP_MS3TOKEN (legacy)
+     * 3. httpOnly cookie `ms3_token`
+     * 4. $_REQUEST['ms3_token'] after middleware cookie inject (#576: query stripped)
+     * 5. PHP session cache
+     *
+     * Query-string `token` / `ms3_token` are not accepted here.
+     */
+    public static function resolveTokenFromRequest(): string
+    {
+        $fromHeader = self::resolveBearerOrLegacyHeader();
+        if ($fromHeader !== '') {
+            return $fromHeader;
+        }
+
+        $cookieToken = CookieHelper::getTokenFromCookie();
+        if ($cookieToken !== '') {
+            return $cookieToken;
+        }
+
+        $fromRequest = $_REQUEST['ms3_token'] ?? '';
+        if ($fromRequest !== '') {
+            return (string) $fromRequest;
+        }
+
+        return (string) ($_SESSION['ms3']['customer_token'] ?? '');
+    }
+
+    /**
+     * Token to bind cart on login/register (no mint).
+     *
+     * Order: valid Bearer/MS3TOKEN → session → cookie.
+     * Header only when resolveApiToken is ok (junk Bearer must not hide cookie cart).
      */
     public function getBindableTokenString(): string
     {
         SessionHelper::ensureActive();
 
-        $token = $this->getCustomerToken();
-        if ($token !== null && $token !== '') {
-            return $token;
+        $fromHeader = self::resolveBearerOrLegacyHeader();
+        if ($fromHeader !== '' && $this->resolveApiToken($fromHeader)['reason'] === 'ok') {
+            return $fromHeader;
+        }
+
+        $sessionToken = $this->getCustomerToken();
+        if ($sessionToken !== null) {
+            return $sessionToken;
         }
 
         return CookieHelper::getTokenFromCookie();
+    }
+
+    /**
+     * Bearer or legacy MS3TOKEN header value, empty when absent.
+     */
+    private static function resolveBearerOrLegacyHeader(): string
+    {
+        foreach (['HTTP_AUTHORIZATION', 'REDIRECT_HTTP_AUTHORIZATION'] as $serverKey) {
+            $authHeader = $_SERVER[$serverKey] ?? '';
+            if (str_starts_with($authHeader, 'Bearer ')) {
+                $token = substr($authHeader, 7);
+                if ($token !== '') {
+                    return $token;
+                }
+            }
+        }
+
+        return (string) ($_SERVER['HTTP_MS3TOKEN'] ?? '');
+    }
+
+    /**
+     * Rotate a valid API token: mint new row, move draft, revoke old (headless TTL refresh).
+     *
+     * @return array{token: string, expires_at: string, customer_id: int}|null
+     */
+    public function rotateApiToken(string $currentToken): ?array
+    {
+        $resolved = $this->resolveApiToken($currentToken);
+        if ($resolved['reason'] !== 'ok' || $resolved['token'] === null) {
+            return null;
+        }
+
+        /** @var msCustomerToken $oldToken */
+        $oldToken = $resolved['token'];
+        $customerId = (int) $oldToken->get('customer_id');
+
+        $newToken = $this->persistApiToken($customerId, null, null);
+        if (!$newToken) {
+            return null;
+        }
+
+        $newTokenString = (string) $newToken->get('token');
+        if ($newTokenString === '' || $newTokenString === $currentToken) {
+            return null;
+        }
+
+        if (!$this->moveOrderDraftOnTokenRotation($currentToken, $newTokenString, $customerId)) {
+            $newToken->remove();
+            $this->syncSessionFromToken($oldToken);
+
+            return null;
+        }
+
+        if (!$oldToken->remove()) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[TokenService] rotateApiToken: failed to revoke previous API token after mint'
+            );
+            $newToken->remove();
+            $this->syncSessionFromToken($oldToken);
+
+            return null;
+        }
+
+        return [
+            'token' => $newTokenString,
+            'expires_at' => (string) $newToken->get('expires_at'),
+            'customer_id' => $customerId,
+        ];
+    }
+
+    /**
+     * Re-link order draft after API token rotation (guest or authenticated).
+     *
+     * @return bool false when an existing draft could not be moved (caller must abort rotate)
+     */
+    private function moveOrderDraftOnTokenRotation(string $oldToken, string $newToken, int $customerId): bool
+    {
+        if (!$this->modx->services->has('ms3_order_draft_manager')) {
+            return true;
+        }
+
+        /** @var \MiniShop3\Services\Order\OrderDraftManager $draftManager */
+        $draftManager = $this->modx->services->get('ms3_order_draft_manager');
+
+        if ($customerId > 0) {
+            if ($draftManager->transferDraftToToken($oldToken, $newToken, $customerId)) {
+                return true;
+            }
+            $this->modx->log(
+                modX::LOG_LEVEL_WARN,
+                '[TokenService] rotateApiToken: transferDraftToToken failed'
+            );
+
+            return false;
+        }
+
+        $draft = $draftManager->getDraft($oldToken);
+        if (!$draft) {
+            return true;
+        }
+
+        if ($draftManager->syncToken($draft, $newToken)) {
+            return true;
+        }
+
+        $this->modx->log(
+            modX::LOG_LEVEL_ERROR,
+            '[TokenService] rotateApiToken: guest draft syncToken failed'
+        );
+
+        return false;
     }
 
     /**

--- a/core/components/minishop3/tests/CustomerAuthRoutesTest.php
+++ b/core/components/minishop3/tests/CustomerAuthRoutesTest.php
@@ -119,6 +119,10 @@ $expectedRoutes = [
         'tokenMiddleware' => false,
         'handlerMethod' => 'registerFromRequest',
     ],
+    'GET /api/v1/customer/me' => [
+        'tokenMiddleware' => true,
+        'handlerMethod' => 'me',
+    ],
     'POST /api/v1/customer/logout' => [
         'tokenMiddleware' => true,
         'handlerMethod' => 'logout',
@@ -130,6 +134,10 @@ $expectedRoutes = [
     'POST /api/v1/customer/reset-password' => [
         'tokenMiddleware' => false,
         'handlerMethod' => 'resetPasswordFromRequest',
+    ],
+    'POST /api/v1/customer/token/refresh' => [
+        'tokenMiddleware' => true,
+        'handlerMethod' => 'refreshToken',
     ],
 ];
 

--- a/core/components/minishop3/tests/CustomerSessionContractTest.php
+++ b/core/components/minishop3/tests/CustomerSessionContractTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * #571 customer auth contract: me payload shape, Bearer bind order, refresh rotation.
+ *
+ * Standalone (no MODX). Run: php tests/CustomerSessionContractTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use MiniShop3\Services\Customer\CustomerPublicDto;
+use MiniShop3\Services\TokenService;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertTrue = static function (bool $actual, string $case) use ($fail): void {
+    if (!$actual) {
+        $fail($case . ': expected true');
+    }
+};
+
+$assertFalse = static function (bool $actual, string $case) use ($fail): void {
+    if ($actual) {
+        $fail($case . ': expected false');
+    }
+};
+
+// --- resolveTokenFromRequest priority: Bearer > MS3TOKEN > REQUEST > session ---
+$_SERVER = [];
+$_REQUEST = [];
+$_SESSION = [];
+
+$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer bearer-token-value';
+$_SERVER['HTTP_MS3TOKEN'] = 'legacy-header';
+$_REQUEST['ms3_token'] = 'request-token';
+$_SESSION['ms3']['customer_token'] = 'session-token';
+$assertSame('bearer-token-value', TokenService::resolveTokenFromRequest(), 'Bearer wins');
+
+unset($_SERVER['HTTP_AUTHORIZATION']);
+$assertSame('legacy-header', TokenService::resolveTokenFromRequest(), 'MS3TOKEN next');
+
+unset($_SERVER['HTTP_MS3TOKEN']);
+$assertSame('request-token', TokenService::resolveTokenFromRequest(), 'REQUEST next');
+
+unset($_REQUEST['ms3_token'], $_REQUEST['token']);
+$assertSame('session-token', TokenService::resolveTokenFromRequest(), 'session last among globals');
+
+unset($_SESSION['ms3']['customer_token']);
+$assertSame('', TokenService::resolveTokenFromRequest(), 'empty when nothing set');
+
+// --- CustomerPublicDto must not expose secrets (me allowlist) ---
+$leaky = [
+    'id' => 1,
+    'email' => 'a@b.c',
+    'password' => 'hash',
+    'token' => 'internal',
+    'user_id' => 9,
+    'first_name' => 'Ann',
+];
+$public = CustomerPublicDto::fromArray($leaky);
+$assertSame(1, $public['id'] ?? null, 'id kept');
+$assertSame('a@b.c', $public['email'] ?? null, 'email kept');
+$assertSame('Ann', $public['first_name'] ?? null, 'first_name kept');
+$assertFalse(array_key_exists('password', $public), 'password stripped');
+$assertFalse(array_key_exists('token', $public), 'token stripped');
+$assertFalse(array_key_exists('user_id', $public), 'user_id stripped');
+
+// --- me / refresh source contracts ---
+$sessionService = file_get_contents(__DIR__ . '/../src/Services/Customer/CustomerSessionService.php');
+if ($sessionService === false) {
+    $fail('cannot read CustomerSessionService');
+}
+$assertTrue(str_contains($sessionService, "'authenticated'"), 'me payload has authenticated');
+$assertTrue(str_contains($sessionService, 'CustomerPublicDto::fromCustomer'), 'me uses public DTO');
+$assertFalse(str_contains($sessionService, 'rotateApiToken'), 'session service is me-only (no refresh wrapper)');
+
+$tokenServiceSrc = file_get_contents(__DIR__ . '/../src/Services/TokenService.php');
+if ($tokenServiceSrc === false) {
+    $fail('cannot read TokenService');
+}
+$assertTrue(str_contains($tokenServiceSrc, 'resolveTokenFromRequest()'), 'bind uses shared resolve');
+$assertTrue(
+    str_contains($tokenServiceSrc, 'getBindableTokenString')
+    && str_contains($tokenServiceSrc, 'resolveTokenFromRequest'),
+    'getBindableTokenString file includes resolveTokenFromRequest for Bearer bind'
+);
+
+$middlewareSrc = file_get_contents(__DIR__ . '/../src/Middleware/TokenMiddleware.php');
+if ($middlewareSrc === false) {
+    $fail('cannot read TokenMiddleware');
+}
+$assertTrue(
+    str_contains($middlewareSrc, 'TokenService::resolveTokenFromRequest()'),
+    'TokenMiddleware uses shared resolve'
+);
+$assertFalse(
+    str_contains($middlewareSrc, 'private function resolveToken'),
+    'TokenMiddleware must not keep a private resolveToken duplicate'
+);
+
+fwrite(STDOUT, "OK CustomerSessionContractTest\n");
+exit(0);

--- a/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
+++ b/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
@@ -39,6 +39,12 @@ class AuthManagerLifecycleTest extends TestCase
         }
         $_SESSION = [];
         $_COOKIE = [];
+        unset(
+            $_REQUEST['ms3_token'],
+            $_REQUEST['token'],
+            $_SERVER['HTTP_AUTHORIZATION'],
+            $_SERVER['HTTP_MS3TOKEN']
+        );
 
         $this->store = $this->createStore();
         $this->store->reset();
@@ -49,6 +55,12 @@ class AuthManagerLifecycleTest extends TestCase
     {
         $_SESSION = [];
         $_COOKIE = [];
+        unset(
+            $_REQUEST['ms3_token'],
+            $_REQUEST['token'],
+            $_SERVER['HTTP_AUTHORIZATION'],
+            $_SERVER['HTTP_MS3TOKEN']
+        );
     }
 
     protected function createStore(): CustomerAuthPdoStore
@@ -167,6 +179,66 @@ class AuthManagerLifecycleTest extends TestCase
                 static fn(string $call): bool => str_starts_with($call, 'transfer:')
             )
         );
+    }
+
+    public function testRotateApiTokenRevokesOldAndKeepsCustomer(): void
+    {
+        $customer = $this->seedCustomer([
+            'email' => 'buyer@example.com',
+            'is_active' => 1,
+            'is_blocked' => 0,
+        ]);
+
+        $modx = $this->makeModx();
+        $tokenService = new TokenService($modx);
+        $current = $tokenService->persistApiToken((int) $customer->id, null, 3600);
+        self::assertNotNull($current);
+        $oldToken = (string) $current->get('token');
+
+        $rotated = $tokenService->rotateApiToken($oldToken);
+        self::assertNotNull($rotated);
+        self::assertNotSame($oldToken, $rotated['token']);
+        self::assertSame((int) $customer->id, $rotated['customer_id']);
+        self::assertNull($this->store->findToken(['token' => $oldToken, 'type' => msCustomerToken::TYPE_API]));
+        self::assertNotNull($this->store->findToken(['token' => $rotated['token'], 'type' => msCustomerToken::TYPE_API]));
+        self::assertContains('transfer:' . $oldToken . '=>' . $rotated['token'], $this->draftCalls);
+
+        self::assertNull($tokenService->rotateApiToken($oldToken));
+    }
+
+    public function testGetBindableTokenStringPrefersBearerOverSession(): void
+    {
+        $modx = $this->makeModx();
+        $tokenService = new TokenService($modx);
+        $bearer = $tokenService->persistApiToken(0, null, 3600);
+        self::assertNotNull($bearer);
+        $bearerToken = (string) $bearer->get('token');
+
+        $_SESSION['ms3']['customer_token'] = 'session-only-token';
+        $_SESSION['ms3']['customer_token_expires'] = time() + 3600;
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $bearerToken;
+        unset($_REQUEST['ms3_token'], $_REQUEST['token'], $_COOKIE['ms3_token']);
+
+        self::assertSame($bearerToken, $tokenService->getBindableTokenString());
+
+        unset($_SERVER['HTTP_AUTHORIZATION']);
+    }
+
+    public function testGetBindableTokenStringIgnoresInvalidBearerAndUsesSession(): void
+    {
+        $modx = $this->makeModx();
+        $tokenService = new TokenService($modx);
+        $guest = $tokenService->persistApiToken(0, null, 3600);
+        self::assertNotNull($guest);
+        $guestToken = (string) $guest->get('token');
+
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer dead-or-revoked-token';
+        unset($_REQUEST['ms3_token'], $_REQUEST['token'], $_COOKIE['ms3_token']);
+
+        self::assertSame($guestToken, $tokenService->getBindableTokenString());
+        self::assertSame($guestToken, $_SESSION['ms3']['customer_token'] ?? null);
+
+        unset($_SERVER['HTTP_AUTHORIZATION']);
     }
 
     public function testValidateTokenAndRevokeTokens(): void

--- a/core/components/minishop3/tests/TokenMiddlewareQueryTokenTest.php
+++ b/core/components/minishop3/tests/TokenMiddlewareQueryTokenTest.php
@@ -3,6 +3,9 @@
 /**
  * #576: API session token must not be accepted from the query string.
  *
+ * After #571, resolution lives in TokenService::resolveTokenFromRequest();
+ * TokenMiddleware still strips query tokens before resolve.
+ *
  * Run: php tests/TokenMiddlewareQueryTokenTest.php
  */
 
@@ -13,41 +16,52 @@ $fail = static function (string $message): never {
     exit(1);
 };
 
-$src = file_get_contents(__DIR__ . '/../src/Middleware/TokenMiddleware.php');
-if ($src === false) {
-    $fail('unable to read TokenMiddleware.php');
+$middleware = file_get_contents(__DIR__ . '/../src/Middleware/TokenMiddleware.php');
+$tokenService = file_get_contents(__DIR__ . '/../src/Services/TokenService.php');
+if ($middleware === false || $tokenService === false) {
+    $fail('unable to read TokenMiddleware.php / TokenService.php');
 }
 
-if (!str_contains($src, 'stripQueryStringApiTokens')) {
+if (!str_contains($middleware, 'stripQueryStringApiTokens')) {
     $fail('TokenMiddleware must strip query-string API tokens');
 }
 
-if (!preg_match('/function resolveToken\(\): string\s*\{([\s\S]*?)\n    \}/', $src, $resolveBody)) {
-    $fail('resolveToken() body not found');
+if (!str_contains($middleware, 'TokenService::resolveTokenFromRequest()')) {
+    $fail('TokenMiddleware must resolve via TokenService::resolveTokenFromRequest()');
+}
+
+if (!preg_match(
+    '/function resolveTokenFromRequest\(\): string\s*\{([\s\S]*?)\n    \}/',
+    $tokenService,
+    $resolveBody
+)) {
+    $fail('TokenService::resolveTokenFromRequest() body not found');
 }
 
 $resolve = $resolveBody[1];
 
-if (!str_contains($resolve, 'HTTP_AUTHORIZATION') || !str_contains($resolve, 'Bearer ')) {
-    $fail('resolveToken must accept Authorization Bearer');
+if (!str_contains($resolve, 'resolveBearerOrLegacyHeader')
+    && (!str_contains($resolve, 'HTTP_AUTHORIZATION') || !str_contains($resolve, 'Bearer '))
+) {
+    $fail('resolveTokenFromRequest must accept Authorization Bearer');
 }
-if (!str_contains($resolve, 'HTTP_MS3TOKEN')) {
-    $fail('resolveToken must accept HTTP_MS3TOKEN');
+if (!str_contains($resolve, 'resolveBearerOrLegacyHeader') && !str_contains($resolve, 'HTTP_MS3TOKEN')) {
+    $fail('resolveTokenFromRequest must accept HTTP_MS3TOKEN');
 }
 if (!str_contains($resolve, 'CookieHelper::getTokenFromCookie()')) {
-    $fail('resolveToken must accept cookie via CookieHelper');
+    $fail('resolveTokenFromRequest must accept cookie via CookieHelper');
 }
 if (!str_contains($resolve, "\$_SESSION['ms3']['customer_token']")) {
-    $fail('resolveToken must fall back to session cache');
+    $fail('resolveTokenFromRequest must fall back to session cache');
 }
-if (str_contains($resolve, '$_REQUEST') || str_contains($resolve, '$_GET')) {
-    $fail('resolveToken must not read $_REQUEST/$_GET (query is not a credential source)');
+if (str_contains($resolve, '$_GET')) {
+    $fail('resolveTokenFromRequest must not read $_GET (query is not a credential source)');
 }
 if (str_contains($resolve, "['token']")) {
-    $fail('resolveToken must not read legacy token param');
+    $fail('resolveTokenFromRequest must not read legacy token param');
 }
 
-if (!preg_match('/query[- ]string/i', $src)) {
+if (!preg_match('/query[- ]string/i', $middleware)) {
     $fail('TokenMiddleware docs must mention query-string rejection');
 }
 

--- a/core/components/minishop3/tests/TokenRefreshRouteRemovedTest.php
+++ b/core/components/minishop3/tests/TokenRefreshRouteRemovedTest.php
@@ -1,10 +1,10 @@
 <?php
 
 /**
- * Контракт #334: POST /customer/token/refresh не зарегистрирован
- * и не отдаёт ложный success-stub.
+ * #571 / #334: POST /customer/token/refresh is a real rotate endpoint (not a success stub).
+ * GET /customer/me is registered and not public.
  *
- * Запуск: php tests/TokenRefreshRouteRemovedTest.php
+ * Run: php tests/TokenRefreshRouteRemovedTest.php
  */
 
 declare(strict_types=1);
@@ -25,16 +25,54 @@ if ($tokenMiddleware === false) {
     $fail('cannot read src/Middleware/TokenMiddleware.php');
 }
 
-if (str_contains($webRoutes, 'token/refresh')) {
-    $fail('config/routes/web.php must not register token/refresh');
+$authController = file_get_contents($base . '/src/Controllers/Api/Web/CustomerAuthController.php');
+if ($authController === false) {
+    $fail('cannot read CustomerAuthController.php');
 }
 
-if (str_contains($tokenMiddleware, 'token/refresh')) {
-    $fail('TokenMiddleware publicRoutes must not include token/refresh');
+$tokenService = file_get_contents($base . '/src/Services/TokenService.php');
+if ($tokenService === false) {
+    $fail('cannot read TokenService.php');
+}
+
+if (!str_contains($webRoutes, "post('/token/refresh'")) {
+    $fail('config/routes/web.php must register POST /customer/token/refresh');
+}
+
+if (!str_contains($webRoutes, "get('/me'")) {
+    $fail('config/routes/web.php must register GET /customer/me');
 }
 
 if (str_contains($webRoutes, 'Customer token/refresh endpoint - not implemented yet')) {
-    $fail('web.php must not contain the customer token/refresh success stub');
+    $fail('web.php must not contain the customer token/refresh success stub (#334)');
+}
+
+if (str_contains($webRoutes, "success([], 'Token refresh not implemented yet')")) {
+    $fail('web.php must not return false success stub for token/refresh (#334)');
+}
+
+if (str_contains($tokenMiddleware, '/api/v1/customer/token/refresh')) {
+    $fail('TokenMiddleware publicRoutes must not include token/refresh');
+}
+
+if (str_contains($tokenMiddleware, '/api/v1/customer/me')) {
+    $fail('TokenMiddleware publicRoutes must not include /customer/me');
+}
+
+if (!str_contains($authController, 'function refreshToken')) {
+    $fail('CustomerAuthController must implement refreshToken()');
+}
+
+if (!str_contains($authController, 'function me(')) {
+    $fail('CustomerAuthController must implement me()');
+}
+
+if (!str_contains($tokenService, 'function rotateApiToken')) {
+    $fail('TokenService must implement rotateApiToken()');
+}
+
+if (!str_contains($tokenService, 'function resolveTokenFromRequest')) {
+    $fail('TokenService must implement resolveTokenFromRequest() for Bearer bind');
 }
 
 fwrite(STDOUT, "OK TokenRefreshRouteRemovedTest\n");


### PR DESCRIPTION
## Описание

Контракт customer auth Web API для headless/Nuxt SSR: introspection `GET /customer/me`, реальное продление TTL через `POST /customer/token/refresh` (ротация opaque token, без JWT), bind guest-корзины из валидного Bearer на login/register.

## Тип изменений

- [x] Новая функциональность (non-breaking change)

## Связанные Issues

Closes #571

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/TokenService.php
php -l src/Services/Customer/CustomerSessionService.php
php -l src/Controllers/Api/Web/CustomerAuthController.php
php -l src/Middleware/TokenMiddleware.php
composer test:smoke          # exit 0, 77 tests
./vendor/bin/phpunit tests/Integration/Customer/AuthManagerLifecycleTest.php
./vendor/bin/phpunit tests/Integration/Customer/ResolveApiTokenTest.php
composer stan -- src/Services/TokenService.php src/Services/Customer/CustomerSessionService.php \
  src/Controllers/Api/Web/CustomerAuthController.php src/Middleware/TokenMiddleware.php
```

- [x] Автоматические тесты (`composer test:smoke`, PHPUnit lifecycle, PHPStan на затронутых файлах)
- [ ] Ручное тестирование на живом MODX

**Конфигурация тестирования:**
- MiniShop3: branch `feat/issue-571-customer-auth-contract` ← `beta`
- PHP: 8.4.17

## Nuxt / SSR contract (docs для #571)

### Рекомендуемый production path (BFF + Bearer)

1. Nuxt BFF держит свою httpOnly session cookie.
2. Server-side proxy к MODX с `Authorization: Bearer <ms3_token>`.
3. Браузер не видит raw MODX token.
4. CSRF для чистого Bearer не требуется.

### Same-site cookie path

1. `GET /api/v1/customer/token/get` (или auto-mint на cart).
2. Запросы с `credentials: 'include'` и точным `ms3_cors_allowed_origins`.
3. Cross-site cookie: `Secure` + `SameSite=None` через MODX `session_cookie_*` (или follow-up settings). Иначе BFF.
4. Cookie + cross-origin без BFF — риск CSRF; предпочтителен BFF или SameSite=Lax same-site.

### Запрет

Не хранить API token в `localStorage` / `sessionStorage`.

### Endpoints

| Method | Path | Auth |
|--------|------|------|
| GET | `/api/v1/customer/me` | TokenMiddleware (guest → `authenticated:false`) |
| POST | `/api/v1/customer/token/refresh` | TokenMiddleware; ротация, старый revoke |
| POST | `/api/v1/customer/login\|register` | без middleware; bind читает **валидный** Bearer → session → cookie |

TTL strategy: **A** (refresh rotate). Sliding TTL не включён. JWT не внедрён. Отдельные `ms3_token_cookie_*` settings — out of scope (follow-up).

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] PHPStan проходит без новых ошибок (на затронутых файлах)
- [ ] CHANGELOG.md (релизный maintainer)

## Дополнительные заметки

- `#334`: ложный success-stub не возвращён; тест обновлён под реальный refresh.
- Review fix: невалидный Bearer не маскирует guest cookie/session при bind.
- Rotate откатывает mint, если draft sync/transfer или revoke old fails.
- Deferred: декомпозиция `TokenService` (~750 LOC), DI-ключ для `CustomerSessionService`, Apache `getallheaders` beyond `REDIRECT_HTTP_AUTHORIZATION`.