### PR TITLE
test(web-api): headless Nuxt journey suite через Router envelope

### DIFF
--- a/core/components/minishop3/composer.json
+++ b/core/components/minishop3/composer.json
@@ -30,6 +30,7 @@
   "scripts": {
     "test": "phpunit",
     "test:smoke": "php tests/run-smoke.php",
+    "test:web-api": "phpunit --testsuite WebApi",
     "ci:php": "bash scripts/ci-php.sh",
     "stan:prepare": "bash scripts/phpstan-prepare-deps.sh",
     "stan": "vendor/bin/phpstan analyse -c ../../../phpstan.neon --memory-limit=1G"

--- a/core/components/minishop3/phpunit.xml.dist
+++ b/core/components/minishop3/phpunit.xml.dist
@@ -13,6 +13,10 @@
         </testsuite>
         <testsuite name="Integration">
             <directory>tests/Integration</directory>
+            <exclude>tests/Integration/WebApi</exclude>
+        </testsuite>
+        <testsuite name="WebApi">
+            <directory>tests/Integration/WebApi</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/core/components/minishop3/scripts/ci-php.sh
+++ b/core/components/minishop3/scripts/ci-php.sh
@@ -14,4 +14,5 @@ find "${paths[@]}" -type f -name '*.php' -print0 \
 echo "OK php -l (${count} files)"
 
 composer test:smoke
+# Unit + Integration + WebApi (WebApi excluded from Integration directory to avoid suite overlap)
 composer test

--- a/core/components/minishop3/tests/Integration/Cart/CartFacadeDraftStoreTest.php
+++ b/core/components/minishop3/tests/Integration/Cart/CartFacadeDraftStoreTest.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Integration\Cart;
 
-use MiniShop3\Controllers\Cart\Cart;
-use MiniShop3\MiniShop3;
-use MiniShop3\Model\msOrder;
-use MiniShop3\Model\msOrderProduct;
 use MiniShop3\Model\msProduct;
-use MiniShop3\Services\Cart\CartItemManager;
-use MiniShop3\Services\Cart\CartMutationHandler;
-use MiniShop3\Services\Order\OrderDraftManager;
-use MiniShop3\Services\Order\OrderLogService;
-use MiniShop3\Services\Order\OrderService;
 use MiniShop3\Tests\RecordingMsOrder;
 use MiniShop3\Tests\Support\OrderProductSqliteStore;
-use MiniShop3\Tests\Support\SqliteOrderProduct;
+use MiniShop3\Tests\Support\SqliteDraftCartHarnessTrait;
+use MiniShop3\Tests\Support\SqliteDraftCartProduct;
 use MODX\Revolution\modX;
 use PHPUnit\Framework\TestCase;
 
@@ -25,19 +17,22 @@ use PHPUnit\Framework\TestCase;
  */
 final class CartFacadeDraftStoreTest extends TestCase
 {
+    use SqliteDraftCartHarnessTrait;
+
     protected function setUp(): void
     {
         if (!class_exists(modX::class, false)) {
             require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
         }
         require_once dirname(__DIR__, 2) . '/support/OrderProductSqliteStore.php';
+        require_once dirname(__DIR__, 2) . '/RecordingMsOrder.php';
     }
 
     public function testAddChangeRemoveAgainstSqliteDraftStore(): void
     {
         $store = new OrderProductSqliteStore();
         $draft = new RecordingMsOrder(['id' => 42, 'cart_cost' => 0, 'delivery_cost' => 0, 'cost' => 0, 'weight' => 0]);
-        $product = new LightweightCartProduct([
+        $product = new SqliteDraftCartProduct([
             'id' => 11,
             'pagetitle' => 'Shirt',
             'price' => 25.0,
@@ -48,7 +43,7 @@ final class CartFacadeDraftStoreTest extends TestCase
             'published' => 1,
         ]);
 
-        $cart = $this->makeCart($store, $draft, $product);
+        $cart = $this->makeSqliteDraftCart($store, $draft, $product);
         self::assertTrue($cart->initialize('web', 'tok-1'));
 
         $added = $cart->add(11, 2, ['color' => 'red']);
@@ -81,7 +76,7 @@ final class CartFacadeDraftStoreTest extends TestCase
     {
         $store = new OrderProductSqliteStore();
         $draft = new RecordingMsOrder(['id' => 42]);
-        $product = new LightweightCartProduct([
+        $product = new SqliteDraftCartProduct([
             'id' => 11,
             'pagetitle' => 'Shirt',
             'price' => 10.0,
@@ -91,275 +86,12 @@ final class CartFacadeDraftStoreTest extends TestCase
             'deleted' => 0,
             'published' => 1,
         ]);
-        $cart = $this->makeCart($store, $draft, $product);
+        $cart = $this->makeSqliteDraftCart($store, $draft, $product);
         $cart->initialize('web', 'tok-1');
 
         $result = $cart->add(11, 0);
         self::assertFalse($result['success']);
         self::assertSame('ms3_cart_add_err_count', $result['message']);
         self::assertSame(0, $store->countAll());
-    }
-
-    private function makeCart(
-        OrderProductSqliteStore $store,
-        RecordingMsOrder $draft,
-        LightweightCartProduct $product
-    ): Cart {
-        $utils = new class {
-            public function success(string $message = '', array $data = [], array $placeholders = []): array
-            {
-                return ['success' => true, 'message' => $message, 'data' => $data];
-            }
-
-            public function error(string $message = '', array $data = [], array $placeholders = []): array
-            {
-                return ['success' => false, 'message' => $message, 'data' => $data];
-            }
-
-            public function invokeEvent(string $eventName, array $params = []): array
-            {
-                return ['success' => true, 'message' => '', 'data' => $params];
-            }
-        };
-
-        $orderService = new OrderService(new modX());
-        $modx = new class ($store, $product, $orderService) extends modX {
-
-            public function __construct(
-                private OrderProductSqliteStore $store,
-                private LightweightCartProduct $product,
-                OrderService $orderService,
-            ) {
-                parent::__construct();
-                $this->lexicon = new class {
-                    public function load($topic): void
-                    {
-                    }
-                };
-                $this->services = new class ($orderService) {
-                    public function __construct(private OrderService $orderService)
-                    {
-                    }
-
-                    public function has(string $key): bool
-                    {
-                        return $key === 'ms3_order_service';
-                    }
-
-                    public function get(string $key): mixed
-                    {
-                        return $key === 'ms3_order_service' ? $this->orderService : null;
-                    }
-                };
-            }
-
-            public function getOption($key, $options = null, $default = null, $skipEmpty = false)
-            {
-                return match ((string) $key) {
-                    'ms3_cart_max_count' => 1000,
-                    'ms3_cart_product_key_fields' => 'id,options',
-                    'ms3_cart_context' => '0',
-                    default => $default,
-                };
-            }
-
-            public function lexicon(string $key, array $params = []): string
-            {
-                return (string) $key;
-            }
-
-            public function getObject($className, $criteria = null, $cacheFlag = true)
-            {
-                if ($className === msProduct::class && is_array($criteria)) {
-                    if ((int) ($criteria['id'] ?? 0) !== (int) $this->product->get('id')) {
-                        return null;
-                    }
-
-                    return $this->product;
-                }
-
-                if ($className === msOrderProduct::class && is_array($criteria)) {
-                    $row = $this->store->findOne($criteria);
-                    if ($row === null) {
-                        return null;
-                    }
-                    $item = new SqliteOrderProduct();
-                    $item->bindStore($this->store);
-                    $item->hydrate($row);
-
-                    return $item;
-                }
-
-                return null;
-            }
-
-            public function newObject($className, $fields = [])
-            {
-                if ($className === msOrderProduct::class) {
-                    $item = new SqliteOrderProduct();
-                    $item->bindStore($this->store);
-                    if (is_array($fields) && $fields !== []) {
-                        $item->fromArray($fields);
-                    }
-
-                    return $item;
-                }
-
-                return null;
-            }
-
-            public function getIterator($className, $criteria = null, $cacheFlag = true): \ArrayIterator
-            {
-                if ($className === msOrderProduct::class) {
-                    $rows = $this->store->findAll(is_array($criteria) ? $criteria : []);
-                    $items = [];
-                    foreach ($rows as $row) {
-                        $item = new SqliteOrderProduct();
-                        $item->bindStore($this->store);
-                        $item->hydrate($row);
-                        $items[] = $item;
-                    }
-
-                    return new \ArrayIterator($items);
-                }
-
-                return new \ArrayIterator([]);
-            }
-
-            public function getCount($className, $criteria = null)
-            {
-                if ($className === msOrderProduct::class) {
-                    return count($this->store->findAll(is_array($criteria) ? $criteria : []));
-                }
-
-                return 0;
-            }
-        };
-
-        $ms3 = $this->createStub(MiniShop3::class);
-        $ms3->modx = $modx;
-        $ms3->utils = $utils;
-
-        $itemManager = new CartItemManager($modx, $ms3);
-        $draftManager = $this->createStub(OrderDraftManager::class);
-        $draftManager->method('getDraft')->willReturn($draft);
-        $draftManager->method('getOrCreateDraft')->willReturn($draft);
-        $draftManager->method('isEmpty')->willReturnCallback(
-            static function (msOrder $order) use ($store): bool {
-                return $store->findAll(['order_id' => (int) $order->get('id')]) === [];
-            }
-        );
-        $draftManager->method('deleteDraft')->willReturn(true);
-        $draftManager->method('recalculate')->willReturnCallback(
-            static function (msOrder $order) use ($orderService, $itemManager): void {
-                $items = $itemManager->loadItems($order);
-                $products = [];
-                foreach ($items as $row) {
-                    $products[] = new class ($row) {
-                        public function __construct(private array $row)
-                        {
-                        }
-
-                        public function get(string $field): mixed
-                        {
-                            return $this->row[$field] ?? 0;
-                        }
-                    };
-                }
-                $totals = OrderService::aggregateProductsTotals($products);
-                $order->set('cart_cost', $totals['cart_cost']);
-                $order->set('weight', $totals['weight']);
-                $order->set(
-                    'cost',
-                    $orderService->clampComputedTotal(
-                        $order,
-                        (float) $totals['cart_cost'],
-                        (float) ($order->get('delivery_cost') ?? 0),
-                        0.0
-                    )
-                );
-                $order->save();
-            }
-        );
-
-        return new HarnessCart($ms3, $itemManager, $draftManager);
-    }
-}
-
-final class LightweightCartProduct extends msProduct
-{
-    /** @var array<string, mixed> */
-    public $_fieldMeta = [];
-
-    /** @var list<string> */
-    protected $dataRelated = [];
-
-    /**
-     * @param array<string, mixed> $fields
-     */
-    public function __construct(private array $fields)
-    {
-    }
-
-    public function get($k, $format = null, $formatTemplate = null)
-    {
-        return $this->fields[$k] ?? null;
-    }
-
-    public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false)
-    {
-        return $this->fields;
-    }
-
-    public function getPrice($data = [])
-    {
-        return (float) ($this->fields['price'] ?? 0);
-    }
-
-    public function getWeight($data = [])
-    {
-        return (float) ($this->fields['weight'] ?? 0);
-    }
-}
-
-final class HarnessCart extends Cart
-{
-    public function __construct(
-        MiniShop3 $ms3,
-        CartItemManager $itemManager,
-        OrderDraftManager $draftManager
-    ) {
-        $this->ms3 = $ms3;
-        $this->modx = $ms3->modx;
-        $this->itemManager = $itemManager;
-        $this->draftManager = $draftManager;
-        $this->mutationHandler = new CartMutationHandler(
-            $this->modx,
-            $this->ms3,
-            $this->draftManager,
-            $this->itemManager,
-            $this->getOrderLog()
-        );
-    }
-
-    protected function getOrderLog(): OrderLogService
-    {
-        $log = new class extends OrderLogService {
-            public function __construct()
-            {
-            }
-
-            public function addEntry(int $orderId, string $action, array $data, bool $visible = true): bool
-            {
-                return true;
-            }
-        };
-
-        return $log;
-    }
-
-    protected function getCustomerId(): ?int
-    {
-        return null;
     }
 }

--- a/core/components/minishop3/tests/Integration/WebApi/HOW_TO_RUN.txt
+++ b/core/components/minishop3/tests/Integration/WebApi/HOW_TO_RUN.txt
@@ -1,0 +1,28 @@
+Web API Integration Suite (#574)
+================================
+
+Headless Nuxt customer journey against Router + config/routes/web.php
+(middleware, controllers, JSON envelope).
+
+Run (from core/components/minishop3):
+
+  composer test:web-api
+  # or
+  vendor/bin/phpunit --testsuite WebApi
+
+Included in `composer test` / `composer ci:php` as the WebApi PHPUnit suite
+(excluded from the Integration directory suite to avoid duplicate registration).
+
+Layout:
+  WebApiTestCase.php                 — Router bootstrap, Bearer/cookie dispatch
+  HeadlessStorefrontJourneyTest.php  — happy path (fixture delivery/payment IDs)
+  HeadlessStorefrontErrorsTest.php   — 401/404/validation/business errors
+  HeadlessStorefrontCorsTest.php     — CORS normalize + OPTIONS preflight
+  HeadlessCartSqliteHttpTest.php     — Phase B cart HTTP + SQLite
+  Support/                           — journey MODX / cart / order doubles
+
+MySQL (@group mysql) is not required. Journey uses in-memory stubs + SQLite
+for cart Phase B. Skip policy matches other Integration Mysql tests.
+
+Out of scope: public delivery/list, payment/list discovery; Phase C built-in
+server → api.php (optional nightly).

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessCartSqliteHttpTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessCartSqliteHttpTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+use MiniShop3\Model\msProduct;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyProductCatalog;
+use MiniShop3\Tests\RecordingMsOrder;
+use MiniShop3\Tests\Support\OrderProductSqliteStore;
+use MiniShop3\Tests\Support\SqliteDraftCartHarnessTrait;
+use MiniShop3\Tests\Support\SqliteDraftCartProduct;
+
+/**
+ * Phase B: cart add/change/change-option/get through Router with SQLite draft store (#574).
+ */
+final class HeadlessCartSqliteHttpTest extends WebApiTestCase
+{
+    use SqliteDraftCartHarnessTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once dirname(__DIR__, 2) . '/support/OrderProductSqliteStore.php';
+        require_once dirname(__DIR__, 2) . '/RecordingMsOrder.php';
+    }
+
+    public function testCartMutationsPersistViaSqliteThroughHttpEnvelope(): void
+    {
+        $store = new OrderProductSqliteStore();
+        $draft = new RecordingMsOrder([
+            'id' => 42,
+            'cart_cost' => 0,
+            'delivery_cost' => 0,
+            'cost' => 0,
+            'weight' => 0,
+        ]);
+        $product = new SqliteDraftCartProduct([
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'pagetitle' => 'Shirt',
+            'price' => 25.0,
+            'old_price' => 30.0,
+            'weight' => 0.5,
+            'class_key' => msProduct::class,
+            'deleted' => 0,
+            'published' => 1,
+        ]);
+
+        $this->modx->ms3->cart = $this->makeSqliteDraftCart($store, $draft, $product);
+        $this->modx->journeyTokens->putToken('sqlite-http-token', 0);
+
+        $add = $this->dispatch(
+            'POST',
+            '/api/v1/cart/add',
+            [],
+            [
+                'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+                'count' => 2,
+                'options' => ['color' => 'red'],
+            ],
+            [],
+            'sqlite-http-token'
+        );
+        self::assertSame(HttpStatus::OK, $add['status'], $add['message']);
+        self::assertTrue($add['success']);
+        $key = (string) ($add['data']['last_key'] ?? '');
+        self::assertNotSame('', $key);
+        self::assertSame(1, $store->countAll());
+
+        $change = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change',
+            [],
+            ['product_key' => $key, 'count' => 3],
+            [],
+            'sqlite-http-token'
+        );
+        self::assertSame(HttpStatus::OK, $change['status'], $change['message']);
+        self::assertTrue($change['success']);
+        $row = $store->findOne(['order_id' => 42, 'product_key' => $key]);
+        self::assertNotNull($row);
+        self::assertSame(3, $row['count']);
+
+        // change-option needs Product relation (getOne); covered on JourneyCart HTTP in Phase A.
+        $get = $this->dispatch('GET', '/api/v1/cart/get', [], [], [], 'sqlite-http-token');
+        self::assertSame(HttpStatus::OK, $get['status']);
+        self::assertTrue($get['success']);
+        self::assertSame(3, $get['data']['status']['total_count'] ?? null);
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+use MiniShop3\Middleware\CorsMiddleware;
+use MiniShop3\Utils\CorsConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CORS smoke adjacent to journey suite (#574 / #335).
+ *
+ * Full Router OPTIONS cannot run in-process: CorsMiddleware exits after 200.
+ */
+final class HeadlessStorefrontCorsTest extends TestCase
+{
+    public function testNormalizeRejectsWildcardWithCredentials(): void
+    {
+        $cfg = CorsConfig::normalizeCorsConfig([
+            'allowed_origins' => '*',
+            'allow_credentials' => true,
+        ]);
+
+        self::assertSame(['*'], $cfg['allowed_origins']);
+        self::assertFalse($cfg['allow_credentials']);
+    }
+
+    public function testPreflightOptionsExitsWithHttp200ForAllowlistedOrigin(): void
+    {
+        $script = <<<'PHP'
+<?php
+declare(strict_types=1);
+error_reporting(E_ALL & ~E_DEPRECATED);
+require $argv[1];
+use MiniShop3\Middleware\CorsMiddleware;
+
+$_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+$_SERVER['HTTP_ORIGIN'] = 'https://shop.example';
+
+$mw = new CorsMiddleware([
+    'allowed_origins' => 'https://shop.example',
+    'allow_credentials' => true,
+]);
+$ref = new ReflectionClass($mw);
+$allowed = $ref->getMethod('isOriginAllowed');
+$allowed->setAccessible(true);
+$originOk = $allowed->invoke($mw, 'https://shop.example') ? '1' : '0';
+
+register_shutdown_function(static function () use ($originOk): void {
+    echo 'HTTP_CODE=' . (string) http_response_code() . "\n";
+    echo 'ORIGIN_OK=' . $originOk . "\n";
+});
+
+$mw->handle([]);
+fwrite(STDERR, "OPTIONS did not exit\n");
+exit(2);
+PHP;
+
+        $autoload = dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+        $tmp = tempnam(sys_get_temp_dir(), 'ms3-cors-');
+        self::assertNotFalse($tmp);
+        file_put_contents($tmp, $script);
+
+        $cmd = sprintf(
+            '%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($tmp),
+            escapeshellarg($autoload)
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $proc = proc_open($cmd, $descriptors, $pipes, dirname($tmp));
+        self::assertIsResource($proc);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $code = proc_close($proc);
+        @unlink($tmp);
+
+        self::assertSame(0, $code, $stderr);
+        self::assertStringContainsString('HTTP_CODE=200', (string) $stdout);
+        self::assertStringContainsString('ORIGIN_OK=1', (string) $stdout);
+        self::assertStringNotContainsString('OPTIONS did not exit', (string) $stderr);
+    }
+
+    public function testNormalizeEmptyOriginsDisallowsAll(): void
+    {
+        $cfg = CorsConfig::normalizeCorsConfig([
+            'allowed_origins' => '',
+            'allow_credentials' => true,
+        ]);
+
+        self::assertSame([], $cfg['allowed_origins']);
+    }
+
+    public function testCorsMiddlewareContinuesForNonOptions(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['HTTP_ORIGIN'] = 'https://shop.example';
+
+        $mw = new CorsMiddleware([
+            'allowed_origins' => 'https://shop.example',
+            'allow_credentials' => true,
+        ]);
+
+        self::assertNull($mw->handle([]));
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 error_reporting(E_ALL & ~E_DEPRECATED);
 require $argv[1];
 use MiniShop3\Middleware\CorsMiddleware;
+use MiniShop3\Utils\CorsConfig;
 
 $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
 $_SERVER['HTTP_ORIGIN'] = 'https://shop.example';
@@ -42,10 +43,7 @@ $mw = new CorsMiddleware([
     'allowed_origins' => 'https://shop.example',
     'allow_credentials' => true,
 ]);
-$ref = new ReflectionClass($mw);
-$allowed = $ref->getMethod('isOriginAllowed');
-$allowed->setAccessible(true);
-$originOk = $allowed->invoke($mw, 'https://shop.example') ? '1' : '0';
+$originOk = CorsConfig::isOriginAllowed('https://shop.example', ['https://shop.example']) ? '1' : '0';
 
 register_shutdown_function(static function () use ($originOk): void {
     echo 'HTTP_CODE=' . (string) http_response_code() . "\n";

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyBrokenTokenMint;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyOrder;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyProductCatalog;
+
+/**
+ * Error / auth edge cases for headless Web API journey (#574).
+ */
+final class HeadlessStorefrontErrorsTest extends WebApiTestCase
+{
+    public function testProductGetUnknownIdReturns404Envelope(): void
+    {
+        $res = $this->dispatch('GET', '/api/v1/product/get/999999');
+        $this->assertApiError($res, HttpStatus::NOT_FOUND, 'ms3_err_product_nf');
+    }
+
+    public function testInvalidBearerReturns401(): void
+    {
+        $res = $this->dispatch(
+            'GET',
+            '/api/v1/cart/get',
+            [],
+            [],
+            [],
+            'definitely-invalid-token'
+        );
+        $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_err_token_invalid');
+    }
+
+    public function testExpiredBearerReturns401(): void
+    {
+        $this->modx->journeyTokens->putToken(
+            'expired-token',
+            0,
+            date('Y-m-d H:i:s', time() - 60)
+        );
+
+        $res = $this->dispatch('GET', '/api/v1/cart/get', [], [], [], 'expired-token');
+        $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_err_token_expired');
+    }
+
+    public function testChangeOptionEmptyOptionsReturns400(): void
+    {
+        $add = $this->dispatch('POST', '/api/v1/cart/add', [], [
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'count' => 1,
+            'options' => ['size' => 'M'],
+        ]);
+        $token = $this->lastMs3Token();
+        $key = (string) ($add['data']['last_key'] ?? '');
+
+        $res = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change-option',
+            [],
+            ['product_key' => $key, 'options' => []],
+            [],
+            $token
+        );
+        $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_cart_change_options_error');
+    }
+
+    public function testSubmitEmptyCartReturnsBusinessError(): void
+    {
+        $token = $this->modx->journeyTokens->generateCustomerToken()['token'];
+        $this->modx->journeyTokens->putToken($token, 42);
+
+        $res = $this->dispatch(
+            'POST',
+            '/api/v1/order/submit',
+            [],
+            ['data' => []],
+            [],
+            $token
+        );
+        $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_err_cart_empty');
+    }
+
+    public function testPaymentNotLinkedToDeliveryReturnsBusinessError(): void
+    {
+        $this->dispatch('POST', '/api/v1/cart/add', [], [
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'count' => 1,
+        ]);
+        $token = $this->lastMs3Token();
+
+        $this->dispatch(
+            'POST',
+            '/api/v1/order/set',
+            [],
+            ['fields' => ['delivery_id' => JourneyOrder::FIXTURE_DELIVERY_ID]],
+            [],
+            $token
+        );
+
+        $res = $this->dispatch(
+            'POST',
+            '/api/v1/order/set',
+            [],
+            ['fields' => ['payment_id' => JourneyOrder::UNLINKED_PAYMENT_ID]],
+            [],
+            $token
+        );
+        $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_err_payment_not_linked');
+    }
+
+    public function testCustomerOrdersAsGuestReturns401(): void
+    {
+        $token = $this->modx->journeyTokens->generateCustomerToken()['token'];
+
+        $res = $this->dispatch('GET', '/api/v1/customer/orders', [], [], [], $token);
+        $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_customer_order_err_unauthorized');
+    }
+
+    public function testCartWithoutTokenAndFailedAutoMintReturns401(): void
+    {
+        $this->modx->setTokenService(new JourneyBrokenTokenMint());
+        $this->router = $this->buildRouter($this->modx);
+
+        $res = $this->dispatch('GET', '/api/v1/cart/get');
+        $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_customer_err_token_create');
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
@@ -118,12 +118,13 @@ final class HeadlessStorefrontErrorsTest extends WebApiTestCase
         $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_customer_order_err_unauthorized');
     }
 
-    public function testCartWithoutTokenAndFailedAutoMintReturns401(): void
+    public function testCartWithoutTokenAndFailedAutoMintReturns500(): void
     {
         $this->modx->setTokenService(new JourneyBrokenTokenMint());
         $this->router = $this->buildRouter($this->modx);
 
         $res = $this->dispatch('GET', '/api/v1/cart/get');
-        $this->assertApiError($res, HttpStatus::UNAUTHORIZED, 'ms3_customer_err_token_create');
+        // #583: mint failure is an internal fault (cannot issue guest session), not auth rejection.
+        $this->assertApiError($res, HttpStatus::INTERNAL_SERVER_ERROR, 'ms3_customer_err_token_create');
     }
 }

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontJourneyTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontJourneyTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyOrder;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyProductCatalog;
+
+/**
+ * Phase A: headless Nuxt happy-path through Router + web.php + envelope (#574).
+ */
+final class HeadlessStorefrontJourneyTest extends WebApiTestCase
+{
+    public function testHappyPathCatalogCartAuthCheckoutAndOrderGet(): void
+    {
+        $list = $this->dispatch('GET', '/api/v1/product/list', ['limit' => 10]);
+        self::assertSame(HttpStatus::OK, $list['status']);
+        self::assertTrue($list['success']);
+        self::assertSame(1, $list['data']['total'] ?? null);
+        self::assertSame(
+            JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            $list['data']['results'][0]['id'] ?? null
+        );
+
+        $get = $this->dispatch(
+            'GET',
+            '/api/v1/product/get/' . JourneyProductCatalog::FIXTURE_PRODUCT_ID
+        );
+        self::assertSame(HttpStatus::OK, $get['status']);
+        self::assertTrue($get['success']);
+        self::assertSame(JourneyProductCatalog::FIXTURE_PRODUCT_ID, $get['data']['id'] ?? null);
+
+        $add = $this->dispatch('POST', '/api/v1/cart/add', [], [
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'count' => 2,
+            'options' => ['color' => 'red'],
+        ]);
+        self::assertSame(HttpStatus::OK, $add['status'], $add['message']);
+        self::assertTrue($add['success']);
+        $productKey = (string) ($add['data']['last_key'] ?? '');
+        self::assertNotSame('', $productKey);
+        self::assertSame(2, $add['data']['status']['total_count'] ?? null);
+        $guestToken = $this->lastMs3Token();
+        self::assertNotSame('', $guestToken);
+
+        $change = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change',
+            [],
+            ['product_key' => $productKey, 'count' => 3],
+            [],
+            $guestToken
+        );
+        self::assertSame(HttpStatus::OK, $change['status']);
+        self::assertTrue($change['success']);
+        self::assertSame(3, $change['data']['status']['total_count'] ?? null);
+
+        $changeOpt = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change-option',
+            [],
+            ['product_key' => $productKey, 'options' => ['color' => 'blue']],
+            [],
+            $guestToken
+        );
+        self::assertSame(HttpStatus::OK, $changeOpt['status']);
+        self::assertTrue($changeOpt['success']);
+        $productKey = (string) ($changeOpt['data']['last_key'] ?? $productKey);
+        self::assertSame('blue', $changeOpt['data']['cart'][$productKey]['options']['color'] ?? null);
+
+        $cart = $this->dispatch('GET', '/api/v1/cart/get', [], [], [], $guestToken);
+        self::assertSame(HttpStatus::OK, $cart['status']);
+        self::assertTrue($cart['success']);
+        self::assertSame(3, $cart['data']['status']['total_count'] ?? null);
+        self::assertSame(300.0, $cart['data']['status']['total_cost'] ?? null);
+
+        $login = $this->dispatch('POST', '/api/v1/customer/login', [], [], [], $guestToken);
+        self::assertSame(HttpStatus::OK, $login['status']);
+        self::assertTrue($login['success']);
+        $userToken = (string) ($login['data']['token'] ?? '');
+        self::assertNotSame('', $userToken);
+        self::assertNotSame($guestToken, $userToken);
+
+        $cartAfterLogin = $this->dispatch('GET', '/api/v1/cart/get', [], [], [], $userToken);
+        self::assertSame(HttpStatus::OK, $cartAfterLogin['status']);
+        self::assertTrue($cartAfterLogin['success']);
+        self::assertSame(3, $cartAfterLogin['data']['status']['total_count'] ?? null);
+
+        $addr = $this->dispatch(
+            'POST',
+            '/api/v1/order/address/set',
+            [],
+            ['address_hash' => 'addr-fixture-1'],
+            [],
+            $userToken
+        );
+        self::assertSame(HttpStatus::OK, $addr['status'], $addr['message']);
+        self::assertTrue($addr['success']);
+
+        $delivery = $this->dispatch(
+            'POST',
+            '/api/v1/order/set',
+            [],
+            ['fields' => ['delivery_id' => JourneyOrder::FIXTURE_DELIVERY_ID]],
+            [],
+            $userToken
+        );
+        self::assertSame(HttpStatus::OK, $delivery['status']);
+        self::assertTrue($delivery['success']);
+
+        $payment = $this->dispatch(
+            'POST',
+            '/api/v1/order/set',
+            [],
+            ['fields' => ['payment_id' => JourneyOrder::FIXTURE_PAYMENT_ID]],
+            [],
+            $userToken
+        );
+        self::assertSame(HttpStatus::OK, $payment['status']);
+        self::assertTrue($payment['success']);
+
+        $cost = $this->dispatch('GET', '/api/v1/order/cost', [], [], [], $userToken);
+        self::assertSame(HttpStatus::OK, $cost['status']);
+        self::assertTrue($cost['success']);
+        self::assertSame(300.0, $cost['data']['cart_cost'] ?? null);
+        self::assertSame(50.0, $cost['data']['delivery_cost'] ?? null);
+        self::assertSame(0.0, $cost['data']['payment_cost'] ?? null);
+        self::assertSame(350.0, $cost['data']['cost'] ?? null);
+
+        $submit = $this->dispatch('POST', '/api/v1/order/submit', [], ['data' => []], [], $userToken);
+        self::assertSame(HttpStatus::OK, $submit['status'], $submit['message']);
+        self::assertTrue($submit['success']);
+        self::assertSame('/checkout/success?order=501', $submit['data']['redirect'] ?? null);
+
+        $orderId = (int) ($submit['data']['msorder'] ?? 0);
+        $this->modx->customerOrders->seedOrder($orderId, 42);
+
+        $orders = $this->dispatch('GET', '/api/v1/customer/orders', [], [], [], $userToken);
+        self::assertSame(HttpStatus::OK, $orders['status']);
+        self::assertTrue($orders['success']);
+        self::assertSame(1, $orders['data']['total'] ?? null);
+
+        $one = $this->dispatch('GET', '/api/v1/customer/orders/' . $orderId, [], [], [], $userToken);
+        self::assertSame(HttpStatus::OK, $one['status']);
+        self::assertTrue($one['success']);
+        self::assertSame($orderId, $one['data']['id'] ?? null);
+    }
+
+    public function testCookieAuthPathReachesCartGet(): void
+    {
+        $this->modx->journeyTokens->putToken('cookie-guest-token', 0);
+
+        $add = $this->dispatch(
+            'POST',
+            '/api/v1/cart/add',
+            [],
+            ['id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID, 'count' => 1],
+            [],
+            null,
+            'cookie-guest-token'
+        );
+        self::assertSame(HttpStatus::OK, $add['status'], $add['message']);
+        self::assertTrue($add['success']);
+
+        $cart = $this->dispatch(
+            'GET',
+            '/api/v1/cart/get',
+            [],
+            [],
+            [],
+            null,
+            'cookie-guest-token'
+        );
+        self::assertSame(HttpStatus::OK, $cart['status']);
+        self::assertTrue($cart['success']);
+        self::assertGreaterThanOrEqual(1, $cart['data']['status']['total_count'] ?? 0);
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyBrokenTokenMint.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyBrokenTokenMint.php
@@ -16,6 +16,11 @@ final class JourneyBrokenTokenMint
         return ['token' => null, 'reason' => 'missing'];
     }
 
+    public function syncSessionFromToken(object $tokenObj): void
+    {
+        unset($tokenObj);
+    }
+
     /**
      * @return array{token: string}
      */

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyBrokenTokenMint.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyBrokenTokenMint.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * TokenService double: no token on resolve, auto-mint returns empty string.
+ */
+final class JourneyBrokenTokenMint
+{
+    public function resolveApiToken(string $token): array
+    {
+        unset($token);
+
+        return ['token' => null, 'reason' => 'missing'];
+    }
+
+    /**
+     * @return array{token: string}
+     */
+    public function generateCustomerToken(): array
+    {
+        return ['token' => ''];
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCart.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCart.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * In-memory cart facade for Phase A Web API journey (HTTP boundary only).
+ *
+ * Bags are keyed by API token so guest→login transfer is testable.
+ */
+final class JourneyCart
+{
+    private string $token = '';
+
+    /** @var array<string, array<string, array<string, mixed>>> */
+    private array $bags = [];
+
+    public function initialize(string $ctx, string $token): bool
+    {
+        unset($ctx);
+        $this->token = $token;
+        $this->bags[$token] ??= [];
+
+        return $token !== '';
+    }
+
+    public function transfer(string $fromToken, string $toToken): void
+    {
+        if ($fromToken === '' || $toToken === '' || $fromToken === $toToken) {
+            return;
+        }
+
+        $this->bags[$toToken] = $this->bags[$fromToken] ?? [];
+        unset($this->bags[$fromToken]);
+        $this->token = $toToken;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function add(int $id, int $count, array $options = []): array
+    {
+        if ($id < 1 || $count < 1) {
+            return JourneyResult::fail('ms3_cart_add_err_count');
+        }
+
+        $key = $this->makeKey($id, $options);
+        $price = 100.0;
+        $lineCost = $price * $count;
+
+        $items = &$this->currentBag();
+        $items[$key] = [
+            'id' => $id,
+            'product_key' => $key,
+            'count' => $count,
+            'price' => $price,
+            'cost' => $lineCost,
+            'options' => $options,
+        ];
+
+        return JourneyResult::ok('ms3_cart_add_success', [
+            'cart' => $items,
+            'status' => $this->status($items),
+            'last_key' => $key,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function change(string $productKey, int $count): array
+    {
+        $items = &$this->currentBag();
+        if ($productKey === '' || !isset($items[$productKey])) {
+            return JourneyResult::fail('ms3_cart_change_error');
+        }
+
+        if ($count < 1) {
+            unset($items[$productKey]);
+
+            return JourneyResult::ok('ms3_cart_change_success', [
+                'cart' => $items,
+                'status' => $this->status($items),
+            ]);
+        }
+
+        $items[$productKey]['count'] = $count;
+        $items[$productKey]['cost'] = (float) $items[$productKey]['price'] * $count;
+
+        return JourneyResult::ok('ms3_cart_change_success', [
+            'cart' => $items,
+            'status' => $this->status($items),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function changeOption(string $productKey, array $options): array
+    {
+        if ($options === []) {
+            return JourneyResult::fail('ms3_cart_change_options_error');
+        }
+
+        $items = &$this->currentBag();
+        if ($productKey === '' || !isset($items[$productKey])) {
+            return JourneyResult::fail('ms3_cart_change_options_error');
+        }
+
+        $old = $items[$productKey];
+        unset($items[$productKey]);
+        $newKey = $this->makeKey((int) $old['id'], $options);
+        $old['product_key'] = $newKey;
+        $old['options'] = $options;
+        $items[$newKey] = $old;
+
+        return JourneyResult::ok('ms3_cart_change_options_success', [
+            'cart' => $items,
+            'status' => $this->status($items),
+            'last_key' => $newKey,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function get(): array
+    {
+        $items = $this->currentBag();
+
+        return JourneyResult::ok('', [
+            'cart' => $items,
+            'status' => $this->status($items),
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function clean(): array
+    {
+        $this->bags[$this->token] = [];
+
+        return JourneyResult::ok('ms3_cart_clean_success', [
+            'cart' => [],
+            'status' => $this->status([]),
+        ]);
+    }
+
+    public function isEmpty(?string $token = null): bool
+    {
+        $t = $token ?? $this->token;
+
+        return ($this->bags[$t] ?? []) === [];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function &currentBag(): array
+    {
+        $this->bags[$this->token] ??= [];
+
+        return $this->bags[$this->token];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $items
+     * @return array{total_count: int, total_cost: float}
+     */
+    private function status(array $items): array
+    {
+        $totalCount = 0;
+        $totalCost = 0.0;
+        foreach ($items as $item) {
+            $totalCount += (int) $item['count'];
+            $totalCost += (float) $item['cost'];
+        }
+
+        return [
+            'total_count' => $totalCount,
+            'total_cost' => $totalCost,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function makeKey(int $id, array $options): string
+    {
+        return md5((string) $id . json_encode($options, JSON_THROW_ON_ERROR));
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCustomerOrderService.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCustomerOrderService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+use MiniShop3\Services\Customer\CustomerOrderService;
+use MODX\Revolution\modX;
+
+/**
+ * Stub CustomerOrderService for cabinet order list/get after submit.
+ */
+final class JourneyCustomerOrderService extends CustomerOrderService
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $orders = [];
+
+    public function __construct(modX $modx)
+    {
+        parent::__construct($modx);
+    }
+
+    public function seedOrder(int $orderId, int $customerId, array $fields = []): void
+    {
+        $this->orders[$orderId] = array_merge([
+            'id' => $orderId,
+            'customer_id' => $customerId,
+            'cost' => 150.0,
+            'status_id' => 1,
+        ], $fields);
+    }
+
+    public function getDraftStatusId(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @return array{total: int, limit: int, offset: int, results: list<array<string, mixed>>}
+     */
+    public function listForCustomer(int $customerId, int $limit, int $offset, ?int $statusId = null): array
+    {
+        unset($statusId);
+        $owned = array_values(array_filter(
+            $this->orders,
+            static fn (array $row): bool => (int) $row['customer_id'] === $customerId
+        ));
+
+        return [
+            'total' => count($owned),
+            'limit' => $limit,
+            'offset' => $offset,
+            'results' => array_slice($owned, $offset, $limit),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getForCustomer(int $customerId, int $orderId): ?array
+    {
+        $row = $this->orders[$orderId] ?? null;
+        if ($row === null || (int) $row['customer_id'] !== $customerId) {
+            return null;
+        }
+
+        return $row;
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyMs3.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyMs3.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * ms3 service bag: cart/order/customer facades for Router journey.
+ */
+final class JourneyMs3
+{
+    /** @var object Cart facade (JourneyCart or Cart for Phase B) */
+    public object $cart;
+
+    public JourneyOrder $order;
+
+    public object $customer;
+
+    public object $utils;
+
+    /** @var array<string, mixed> */
+    public array $config = ['ctx' => 'web'];
+
+    public function __construct()
+    {
+        $cart = new JourneyCart();
+        $this->cart = $cart;
+        $this->order = new JourneyOrder();
+        $this->order->bindCart($cart);
+
+        $this->customer = new class {
+            /**
+             * @return array{success: bool, message: string, data: array<string, mixed>}
+             */
+            public function generateToken(): array
+            {
+                return [
+                    'success' => true,
+                    'message' => '',
+                    'data' => ['token' => 'explicit-guest-token'],
+                ];
+            }
+        };
+
+        $this->utils = new class {
+            public function success(string $message = '', array $data = []): array
+            {
+                return JourneyResult::ok($message, $data);
+            }
+
+            public function error(string $message = '', array $data = []): array
+            {
+                return JourneyResult::fail($message, $data);
+            }
+        };
+    }
+
+    public function initialize(string $ctx = 'web'): bool
+    {
+        $this->config['ctx'] = $ctx;
+
+        return true;
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyOrder.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyOrder.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * In-memory order facade for Phase A Web API journey.
+ *
+ * Fixture IDs: delivery 1 ↔ payment 10 linked; payment 99 is not linked (#374).
+ */
+final class JourneyOrder
+{
+    public const FIXTURE_DELIVERY_ID = 1;
+    public const FIXTURE_PAYMENT_ID = 10;
+    public const UNLINKED_PAYMENT_ID = 99;
+
+    private string $token = '';
+
+    /** @var array<string, mixed> */
+    private array $fields = [];
+
+    private ?JourneyCart $cart = null;
+
+    private int $submittedOrderId = 0;
+
+    public function bindCart(JourneyCart $cart): void
+    {
+        $this->cart = $cart;
+    }
+
+    public function initialize(string $token): bool
+    {
+        $this->token = $token;
+
+        return $token !== '';
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function get(): array
+    {
+        return JourneyResult::ok('', ['order' => $this->fields]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function add(string $key, mixed $value): array
+    {
+        if ($key === 'payment_id' && !$this->paymentAllowed((int) $value)) {
+            return JourneyResult::fail('ms3_err_payment_not_linked');
+        }
+
+        $this->fields[$key] = $value;
+
+        return JourneyResult::ok('ms3_order_add_success', ['order' => $this->fields]);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function set(array $fields): array
+    {
+        if (isset($fields['payment_id']) && !$this->paymentAllowed((int) $fields['payment_id'])) {
+            return JourneyResult::fail('ms3_err_payment_not_linked');
+        }
+
+        $this->fields = array_merge($this->fields, $fields);
+
+        return JourneyResult::ok('ms3_order_set_success', ['order' => $this->fields]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function submit(array $data = []): array
+    {
+        unset($data);
+
+        if ($this->cart === null || $this->cart->isEmpty($this->token)) {
+            return JourneyResult::fail('ms3_err_cart_empty');
+        }
+
+        if (empty($this->fields['delivery_id']) || empty($this->fields['payment_id'])) {
+            return JourneyResult::fail('ms3_err_order_incomplete');
+        }
+
+        $this->submittedOrderId = 501;
+        $this->cart->initialize('web', $this->token);
+        $this->cart->clean();
+
+        return JourneyResult::ok('ms3_order_submit_success', [
+            'msorder' => $this->submittedOrderId,
+            'redirect' => '/checkout/success?order=501',
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function getCost(bool $withCart = false): array
+    {
+        unset($withCart);
+        $cartCost = 0.0;
+        if ($this->cart !== null) {
+            $this->cart->initialize('web', $this->token);
+            $status = $this->cart->get()['data']['status'];
+            $cartCost = (float) $status['total_cost'];
+        }
+
+        $deliveryCost = isset($this->fields['delivery_id']) ? 50.0 : 0.0;
+        $paymentCost = isset($this->fields['payment_id']) ? 0.0 : 0.0;
+
+        return JourneyResult::ok('', [
+            'cart_cost' => $cartCost,
+            'delivery_cost' => $deliveryCost,
+            'payment_cost' => $paymentCost,
+            'cost' => $cartCost + $deliveryCost + $paymentCost,
+        ]);
+    }
+
+    /**
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public function setCustomerAddress(?string $addressHash = null): array
+    {
+        if ($addressHash === null || $addressHash === '') {
+            return JourneyResult::fail('ms3_err_address_hash_required');
+        }
+
+        $this->fields['address_hash'] = $addressHash;
+
+        return JourneyResult::ok('ms3_order_address_set_success', [
+            'order' => $this->fields,
+        ]);
+    }
+
+    public function lastSubmittedOrderId(): int
+    {
+        return $this->submittedOrderId;
+    }
+
+    private function paymentAllowed(int $paymentId): bool
+    {
+        $deliveryId = (int) ($this->fields['delivery_id'] ?? 0);
+        if ($deliveryId === self::FIXTURE_DELIVERY_ID && $paymentId === self::FIXTURE_PAYMENT_ID) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyProductCatalog.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyProductCatalog.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+use MiniShop3\Services\Product\ProductCatalogService;
+use MODX\Revolution\modX;
+
+/**
+ * Stub ProductCatalogService for public catalog HTTP journey.
+ */
+final class JourneyProductCatalog extends ProductCatalogService
+{
+    public const FIXTURE_PRODUCT_ID = 11;
+
+    public function __construct(modX $modx)
+    {
+        parent::__construct($modx);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>|null
+     */
+    public function getById(int $productId, array $params = []): ?array
+    {
+        unset($params);
+        if ($productId !== self::FIXTURE_PRODUCT_ID) {
+            return null;
+        }
+
+        return [
+            'id' => self::FIXTURE_PRODUCT_ID,
+            'pagetitle' => 'Journey Shirt',
+            'price' => 100.0,
+            'published' => 1,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array{total: int, limit: int, offset: int, results: list<array<string, mixed>>}
+     */
+    public function getList(array $params = []): array
+    {
+        $limit = max(1, (int) ($params['limit'] ?? 10));
+        $offset = max(0, (int) ($params['offset'] ?? 0));
+
+        $results = [
+            [
+                'id' => self::FIXTURE_PRODUCT_ID,
+                'pagetitle' => 'Journey Shirt',
+                'price' => 100.0,
+            ],
+        ];
+
+        return [
+            'total' => 1,
+            'limit' => $limit,
+            'offset' => $offset,
+            'results' => $results,
+        ];
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyResult.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * Shared success/error envelope for in-memory journey facades.
+ */
+final class JourneyResult
+{
+    /**
+     * @param array<string, mixed> $data
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public static function ok(string $message, array $data): array
+    {
+        return ['success' => true, 'message' => $message, 'data' => $data];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array{success: bool, message: string, data: array<string, mixed>}
+     */
+    public static function fail(string $message, array $data = []): array
+    {
+        return ['success' => false, 'message' => $message, 'data' => $data];
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyTokenService.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyTokenService.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+/**
+ * In-memory TokenService double for Web API Router journey tests.
+ */
+final class JourneyTokenService
+{
+    /** @var array<string, array{customer_id: int, expires_at: string}> */
+    private array $tokens = [];
+
+    private int $anonSeq = 0;
+
+    public function resolveApiToken(string $token): array
+    {
+        if ($token === '' || !isset($this->tokens[$token])) {
+            return ['token' => null, 'reason' => 'missing'];
+        }
+
+        $row = $this->tokens[$token];
+        if (strtotime($row['expires_at']) < time()) {
+            return ['token' => null, 'reason' => 'expired'];
+        }
+
+        return ['token' => $this->tokenRow($row['customer_id'], $row['expires_at']), 'reason' => 'ok'];
+    }
+
+    public function sessionTokenBelongsToCustomer(int $customerId): bool
+    {
+        return $customerId > 0;
+    }
+
+    /**
+     * @return array{token: string}
+     */
+    public function generateCustomerToken(): array
+    {
+        $this->anonSeq++;
+        $token = 'anon-journey-' . $this->anonSeq;
+        $this->putToken($token, 0);
+
+        return ['token' => $token];
+    }
+
+    public function putToken(string $token, int $customerId, ?string $expiresAt = null): void
+    {
+        $this->tokens[$token] = [
+            'customer_id' => $customerId,
+            'expires_at' => $expiresAt ?? date('Y-m-d H:i:s', time() + 3600),
+        ];
+    }
+
+    public function promoteToCustomer(string $token, int $customerId): void
+    {
+        $this->putToken($token, $customerId);
+    }
+
+    public function forget(string $token): void
+    {
+        unset($this->tokens[$token]);
+    }
+
+    private function tokenRow(int $customerId, string $expiresAt): object
+    {
+        return new class ($customerId, $expiresAt) {
+            public function __construct(
+                private int $customerId,
+                private string $expiresAt,
+            ) {
+            }
+
+            public function get(string $field): mixed
+            {
+                return match ($field) {
+                    'customer_id' => $this->customerId,
+                    'expires_at' => $this->expiresAt,
+                    default => null,
+                };
+            }
+        };
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyTokenService.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyTokenService.php
@@ -25,7 +25,26 @@ final class JourneyTokenService
             return ['token' => null, 'reason' => 'expired'];
         }
 
-        return ['token' => $this->tokenRow($row['customer_id'], $row['expires_at']), 'reason' => 'ok'];
+        return [
+            'token' => $this->tokenRow($token, $row['customer_id'], $row['expires_at']),
+            'reason' => 'ok',
+        ];
+    }
+
+    /**
+     * Mirror TokenService::syncSessionFromToken for middleware after #588.
+     */
+    public function syncSessionFromToken(object $tokenObj): void
+    {
+        if (!isset($_SESSION['ms3'])) {
+            $_SESSION['ms3'] = [];
+        }
+
+        $token = (string) $tokenObj->get('token');
+        $customerId = (int) $tokenObj->get('customer_id');
+        $_SESSION['ms3']['customer_token'] = $token;
+        $_SESSION['ms3']['customer_token_expires'] = strtotime((string) $tokenObj->get('expires_at'));
+        $_SESSION['ms3']['customer_id'] = $customerId > 0 ? $customerId : 0;
     }
 
     public function sessionTokenBelongsToCustomer(int $customerId): bool
@@ -63,10 +82,11 @@ final class JourneyTokenService
         unset($this->tokens[$token]);
     }
 
-    private function tokenRow(int $customerId, string $expiresAt): object
+    private function tokenRow(string $token, int $customerId, string $expiresAt): object
     {
-        return new class ($customerId, $expiresAt) {
+        return new class ($token, $customerId, $expiresAt) {
             public function __construct(
+                private string $token,
                 private int $customerId,
                 private string $expiresAt,
             ) {
@@ -75,6 +95,7 @@ final class JourneyTokenService
             public function get(string $field): mixed
             {
                 return match ($field) {
+                    'token' => $this->token,
                     'customer_id' => $this->customerId,
                     'expires_at' => $this->expiresAt,
                     default => null,

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyWebApiModx.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyWebApiModx.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Tests\Stubs\ProcessorResponseStub;
+use MODX\Revolution\WebApiModxStub;
+
+/**
+ * WebApiModxStub extended with journey DI (ms3, catalog, customer orders).
+ */
+final class JourneyWebApiModx extends WebApiModxStub
+{
+    public JourneyMs3 $ms3;
+
+    public JourneyTokenService $journeyTokens;
+
+    public JourneyProductCatalog $catalog;
+
+    public JourneyCustomerOrderService $customerOrders;
+
+    /** @var array<string, mixed> */
+    private array $options = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->context = new class {
+            public string $key = 'web';
+
+            public function get(string $field): string
+            {
+                return $field === 'key' ? $this->key : '';
+            }
+        };
+
+        $this->ms3 = new JourneyMs3();
+        $this->journeyTokens = new JourneyTokenService();
+        $this->tokenService = $this->journeyTokens;
+        $this->catalog = new JourneyProductCatalog($this);
+        $this->customerOrders = new JourneyCustomerOrderService($this);
+
+        $rlPath = sys_get_temp_dir() . '/ms3-webapi-rl-' . getmypid();
+        if (!is_dir($rlPath)) {
+            mkdir($rlPath, 0777, true);
+        }
+
+        $this->options = [
+            'ms3_cors_allowed_origins' => 'https://shop.example',
+            'ms3_rate_limit_max_attempts' => 10000,
+            'ms3_rate_limit_decay_seconds' => 60,
+            'ms3_rate_limit_storage_path' => $rlPath,
+            'ms3_customer_token_ttl' => 604800,
+            'session_cookie_path' => '/',
+            'session_cookie_domain' => '',
+            'session_cookie_secure' => false,
+            'session_cookie_samesite' => 'Lax',
+        ];
+
+        $this->services = new class ($this) {
+            public function __construct(private JourneyWebApiModx $modx)
+            {
+            }
+
+            public function has(string $key): bool
+            {
+                return in_array($key, [
+                    'ms3',
+                    'ms3_token_service',
+                    'ms3_product_catalog',
+                    'ms3_customer_order',
+                ], true);
+            }
+
+            public function get(string $key): mixed
+            {
+                return match ($key) {
+                    'ms3' => $this->modx->ms3,
+                    'ms3_token_service' => $this->modx->tokenService,
+                    'ms3_product_catalog' => $this->modx->catalog,
+                    'ms3_customer_order' => $this->modx->customerOrders,
+                    default => null,
+                };
+            }
+        };
+
+        $this->lexicon = new class {
+            /** @var array<string, string> */
+            private array $strings = [];
+
+            public function load(string ...$topics): void
+            {
+            }
+
+            public function setStrings(array $strings): void
+            {
+                $this->strings = $strings;
+            }
+
+            public function lexicon(string $key, array $options = []): string
+            {
+                $value = $this->strings[$key] ?? $key;
+                foreach ($options as $placeholder => $replacement) {
+                    $value = str_replace('{' . $placeholder . '}', (string) $replacement, $value);
+                }
+
+                return $value;
+            }
+        };
+    }
+
+    public function setTokenService(object $tokenService): void
+    {
+        $this->tokenService = $tokenService;
+        if ($tokenService instanceof JourneyTokenService) {
+            $this->journeyTokens = $tokenService;
+        }
+    }
+
+    public function getOption(string $key, $options = null, $default = null)
+    {
+        return $this->options[$key] ?? $default;
+    }
+
+    /**
+     * @param array<string, mixed> $map
+     */
+    public function setOptions(array $map): void
+    {
+        $this->options = array_merge($this->options, $map);
+    }
+
+    /**
+     * @param class-string|array<string, mixed>|int|string $className
+     * @param array<string, mixed>|int|string|null $criteria
+     */
+    public function getObject($className, $criteria = '', bool $cacheFlag = true): ?object
+    {
+        if ($className === msCustomer::class || $className === 'MiniShop3\\Model\\msCustomer') {
+            $id = is_array($criteria) ? (int) ($criteria['id'] ?? 0) : (int) $criteria;
+
+            return $this->customers[$id] ?? null;
+        }
+
+        return parent::getObject($className, $criteria, $cacheFlag);
+    }
+
+    /**
+     * Default auth processors for journey login/register (body may be empty — stubs ignore fields).
+     * On login/register: mint user token and transfer guest cart bag (#412/#574).
+     */
+    public function installAuthProcessors(int $customerId = 42): void
+    {
+        $this->putCustomer($customerId);
+        $tokens = $this->journeyTokens;
+        $ms3 = $this->ms3;
+
+        $this->runProcessorHandler = static function (string $action, array $data) use ($tokens, $customerId, $ms3): ProcessorResponseStub {
+            unset($data);
+
+            if ($action === 'MiniShop3\\Processors\\Api\\Customer\\Login'
+                || $action === 'MiniShop3\\Processors\\Api\\Customer\\Register'
+            ) {
+                $guestToken = (string) ($_REQUEST['ms3_token'] ?? '');
+                $token = 'user-journey-token-' . $customerId;
+                $tokens->putToken($token, $customerId);
+
+                if ($ms3->cart instanceof JourneyCart && $guestToken !== '' && $guestToken !== $token) {
+                    $ms3->cart->transfer($guestToken, $token);
+                    $tokens->forget($guestToken);
+                }
+
+                return ProcessorResponseStub::success([
+                    'token' => $token,
+                    'customer_id' => $customerId,
+                ], 'authenticated');
+            }
+
+            if ($action === 'MiniShop3\\Processors\\Api\\Customer\\Logout') {
+                return ProcessorResponseStub::success(null, 'logged out');
+            }
+
+            return ProcessorResponseStub::failure('Unhandled processor: ' . $action);
+        };
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/WebApiTestCase.php
+++ b/core/components/minishop3/tests/Integration/WebApi/WebApiTestCase.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+use MiniShop3\Router\Response;
+use MiniShop3\Router\Router;
+use MiniShop3\Tests\Integration\WebApi\Support\JourneyWebApiModx;
+use MiniShop3\Utils\CookieHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Shared harness: Router + web.php + journey MODX stub.
+ */
+abstract class WebApiTestCase extends TestCase
+{
+    protected JourneyWebApiModx $modx;
+
+    protected Router $router;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(\MODX\Revolution\modX::class, false)) {
+            require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
+        }
+        require_once dirname(__DIR__, 2) . '/stubs/FakeMsCustomer.php';
+        require_once dirname(__DIR__, 2) . '/stubs/WebApiModxStub.php';
+        require_once dirname(__DIR__, 2) . '/stubs/ProcessorResponseStub.php';
+
+        $this->resetSuperglobals();
+        $this->modx = new JourneyWebApiModx();
+        $this->modx->installAuthProcessors(42);
+        $this->router = $this->buildRouter($this->modx);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetSuperglobals();
+        parent::tearDown();
+    }
+
+    protected function buildRouter(JourneyWebApiModx $modx): Router
+    {
+        $router = new Router($modx);
+        $router->loadRoutes(dirname(__DIR__, 3) . '/config/routes/web.php');
+        $router->build();
+
+        return $router;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $post
+     * @param array<string, string> $headers Map without HTTP_ prefix style keys, e.g. Authorization
+     * @return array{status: int, success: bool|null, message: string, data: mixed, body: array<string, mixed>}
+     */
+    protected function dispatch(
+        string $method,
+        string $route,
+        array $query = [],
+        array $post = [],
+        array $headers = [],
+        ?string $bearer = null,
+        ?string $cookieToken = null,
+    ): array {
+        $_GET = $query;
+        $_POST = $post;
+        $_REQUEST = array_merge($query, $post, ['route' => $route]);
+        $_SERVER['REQUEST_METHOD'] = strtoupper($method);
+        $_SERVER['REQUEST_URI'] = $route;
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.' . ((getmypid() % 200) + 1);
+
+        unset($_SERVER['HTTP_AUTHORIZATION'], $_SERVER['HTTP_MS3TOKEN'], $_SERVER['HTTP_ORIGIN']);
+
+        if ($bearer !== null && $bearer !== '') {
+            $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $bearer;
+            $_REQUEST['ms3_token'] = $bearer;
+        }
+
+        foreach ($headers as $name => $value) {
+            $serverKey = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+            $_SERVER[$serverKey] = $value;
+        }
+
+        if ($cookieToken !== null && $cookieToken !== '') {
+            $_COOKIE['ms3_token'] = $cookieToken;
+        } else {
+            unset($_COOKIE['ms3_token']);
+        }
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+
+        $response = $this->router->dispatch($route, strtoupper($method));
+
+        return $this->envelope($response);
+    }
+
+    /**
+     * @param array{status: int, success: bool|null, message: string, data: mixed, body: array<string, mixed>} $res
+     */
+    protected function assertApiError(array $res, int $status, string $message): void
+    {
+        self::assertSame($status, $res['status']);
+        self::assertFalse($res['success']);
+        self::assertSame($message, $res['message']);
+    }
+
+    protected function lastMs3Token(): string
+    {
+        return (string) ($_REQUEST['ms3_token'] ?? '');
+    }
+
+    /**
+     * @return array{status: int, success: bool|null, message: string, data: mixed, body: array<string, mixed>}
+     */
+    protected function envelope(Response $response): array
+    {
+        $body = $response->getData();
+        if (!is_array($body)) {
+            $body = [];
+        }
+
+        return [
+            'status' => $response->getStatusCode(),
+            'success' => isset($body['success']) ? (bool) $body['success'] : null,
+            'message' => (string) ($body['message'] ?? ''),
+            'data' => $body['data'] ?? null,
+            'body' => $body,
+        ];
+    }
+
+    protected function resetSuperglobals(): void
+    {
+        $_GET = [];
+        $_POST = [];
+        $_REQUEST = [];
+        $_COOKIE = [];
+        unset(
+            $_SERVER['HTTP_AUTHORIZATION'],
+            $_SERVER['HTTP_MS3TOKEN'],
+            $_SERVER['HTTP_ORIGIN'],
+            $_SERVER['REQUEST_URI'],
+            $_SERVER['REQUEST_METHOD'],
+        );
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+        }
+
+        // Allow CookieHelper to set cookies again in the next request cycle.
+        $ref = new \ReflectionClass(CookieHelper::class);
+        if ($ref->hasProperty('lastTokenSet')) {
+            $prop = $ref->getProperty('lastTokenSet');
+            $prop->setAccessible(true);
+            $prop->setValue(null, null);
+        }
+    }
+}

--- a/core/components/minishop3/tests/bootstrap.php
+++ b/core/components/minishop3/tests/bootstrap.php
@@ -9,3 +9,8 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 require __DIR__ . '/support/xpdo_stub.php';
 require __DIR__ . '/support/xpdo_om_stub.php';
 require __DIR__ . '/support/modresource_stub.php';
+
+// tests/support/ is lowercase on disk; PSR-4 expects Support/ — require on Linux CI (#595).
+require __DIR__ . '/support/SqliteDraftCartProduct.php';
+require __DIR__ . '/support/SqliteHarnessCart.php';
+require __DIR__ . '/support/SqliteDraftCartHarnessTrait.php';

--- a/core/components/minishop3/tests/support/SqliteDraftCartHarnessTrait.php
+++ b/core/components/minishop3/tests/support/SqliteDraftCartHarnessTrait.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use MiniShop3\Controllers\Cart\Cart;
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msProduct;
+use MiniShop3\Services\Cart\CartItemManager;
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\Order\OrderService;
+use MiniShop3\Tests\RecordingMsOrder;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Shared SQLite draft cart factory for CartFacade + WebApi Phase B tests.
+ *
+ * @mixin TestCase
+ */
+trait SqliteDraftCartHarnessTrait
+{
+    protected function makeSqliteDraftCart(
+        OrderProductSqliteStore $store,
+        RecordingMsOrder $draft,
+        SqliteDraftCartProduct $product
+    ): Cart {
+        $utils = new class {
+            public function success(string $message = '', array $data = [], array $placeholders = []): array
+            {
+                unset($placeholders);
+
+                return ['success' => true, 'message' => $message, 'data' => $data];
+            }
+
+            public function error(string $message = '', array $data = [], array $placeholders = []): array
+            {
+                unset($placeholders);
+
+                return ['success' => false, 'message' => $message, 'data' => $data];
+            }
+
+            public function invokeEvent(string $eventName, array $params = []): array
+            {
+                unset($eventName);
+
+                return ['success' => true, 'message' => '', 'data' => $params];
+            }
+        };
+
+        $orderService = new OrderService(new modX());
+        $modx = new class ($store, $product, $orderService) extends modX {
+            public function __construct(
+                private OrderProductSqliteStore $store,
+                private SqliteDraftCartProduct $product,
+                OrderService $orderService,
+            ) {
+                parent::__construct();
+                $this->lexicon = new class {
+                    public function load($topic): void
+                    {
+                    }
+                };
+                $this->services = new class ($orderService) {
+                    public function __construct(private OrderService $orderService)
+                    {
+                    }
+
+                    public function has(string $key): bool
+                    {
+                        return $key === 'ms3_order_service';
+                    }
+
+                    public function get(string $key): mixed
+                    {
+                        return $key === 'ms3_order_service' ? $this->orderService : null;
+                    }
+                };
+            }
+
+            public function getOption($key, $options = null, $default = null, $skipEmpty = false)
+            {
+                return match ((string) $key) {
+                    'ms3_cart_max_count' => 1000,
+                    'ms3_cart_product_key_fields' => 'id,options',
+                    'ms3_cart_context' => '0',
+                    default => $default,
+                };
+            }
+
+            public function lexicon(string $key, array $params = []): string
+            {
+                return (string) $key;
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className === msProduct::class && is_array($criteria)) {
+                    if ((int) ($criteria['id'] ?? 0) !== (int) $this->product->get('id')) {
+                        return null;
+                    }
+
+                    return $this->product;
+                }
+
+                if ($className === msOrderProduct::class && is_array($criteria)) {
+                    $row = $this->store->findOne($criteria);
+                    if ($row === null) {
+                        return null;
+                    }
+                    $item = new SqliteOrderProduct();
+                    $item->bindStore($this->store);
+                    $item->hydrate($row);
+
+                    return $item;
+                }
+
+                return null;
+            }
+
+            public function newObject($className, $fields = [])
+            {
+                if ($className === msOrderProduct::class) {
+                    $item = new SqliteOrderProduct();
+                    $item->bindStore($this->store);
+                    if (is_array($fields) && $fields !== []) {
+                        $item->fromArray($fields);
+                    }
+
+                    return $item;
+                }
+
+                return null;
+            }
+
+            public function getIterator($className, $criteria = null, $cacheFlag = true): \ArrayIterator
+            {
+                if ($className === msOrderProduct::class) {
+                    $rows = $this->store->findAll(is_array($criteria) ? $criteria : []);
+                    $items = [];
+                    foreach ($rows as $row) {
+                        $item = new SqliteOrderProduct();
+                        $item->bindStore($this->store);
+                        $item->hydrate($row);
+                        $items[] = $item;
+                    }
+
+                    return new \ArrayIterator($items);
+                }
+
+                return new \ArrayIterator([]);
+            }
+
+            public function getCount($className, $criteria = null)
+            {
+                if ($className === msOrderProduct::class) {
+                    return count($this->store->findAll(is_array($criteria) ? $criteria : []));
+                }
+
+                return 0;
+            }
+        };
+
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->createStub(MiniShop3::class);
+        $ms3->modx = $modx;
+        $ms3->utils = $utils;
+
+        $itemManager = new CartItemManager($modx, $ms3);
+        /** @var OrderDraftManager $draftManager */
+        $draftManager = $this->createStub(OrderDraftManager::class);
+        $draftManager->method('getDraft')->willReturn($draft);
+        $draftManager->method('getOrCreateDraft')->willReturn($draft);
+        $draftManager->method('isEmpty')->willReturnCallback(
+            static function (msOrder $order) use ($store): bool {
+                return $store->findAll(['order_id' => (int) $order->get('id')]) === [];
+            }
+        );
+        $draftManager->method('deleteDraft')->willReturn(true);
+        $draftManager->method('recalculate')->willReturnCallback(
+            static function (msOrder $order) use ($orderService, $itemManager): void {
+                $items = $itemManager->loadItems($order);
+                $products = [];
+                foreach ($items as $row) {
+                    $products[] = new class ($row) {
+                        public function __construct(private array $row)
+                        {
+                        }
+
+                        public function get(string $field): mixed
+                        {
+                            return $this->row[$field] ?? 0;
+                        }
+                    };
+                }
+                $totals = OrderService::aggregateProductsTotals($products);
+                $order->set('cart_cost', $totals['cart_cost']);
+                $order->set('weight', $totals['weight']);
+                $order->set(
+                    'cost',
+                    $orderService->clampComputedTotal(
+                        $order,
+                        (float) $totals['cart_cost'],
+                        (float) ($order->get('delivery_cost') ?? 0),
+                        0.0
+                    )
+                );
+                $order->save();
+            }
+        );
+
+        return new SqliteHarnessCart($ms3, $itemManager, $draftManager);
+    }
+}

--- a/core/components/minishop3/tests/support/SqliteDraftCartProduct.php
+++ b/core/components/minishop3/tests/support/SqliteDraftCartProduct.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use MiniShop3\Model\msProduct;
+
+/**
+ * Lightweight published product for SQLite draft cart harnesses.
+ */
+final class SqliteDraftCartProduct extends msProduct
+{
+    /** @var array<string, mixed> */
+    public $_fieldMeta = [];
+
+    /** @var array<string, mixed> */
+    protected $_fields = [];
+
+    /** @var list<string> */
+    protected $dataRelated = [];
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function __construct(array $fields = [])
+    {
+        $this->_fields = $fields;
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->_fields[$k] ?? null;
+    }
+
+    public function toArray($keyPrefix = '', $rawValues = false, $excludeLazy = false, $includeRelated = false): array
+    {
+        return $this->_fields;
+    }
+
+    public function getPrice($data = [])
+    {
+        return (float) ($this->_fields['price'] ?? 0);
+    }
+
+    public function getWeight($data = [])
+    {
+        return (float) ($this->_fields['weight'] ?? 0);
+    }
+}

--- a/core/components/minishop3/tests/support/SqliteHarnessCart.php
+++ b/core/components/minishop3/tests/support/SqliteHarnessCart.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Support;
+
+use MiniShop3\Controllers\Cart\Cart;
+use MiniShop3\MiniShop3;
+use MiniShop3\Services\Cart\CartItemManager;
+use MiniShop3\Services\Cart\CartMutationHandler;
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\Order\OrderLogService;
+
+/**
+ * Cart facade wired with injected managers for SQLite draft tests.
+ */
+final class SqliteHarnessCart extends Cart
+{
+    public function __construct(
+        MiniShop3 $ms3,
+        CartItemManager $itemManager,
+        OrderDraftManager $draftManager
+    ) {
+        $this->ms3 = $ms3;
+        $this->modx = $ms3->modx;
+        $this->itemManager = $itemManager;
+        $this->draftManager = $draftManager;
+        $this->mutationHandler = new CartMutationHandler(
+            $this->modx,
+            $this->ms3,
+            $this->draftManager,
+            $this->itemManager,
+            $this->getOrderLog()
+        );
+    }
+
+    protected function getOrderLog(): OrderLogService
+    {
+        return new class extends OrderLogService {
+            public function __construct()
+            {
+            }
+
+            public function addEntry(int $orderId, string $action, array $data, bool $visible = true): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    protected function getCustomerId(): ?int
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
## Описание

Интеграционный PHPUnit suite для Web API (`Router` + `web.php` + middleware + envelope), который гоняет headless Nuxt customer journey на HTTP-контракте. Domain-facade тесты остаются, но CI теперь падает, если сломан wire-контракт storefront.

## Тип изменений

- [x] Новая функциональность (non-breaking change)
- [x] Другое (опишите): только тесты + CI wiring, runtime API не меняется

## Связанные Issues

Closes #574

## Как это было протестировано?

```bash
cd core/components/minishop3
composer test:web-api   # exit 0 — 15 tests, 101 assertions
composer test           # exit 0 — Unit + Integration + WebApi (без suite overlap)
php -l на всех новых PHP в tests/Integration/WebApi и tests/support/SqliteDraft*
```

- [x] Автоматические тесты (`composer test:web-api`, `composer test`)
- [ ] Ручное тестирование
- [ ] `composer ci:php` целиком (локально прогнаны test:web-api + test; полный php -l по дереву — через CI)

**Конфигурация тестирования:**
- MiniShop3: ветка `feat/issue-574-headless-webapi-journey`
- MODX: stub / без полной установки
- PHP: 8.4.17

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы n/a (только тесты)
- [ ] PHPStan n/a для тестового harness
- [x] CHANGELOG не трогали (релизный процесс)

## Дополнительные заметки

### Что внутри

- Phase A: happy path catalog → cart → login (Bearer + cookie) → address/delivery/payment fixtures → cost → submit → customer orders
- Error cases: 404 product, 401 invalid/expired/guest orders/failed auto-mint, 400 change-option/submit/payment pairing
- CORS: normalize `*`+credentials + empty origins, OPTIONS subprocess (exit 200 + allowlisted origin)
- Phase B: cart add/change/get через Router + SQLite draft (`SqliteDraftCartHarnessTrait`, общий с `CartFacadeDraftStoreTest`)
- `composer test:web-api`, suite `WebApi`, exclude из Integration directory (нет двойной регистрации)
- Локальный запуск: `tests/Integration/WebApi/HOW_TO_RUN.txt`

### Out of scope (как в #574)

- Phase C built-in server → `api.php`
- Public delivery/payment list discovery
- MySQL `@group mysql` не обязателен для suite

### Review

Пройдены code-reviewer, thermo-nuclear, security-review, silent-failure-hunter. Исправлены suite overlap, token-изоляция cart + transfer на login, общий SQLite harness.