### PR TITLE
feat(web-api): seo-блок для product/category get

### DIFF
--- a/_build/elements/events.php
+++ b/_build/elements/events.php
@@ -83,6 +83,7 @@ return [
     'msOnGetProductPrice',
     'msOnGetProductWeight',
     'msOnGetProductFields',
+    'msOnGetPublicSeo',
 
     // msProducts snippet events (for extending with external packages)
     'msOnProductsLoad',    // After loading products, for bulk data loading

--- a/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
@@ -29,6 +29,9 @@ class CategoryController
     /**
      * GET /api/v1/category/get/{id}
      *
+     * Query: context, include_hidden, include_content, include_breadcrumbs,
+     *        include_children, include_seo (default 1).
+     *
      * @param array<string, mixed> $params
      */
     public function get(array $params = []): Response

--- a/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
@@ -31,7 +31,8 @@ class ProductController
     /**
      * GET /api/v1/product/get/{id}
      *
-     * Query: context, include_images (0|1, default 0 — omit images[]; name→alt, no DB alt).
+     * Query: context, include_images (0|1, default 0 — omit images[]; name→alt, no DB alt),
+     *        include_seo (default 1).
      *
      * @param array<string, mixed> $params
      */

--- a/core/components/minishop3/src/ServiceRegistry.php
+++ b/core/components/minishop3/src/ServiceRegistry.php
@@ -166,6 +166,10 @@ class ServiceRegistry
             'class' => \MiniShop3\Services\Product\ProductGalleryPublicService::class,
             'interface' => null,
         ],
+        'ms3_public_seo' => [
+            'class' => \MiniShop3\Services\Seo\PublicSeoService::class,
+            'interface' => null,
+        ],
         'ms3_category_catalog' => [
             'class' => \MiniShop3\Services\Category\CategoryCatalogService::class,
             'interface' => null,

--- a/core/components/minishop3/src/ServiceRegistryFactories.php
+++ b/core/components/minishop3/src/ServiceRegistryFactories.php
@@ -41,6 +41,7 @@ class ServiceRegistryFactories
             'ms3_product_catalog' => $modxOnly(),
             'ms3_product_facets' => $modxOnly(),
             'ms3_product_gallery_public' => $modxOnly(),
+            'ms3_public_seo' => $modxOnly(),
             'ms3_category_catalog' => $modxOnly(),
             'ms3_delivery_catalog' => $modxOnly(),
             'ms3_payment_catalog' => $modxOnly(),

--- a/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryCatalogService.php
@@ -7,6 +7,7 @@ namespace MiniShop3\Services\Category;
 use MiniShop3\Model\msCategory;
 use MiniShop3\Services\Catalog\CatalogQuery;
 use MiniShop3\Services\Catalog\CatalogResolve;
+use MiniShop3\Services\Seo\PublicSeoService;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOQuery;
 
@@ -126,6 +127,9 @@ class CategoryCatalogService
     }
 
     /**
+     * Query: context, include_hidden, include_content, include_breadcrumbs,
+     *        include_children, include_seo (default 1). List/tree omit seo.
+     *
      * @param array<string, mixed> $params
      * @return array<string, mixed>|null
      */
@@ -159,7 +163,10 @@ class CategoryCatalogService
             );
         }
 
-        return $payload;
+        /** @var PublicSeoService $seo */
+        $seo = $this->modx->services->get('ms3_public_seo');
+
+        return $seo->maybeAttachCategory($payload, $params);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Product/ProductCatalogService.php
+++ b/core/components/minishop3/src/Services/Product/ProductCatalogService.php
@@ -12,6 +12,7 @@ use MiniShop3\Services\Catalog\CatalogResolve;
 use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Services\Option\OptionService;
+use MiniShop3\Services\Seo\PublicSeoService;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOQuery;
 
@@ -166,7 +167,8 @@ class ProductCatalogService
     /**
      * Single published product by ID (same visibility rules as list).
      *
-     * Query: context, include_images (0|1, default 0).
+     * Query: context, include_images (0|1, default 0), include_seo (default 1).
+     * List payloads omit seo.
      *
      * @param array<string, mixed> $params Optional context override
      * @return array<string, mixed>|null
@@ -185,7 +187,12 @@ class ProductCatalogService
         $includeImages = self::toBool($params['include_images'] ?? false);
         $images = $includeImages ? $this->loadImagesForProduct($product) : null;
 
-        return $this->formatProduct($product, true, $options, $images);
+        $payload = $this->formatProduct($product, true, $options, $images);
+
+        /** @var PublicSeoService $seo */
+        $seo = $this->modx->services->get('ms3_public_seo');
+
+        return $seo->maybeAttachProduct($payload, $params);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Seo/PublicSeoBuilder.php
+++ b/core/components/minishop3/src/Services/Seo/PublicSeoBuilder.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Seo;
+
+/**
+ * Core SEO projection for public catalog JSON (#567).
+ *
+ * Fallbacks: title ← longtitle|pagetitle; description ← description|introtext;
+ * canonical / og.image ← absolute site_url + uri/image|thumb; robots = index,follow.
+ * og.type is product|website. Unknown keys are dropped by whitelist().
+ * No third-party SEO Extra. Optional overrides: event msOnGetPublicSeo
+ * (returnedValues['seo'] assoc patch). TV map ms3_public_seo_tv_map is a follow-up.
+ */
+final class PublicSeoBuilder
+{
+    public const OG_TYPE_PRODUCT = 'product';
+    public const OG_TYPE_CATEGORY = 'website';
+
+    /** @var list<string> */
+    public const KEYS = ['title', 'description', 'canonical', 'robots', 'og'];
+
+    /** @var list<string> */
+    public const OG_KEYS = ['title', 'description', 'image', 'type'];
+
+    /**
+     * Absolute URL without double slashes. Already-absolute http(s) and protocol-relative
+     * paths are returned unchanged. Empty path yields empty string (not site root).
+     */
+    public static function absoluteUrl(string $base, string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '';
+        }
+
+        if (preg_match('#^(https?:)?//#i', $path) === 1) {
+            return $path;
+        }
+
+        $base = rtrim(trim($base), '/');
+        if ($base === '') {
+            return '/' . ltrim($path, '/');
+        }
+
+        return $base . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * @param array<string, mixed> $fields Public catalog payload (pagetitle, uri, image, …)
+     * @return array{
+     *     title: string,
+     *     description: string,
+     *     canonical: string,
+     *     robots: string,
+     *     og: array{title: string, description: string, image: string, type: string}
+     * }
+     */
+    public static function build(array $fields, string $siteUrl, string $ogType): array
+    {
+        $title = self::field($fields, 'longtitle', 'pagetitle');
+        $description = self::field($fields, 'description', 'introtext');
+        $imagePath = self::field($fields, 'image', 'thumb');
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => self::absoluteUrl($siteUrl, (string) ($fields['uri'] ?? '')),
+            'robots' => 'index,follow',
+            'og' => [
+                'title' => $title,
+                'description' => $description,
+                'image' => self::absoluteUrl($siteUrl, $imagePath),
+                'type' => $ogType,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $seo
+     * @return array<string, mixed>
+     */
+    public static function whitelist(array $seo): array
+    {
+        $out = [];
+        foreach (self::KEYS as $key) {
+            if (!array_key_exists($key, $seo)) {
+                continue;
+            }
+            if ($key === 'og') {
+                if (is_array($seo['og'])) {
+                    $out['og'] = self::stringFields($seo['og'], self::OG_KEYS);
+                }
+                continue;
+            }
+            if (is_scalar($seo[$key]) || $seo[$key] === null) {
+                $out[$key] = (string) $seo[$key];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * First non-empty trimmed string among payload keys.
+     *
+     * @param array<string, mixed> $fields
+     */
+    private static function field(array $fields, string ...$keys): string
+    {
+        foreach ($keys as $key) {
+            $value = trim((string) ($fields[$key] ?? ''));
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     * @param list<string> $keys
+     * @return array<string, string>
+     */
+    private static function stringFields(array $source, array $keys): array
+    {
+        $out = [];
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $source)) {
+                continue;
+            }
+            $value = $source[$key];
+            if (is_scalar($value) || $value === null) {
+                $out[$key] = (string) $value;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/core/components/minishop3/src/Services/Seo/PublicSeoService.php
+++ b/core/components/minishop3/src/Services/Seo/PublicSeoService.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Seo;
+
+use MiniShop3\Services\Catalog\CatalogQuery;
+use MiniShop3\Utils\EventGate;
+use MODX\Revolution\modX;
+
+/**
+ * Attach allowlisted `seo` to a public catalog payload (#567).
+ *
+ * Optional enrichment: plugins on msOnGetPublicSeo may set
+ * $modx->event->returnedValues['seo'] (assoc patch). Core has no SEO Extra.
+ */
+final class PublicSeoService
+{
+    public function __construct(
+        private modX $modx,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function maybeAttachProduct(array $payload, array $params): array
+    {
+        return $this->maybeAttach($payload, $params, PublicSeoBuilder::OG_TYPE_PRODUCT);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function maybeAttachCategory(array $payload, array $params): array
+    {
+        return $this->maybeAttach($payload, $params, PublicSeoBuilder::OG_TYPE_CATEGORY);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    private function maybeAttach(array $payload, array $params, string $ogType): array
+    {
+        if (!CatalogQuery::resolveBool($params, 'include_seo', true)) {
+            return $payload;
+        }
+
+        $payload['seo'] = $this->build($payload, $params, $ogType);
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    private function build(array $payload, array $params, string $ogType): array
+    {
+        $seo = PublicSeoBuilder::build($payload, $this->siteUrl($payload, $params), $ogType);
+
+        $event = EventGate::invokeRaw($this->modx, 'msOnGetPublicSeo', [
+            'seo' => $seo,
+            'payload' => $payload,
+            'og_type' => $ogType,
+        ]);
+        $patch = $event['returnedValues']['seo'] ?? null;
+        $seo = EventGate::applyReturnedArray($seo, $event['returnedValues'], 'seo');
+
+        return PublicSeoBuilder::whitelist(self::mirrorOgText($seo, $patch));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $params
+     */
+    private function siteUrl(array $payload, array $params): string
+    {
+        $fromPayload = trim((string) ($payload['context_key'] ?? ''));
+        $contextKey = CatalogQuery::resolveContext($params, $fromPayload !== '' ? $fromPayload : 'web');
+        $context = $this->modx->getContext($contextKey);
+        if (is_object($context) && method_exists($context, 'getOption')) {
+            $url = trim((string) $context->getOption('site_url'));
+            if ($url !== '') {
+                return $url;
+            }
+        }
+
+        return (string) $this->modx->getOption('site_url', null, '');
+    }
+
+    /**
+     * Keep og.title / og.description in sync with title / description unless the plugin
+     * explicitly patched those og keys.
+     *
+     * @param array<string, mixed> $seo
+     * @return array<string, mixed>
+     */
+    private static function mirrorOgText(array $seo, mixed $patch): array
+    {
+        $ogPatch = is_array($patch) && isset($patch['og']) && is_array($patch['og']) ? $patch['og'] : [];
+        $og = isset($seo['og']) && is_array($seo['og']) ? $seo['og'] : [];
+        if (!array_key_exists('title', $ogPatch)) {
+            $og['title'] = (string) ($seo['title'] ?? '');
+        }
+        if (!array_key_exists('description', $ogPatch)) {
+            $og['description'] = (string) ($seo['description'] ?? '');
+        }
+        $seo['og'] = $og;
+
+        return $seo;
+    }
+}

--- a/core/components/minishop3/tests/PublicSeoRoutesTest.php
+++ b/core/components/minishop3/tests/PublicSeoRoutesTest.php
@@ -56,6 +56,13 @@ if (substr_count($categoryCatalog, 'maybeAttachCategory') !== 1) {
     $fail('category catalog must attach seo only once (get)');
 }
 
+if (!preg_match('/function resolveByLookup.*?return \$this->getById\(/s', $productCatalog)) {
+    $fail('product resolveByLookup must reuse getById so seo attaches');
+}
+if (!preg_match('/function resolveByLookup.*?return \$this->getById\(/s', $categoryCatalog)) {
+    $fail('category resolveByLookup must reuse getById so seo attaches');
+}
+
 if (str_contains($productCatalog, 'PublicSeoBuilder')) {
     $fail('product catalog must not import PublicSeoBuilder');
 }

--- a/core/components/minishop3/tests/PublicSeoRoutesTest.php
+++ b/core/components/minishop3/tests/PublicSeoRoutesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Smoke: public seo block wiring for product/category get (#567).
+ *
+ * Run: php tests/PublicSeoRoutesTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$read = static function (string $relative) use ($fail): string {
+    $path = __DIR__ . '/../' . $relative;
+    $src = file_get_contents($path);
+    if ($src === false) {
+        $fail("unable to read {$relative}");
+    }
+
+    return $src;
+};
+
+$productCatalog = $read('src/Services/Product/ProductCatalogService.php');
+$categoryCatalog = $read('src/Services/Category/CategoryCatalogService.php');
+$productController = $read('src/Controllers/Api/Web/ProductController.php');
+$categoryController = $read('src/Controllers/Api/Web/CategoryController.php');
+$registry = $read('src/ServiceRegistry.php');
+$factories = $read('src/ServiceRegistryFactories.php');
+$events = $read('../../../_build/elements/events.php');
+$composer = $read('composer.json');
+
+if (!str_contains($registry, "'ms3_public_seo'")) {
+    $fail('ServiceRegistry missing ms3_public_seo');
+}
+if (!str_contains($factories, "'ms3_public_seo'")) {
+    $fail('ServiceRegistryFactories missing ms3_public_seo');
+}
+if (!str_contains($events, "'msOnGetPublicSeo'")) {
+    $fail('events.php missing msOnGetPublicSeo');
+}
+
+if (!str_contains($productCatalog, 'maybeAttachProduct')) {
+    $fail('product getById must attach product seo');
+}
+if (!str_contains($categoryCatalog, 'maybeAttachCategory')) {
+    $fail('category getById must attach category seo');
+}
+
+if (substr_count($productCatalog, 'maybeAttachProduct') !== 1) {
+    $fail('product catalog must attach seo only once (get)');
+}
+if (substr_count($categoryCatalog, 'maybeAttachCategory') !== 1) {
+    $fail('category catalog must attach seo only once (get)');
+}
+
+if (str_contains($productCatalog, 'PublicSeoBuilder')) {
+    $fail('product catalog must not import PublicSeoBuilder');
+}
+if (str_contains($categoryCatalog, 'PublicSeoBuilder')) {
+    $fail('category catalog must not import PublicSeoBuilder');
+}
+
+if (preg_match('/function getList.*?maybeAttach/s', $productCatalog)) {
+    $fail('product getList must not attach seo');
+}
+if (preg_match('/function getList.*?maybeAttach/s', $categoryCatalog)) {
+    $fail('category getList must not attach seo');
+}
+if (preg_match('/function getTree.*?maybeAttach/s', $categoryCatalog)) {
+    $fail('category getTree must not attach seo');
+}
+
+if (!str_contains($productController, 'include_seo')) {
+    $fail('ProductController get must document include_seo');
+}
+if (!str_contains($categoryController, 'include_seo')) {
+    $fail('CategoryController get must document include_seo');
+}
+
+foreach (['seosuite', 'stercseo', 'metax'] as $pkg) {
+    if (stripos($composer, $pkg) !== false) {
+        $fail("composer.json must not depend on {$pkg}");
+    }
+}
+
+fwrite(STDOUT, "OK PublicSeoRoutesTest\n");
+exit(0);

--- a/core/components/minishop3/tests/Unit/Services/Seo/PublicSeoBuilderTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Seo/PublicSeoBuilderTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Seo;
+
+use MiniShop3\Services\Seo\PublicSeoBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class PublicSeoBuilderTest extends TestCase
+{
+    public function testAbsoluteUrlEmptyPathYieldsEmptyString(): void
+    {
+        self::assertSame('', PublicSeoBuilder::absoluteUrl('https://shop.example/', ''));
+        self::assertSame('', PublicSeoBuilder::absoluteUrl('https://shop.example/', '  '));
+    }
+
+    public function testAbsoluteUrlJoinsWithoutDoubleSlash(): void
+    {
+        self::assertSame(
+            'https://shop.example/catalog/kettle/',
+            PublicSeoBuilder::absoluteUrl('https://shop.example/', '/catalog/kettle/'),
+        );
+        self::assertSame(
+            'https://shop.example/catalog/kettle/',
+            PublicSeoBuilder::absoluteUrl('https://shop.example', 'catalog/kettle/'),
+        );
+    }
+
+    public function testAbsoluteUrlKeepsAbsoluteAndProtocolRelative(): void
+    {
+        self::assertSame(
+            'https://cdn.example/img.jpg',
+            PublicSeoBuilder::absoluteUrl('https://shop.example/', 'https://cdn.example/img.jpg'),
+        );
+        self::assertSame(
+            '//cdn.example/img.jpg',
+            PublicSeoBuilder::absoluteUrl('https://shop.example/', '//cdn.example/img.jpg'),
+        );
+    }
+
+    public function testAbsoluteUrlEmptyBaseKeepsRootRelativePath(): void
+    {
+        self::assertSame('/catalog/kettle/', PublicSeoBuilder::absoluteUrl('', '/catalog/kettle/'));
+    }
+
+    public function testTitleFallsBackToPagetitle(): void
+    {
+        $seo = PublicSeoBuilder::build(
+            ['pagetitle' => 'Kettle', 'longtitle' => ''],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+
+        self::assertSame('Kettle', $seo['title']);
+        self::assertSame('Kettle', $seo['og']['title']);
+    }
+
+    public function testPrefersLongtitleWhenSet(): void
+    {
+        $seo = PublicSeoBuilder::build(
+            ['pagetitle' => 'Kettle', 'longtitle' => 'Electric kettle'],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+
+        self::assertSame('Electric kettle', $seo['title']);
+    }
+
+    public function testDescriptionFallsBackToIntrotext(): void
+    {
+        $seo = PublicSeoBuilder::build(
+            ['description' => '', 'introtext' => 'Short blurb'],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+
+        self::assertSame('Short blurb', $seo['description']);
+        self::assertSame('Short blurb', $seo['og']['description']);
+    }
+
+    public function testCanonicalJoinsSiteUrlAndUri(): void
+    {
+        $seo = PublicSeoBuilder::build(
+            ['uri' => 'catalog/kettle/'],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+
+        self::assertSame('https://shop.example/catalog/kettle/', $seo['canonical']);
+    }
+
+    public function testOgImagePrefersImageThenThumb(): void
+    {
+        $fromImage = PublicSeoBuilder::build(
+            ['image' => '/assets/kettle.jpg', 'thumb' => '/assets/kettle_small.jpg'],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+        self::assertSame('https://shop.example/assets/kettle.jpg', $fromImage['og']['image']);
+
+        $fromThumb = PublicSeoBuilder::build(
+            ['image' => '', 'thumb' => '/assets/kettle_small.jpg'],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+        self::assertSame('https://shop.example/assets/kettle_small.jpg', $fromThumb['og']['image']);
+
+        $empty = PublicSeoBuilder::build(
+            ['image' => '', 'thumb' => ''],
+            'https://shop.example/',
+            PublicSeoBuilder::OG_TYPE_PRODUCT,
+        );
+        self::assertSame('', $empty['og']['image']);
+    }
+
+    public function testOgTypeAndDefaultRobots(): void
+    {
+        $product = PublicSeoBuilder::build([], 'https://shop.example/', PublicSeoBuilder::OG_TYPE_PRODUCT);
+        self::assertSame('product', $product['og']['type']);
+        self::assertSame('index,follow', $product['robots']);
+
+        $category = PublicSeoBuilder::build([], 'https://shop.example/', PublicSeoBuilder::OG_TYPE_CATEGORY);
+        self::assertSame('website', $category['og']['type']);
+    }
+
+    public function testWhitelistDropsUnknownKeys(): void
+    {
+        $clean = PublicSeoBuilder::whitelist([
+            'title' => 'A',
+            'description' => 'B',
+            'canonical' => 'https://shop.example/',
+            'robots' => 'index,follow',
+            'jsonld' => '{"leak":true}',
+            'og' => [
+                'title' => 'A',
+                'description' => 'B',
+                'image' => '',
+                'type' => 'product',
+                'extra' => 'nope',
+            ],
+        ]);
+
+        self::assertSame(['title', 'description', 'canonical', 'robots', 'og'], array_keys($clean));
+        self::assertSame(['title', 'description', 'image', 'type'], array_keys($clean['og']));
+        self::assertArrayNotHasKey('jsonld', $clean);
+        self::assertArrayNotHasKey('extra', $clean['og']);
+    }
+
+    public function testWhitelistDropsNonArrayOg(): void
+    {
+        $clean = PublicSeoBuilder::whitelist([
+            'title' => 'A',
+            'og' => 'https://evil.example/',
+        ]);
+
+        self::assertSame('A', $clean['title']);
+        self::assertArrayNotHasKey('og', $clean);
+    }
+
+    public function testWhitelistDropsNonScalarTitle(): void
+    {
+        $clean = PublicSeoBuilder::whitelist([
+            'title' => ['leak'],
+            'robots' => 'index,follow',
+        ]);
+
+        self::assertArrayNotHasKey('title', $clean);
+        self::assertSame('index,follow', $clean['robots']);
+    }
+}

--- a/core/components/minishop3/tests/Unit/Services/Seo/PublicSeoServiceTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Seo/PublicSeoServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Seo;
+
+use MiniShop3\Services\Seo\PublicSeoService;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+final class PublicSeoServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testDefaultOnAttachesSeo(): void
+    {
+        $out = $this->service()->maybeAttachProduct(
+            [
+                'pagetitle' => 'Kettle',
+                'longtitle' => '',
+                'uri' => 'catalog/kettle/',
+                'image' => '/assets/kettle.jpg',
+            ],
+            [],
+        );
+
+        self::assertArrayHasKey('seo', $out);
+        self::assertSame('Kettle', $out['seo']['title']);
+        self::assertSame('https://shop.example/catalog/kettle/', $out['seo']['canonical']);
+        self::assertSame('https://shop.example/assets/kettle.jpg', $out['seo']['og']['image']);
+        self::assertSame('product', $out['seo']['og']['type']);
+        self::assertSame('Kettle', $out['pagetitle']);
+    }
+
+    public function testCategoryOgTypeIsWebsite(): void
+    {
+        $out = $this->service()->maybeAttachCategory(['pagetitle' => 'Tea'], []);
+
+        self::assertSame('website', $out['seo']['og']['type']);
+        self::assertSame('Tea', $out['seo']['title']);
+    }
+
+    public function testIncludeSeoZeroOmitsKey(): void
+    {
+        $out = $this->service()->maybeAttachProduct(
+            ['pagetitle' => 'Kettle'],
+            ['include_seo' => 0],
+        );
+
+        self::assertArrayNotHasKey('seo', $out);
+        self::assertSame('Kettle', $out['pagetitle']);
+    }
+
+    public function testHookTitlePatchMirrorsOgTitle(): void
+    {
+        $out = $this->service(['title' => 'Override', 'jsonld' => '{}'])->maybeAttachProduct(
+            ['pagetitle' => 'Kettle', 'longtitle' => 'Electric kettle'],
+            [],
+        );
+
+        self::assertSame('Override', $out['seo']['title']);
+        self::assertSame('Override', $out['seo']['og']['title']);
+        self::assertArrayNotHasKey('jsonld', $out['seo']);
+    }
+
+    public function testCanonicalUsesContextSiteUrl(): void
+    {
+        $out = $this->service(null, ['en' => 'https://en.example/'])->maybeAttachProduct(
+            [
+                'pagetitle' => 'Kettle',
+                'uri' => 'catalog/kettle/',
+                'context_key' => 'en',
+            ],
+            [],
+        );
+
+        self::assertSame('https://en.example/catalog/kettle/', $out['seo']['canonical']);
+    }
+
+    public function testQueryContextOverridesPayloadContext(): void
+    {
+        $out = $this->service(null, [
+            'web' => 'https://shop.example/',
+            'en' => 'https://en.example/',
+        ])->maybeAttachProduct(
+            [
+                'pagetitle' => 'Kettle',
+                'uri' => 'catalog/kettle/',
+                'context_key' => 'web',
+            ],
+            ['context' => 'en'],
+        );
+
+        self::assertSame('https://en.example/catalog/kettle/', $out['seo']['canonical']);
+    }
+
+    /**
+     * @param array<string, mixed>|null $seoPatch
+     * @param array<string, string> $contextUrls
+     */
+    private function service(?array $seoPatch = null, array $contextUrls = []): PublicSeoService
+    {
+        return new PublicSeoService($this->modx($seoPatch, $contextUrls));
+    }
+
+    /**
+     * @param array<string, mixed>|null $seoPatch
+     * @param array<string, string> $contextUrls
+     */
+    private function modx(?array $seoPatch = null, array $contextUrls = []): modX
+    {
+        return new class ($seoPatch, $contextUrls) extends modX {
+            public object $event;
+
+            /**
+             * @param array<string, mixed>|null $seoPatch
+             * @param array<string, string> $contextUrls
+             */
+            public function __construct(
+                private ?array $seoPatch,
+                private array $contextUrls,
+            ) {
+                parent::__construct();
+                $this->event = (object) ['returnedValues' => null];
+            }
+
+            public function getOption(string $key, $options = null, $default = null)
+            {
+                return $key === 'site_url' ? 'https://shop.example/' : $default;
+            }
+
+            public function getContext($contextKey, $options = null)
+            {
+                $url = $this->contextUrls[$contextKey] ?? null;
+                if ($url === null) {
+                    return null;
+                }
+
+                return new class ($url) {
+                    public function __construct(private string $url)
+                    {
+                    }
+
+                    public function getOption(string $key, $options = null, $default = null)
+                    {
+                        return $key === 'site_url' ? $this->url : $default;
+                    }
+                };
+            }
+
+            public function invokeEvent($eventName, array $params = [])
+            {
+                if ($this->seoPatch !== null) {
+                    $this->event->returnedValues = ['seo' => $this->seoPatch];
+                }
+
+                return [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Описание

В ответах `GET /api/v1/product/get/{id}` и `GET /api/v1/category/get/{id}` появляется объект `seo` с `title`, `description`, `canonical`, `robots` и `og.{title,description,image,type}`. Nuxt SSR может собрать `<title>`, meta description, canonical и базовый Open Graph без своей угадайки по полям ресурса.

Плоские поля (`pagetitle`, `longtitle`, `description`, `uri`, `image`/`thumb`) не меняются. `product/list`, `category/list` и `category/tree` полный `seo` не отдают.

## Тип изменений

- [x] Новая функциональность (non-breaking change)

## Связанные Issues

Closes #567

## Как это было протестировано?

Локальный CI-гейт (без полной установки MODX/MySQL):

```bash
cd core/components/minishop3
php -l src/Services/Seo/PublicSeoBuilder.php
php -l src/Services/Seo/PublicSeoService.php
composer test:smoke
composer ci:php
composer stan
```

| Команда | Результат |
|---------|-----------|
| `php -l` (затронутые PHP) | exit 0 |
| `composer test:smoke` | 88 smoke, exit 0 |
| `composer ci:php` | PHPUnit 258, exit 0 |
| `composer stan` | OK, exit 0 |

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `feat/issue-567-public-seo-block` от `beta`
- MODX: stubs / без live install
- PHP: 8.4.17

## Скриншоты (если применимо)

Не применимо (JSON API).

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — новых ключей нет
- [x] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не трогали
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — запись на релизе

## Дополнительные заметки

Правила derivation: `title` ← непустой `longtitle`, иначе `pagetitle`. `description` ← непустой `description`, иначе `introtext`. `canonical` и `og.image` — absolute URL из `site_url` контекста (`?context=` или `context_key` ресурса) + relative path. `robots` для уже публичных сущностей: `index,follow`. `og.type`: `product` / `website`.

`include_seo=0` на get убирает ключ `seo`. Default на get — включено.

Опциональный хук `msOnGetPublicSeo`: плагин патчит `$modx->event->returnedValues['seo']`. Патч только `title` зеркалится в `og.title`, пока плагин сам не задал `og.title`. Whitelist отбрасывает неизвестные ключи и не-скаляры. TV map `ms3_public_seo_tv_map` в этот PR не входит.

Событие появится в Manager после rebuild/upgrade пакета.

Follow-up: get по `uri`/`alias`, multi-size og из галереи (#566), `include_seo` на list.