### PR TITLE
fix(mgr): UTF-8 whitespace в combo labels model-fields

### DIFF
--- a/core/components/minishop3/src/Services/ComboConfigManager.php
+++ b/core/components/minishop3/src/Services/ComboConfigManager.php
@@ -318,8 +318,11 @@ class ComboConfigManager
                 },
                 $template
             );
-            // Clean up multiple spaces and trim
-            $label = trim(preg_replace('/\s+/', ' ', $label));
+            // Collapse Unicode whitespace (e.g. NBSP U+00A0). Without /u, PCRE treats the
+            // subject as bytes and does not treat UTF-8 NBSP as \s, so combo labels can keep
+            // non-ASCII spaces and break downstream JSON consumers of model-fields (#618).
+            $collapsed = preg_replace('/\s+/u', ' ', $label);
+            $label = trim(is_string($collapsed) ? $collapsed : $label);
         } else {
             // Fallback to single field
             $label = $item->get($singleField);

--- a/core/components/minishop3/tests/Unit/Services/ComboConfigManagerBuildLabelTest.php
+++ b/core/components/minishop3/tests/Unit/Services/ComboConfigManagerBuildLabelTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services;
+
+use MiniShop3\Services\ComboConfigManager;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Regression for #618: buildLabel must not corrupt Cyrillic UTF-8 when collapsing whitespace.
+ */
+final class ComboConfigManagerBuildLabelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 2) . '/stubs/ModxStub.php';
+        }
+
+        if (!defined('MODX_CORE_PATH')) {
+            define('MODX_CORE_PATH', dirname(__DIR__, 3) . '/');
+        }
+    }
+
+    public function testCyrillicErLabelSurvivesWhitespaceCollapse(): void
+    {
+        $label = $this->invokeBuildLabel(
+            ['first_name' => 'Руслан', 'last_name' => 'Иванов'],
+            '{first_name} {last_name}',
+            'name'
+        );
+
+        self::assertSame('Руслан Иванов', $label);
+        self::assertTrue(mb_check_encoding($label, 'UTF-8'));
+        self::assertNotFalse(json_encode(['label' => $label], JSON_THROW_ON_ERROR));
+    }
+
+    public function testUnicodeNbspIsCollapsedToSingleSpace(): void
+    {
+        $nbsp = "\u{00A0}";
+        $label = $this->invokeBuildLabel(
+            ['first_name' => 'Анна', 'last_name' => 'Петрова'],
+            '{first_name}' . $nbsp . $nbsp . '{last_name}',
+            'name'
+        );
+
+        self::assertSame('Анна Петрова', $label);
+        self::assertTrue(mb_check_encoding($label, 'UTF-8'));
+        self::assertNotFalse(json_encode(['label' => $label], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function invokeBuildLabel(array $fields, ?string $template, string $singleField): string
+    {
+        $item = new class ($fields) {
+            /** @param array<string, mixed> $fields */
+            public function __construct(private array $fields)
+            {
+            }
+
+            public function get(string $key): mixed
+            {
+                return $this->fields[$key] ?? null;
+            }
+        };
+
+        $manager = new ComboConfigManager(new modX());
+        $method = new ReflectionMethod(ComboConfigManager::class, 'buildLabel');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke($manager, $item, $template, $singleField);
+    }
+}


### PR DESCRIPTION
## Описание

В `ComboConfigManager::buildLabel()` пробелы схлопывались через `preg_replace('/\s+/')` без Unicode-режима. Без `/u` UTF-8 NBSP (`U+00A0`) не считается `\s`, из‑за чего в `comboOptions` для `visible/msOrder` остаются «кривые» пробелы в кириллических лейблах покупателей и ломается загрузка формы заказа (empty-state «поля не настроены»).

Фикс: `/\s+/u` + безопасный fallback, если `preg_replace` вернул `null` на битой строке.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #618

Не путать с ACL `mssetting_save` (#613 / #614): там чтение schema, здесь UTF-8 в combo labels.

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/ComboConfigManager.php
php -l tests/Unit/Services/ComboConfigManagerBuildLabelTest.php
./vendor/bin/phpunit tests/Unit/Services/ComboConfigManagerBuildLabelTest.php
# OK (2 tests, 6 assertions), exit 0

composer ci:php
# smoke OK (89), PHPUnit 256 tests, exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / focused PHPUnit)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-618-combo-utf8-model-fields` от `beta`
- MODX: n/a (unit + smoke без полной mgr-сессии)
- PHP: 8.4.17

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| empty-state на заказе при NBSP/кириллице в customer combo | unit: NBSP → один ASCII-пробел, `json_encode` OK |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — n/a, новых строк нет
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — n/a, Vue не трогали
- [x] Обновлён CHANGELOG.md (для значимых изменений) — нет, по политике релиза

## Дополнительные заметки

- Gate A: кириллический лейбл «Руслан …» остаётся валидным UTF-8; Unicode NBSP схлопывается; regression-тест падает без `/u`.
- Review: `code-reviewer`=`gpt-5.6-sol-medium` (slug `claude-opus-5-thinking-high` в Task недоступен), `thermo-nuclear`=`cursor-grok-4.6-high-fast`. Удалён тестовый «фейковый envelope»; добавлен null-safe fallback для `preg_replace`.
- Routing: plan=`cursor-grok-4.6-high-fast`, make=Composer session, review=`gpt-5.6-sol-medium`, structure=`cursor-grok-4.6-high-fast`.