### PR TITLE
fix(mgr): сортировка секций на странице товара по sort_order

### DIFF
--- a/vueManager/src/components/ProductDataFields.vue
+++ b/vueManager/src/components/ProductDataFields.vue
@@ -7,6 +7,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 
 import request from '../request.js'
+import { groupProductDataSections } from '../utils/groupProductDataSections.js'
 import {
   isFullWidthExtraFieldXtype,
   parseStructuredExtraFieldValue,
@@ -201,32 +202,11 @@ const visibleFields = computed(() => {
 })
 
 /**
- * Group fields by sections
- * Show only !hidden sections
+ * Group fields by sections (array ordered by section.sort_order).
+ * Do not return an id-keyed object: Vue/JS enumerates those keys by ascending id (#611).
  */
 const fieldsBySections = computed(() => {
-  const sections = {}
-
-  visibleFields.value.forEach(field => {
-    const sectionKey = field.section || 'default'
-    const sectionConfig = fieldsConfig.value.sections[sectionKey]
-
-    // Skip hidden sections
-    if (sectionConfig && sectionConfig.hidden === true) {
-      return
-    }
-
-    if (!sections[sectionKey]) {
-      sections[sectionKey] = {
-        ...sectionConfig,
-        fields: [],
-      }
-    }
-
-    sections[sectionKey].fields.push(field)
-  })
-
-  return sections
+  return groupProductDataSections(visibleFields.value, fieldsConfig.value.sections || {})
 })
 
 // Load configuration on mount
@@ -253,9 +233,9 @@ onMounted(() => {
 
         <div v-else class="sections-container">
           <Fieldset
-            v-for="(section, sectionKey) in fieldsBySections"
-            :key="sectionKey"
-            :legend="section.label || sectionKey"
+            v-for="section in fieldsBySections"
+            :key="section.id ?? section.key"
+            :legend="section.label || section.key"
             :toggleable="true"
             :collapsed="section.collapsed"
             class="section-fieldset"

--- a/vueManager/src/utils/groupProductDataSections.js
+++ b/vueManager/src/utils/groupProductDataSections.js
@@ -1,0 +1,55 @@
+/**
+ * Group visible product-data fields into sections ordered by section.sort_order.
+ *
+ * `getPageFields` returns sections as an object keyed by numeric id. A plain
+ * object + `v-for` enumerates integer-like keys in ascending id order, which
+ * ignores the Utilities → Product fields section sort (#611).
+ *
+ * @param {Array<Object>} fields Visible field configs (already filtered).
+ * @param {Object<string|number, Object>} sectionsById Map from section id → section config.
+ * @returns {Array<{ key: string|number, fields: Array<Object>, [string]: any }>}
+ */
+export function groupProductDataSections(fields, sectionsById = {}) {
+  const grouped = new Map()
+
+  for (const field of fields) {
+    // Normalize to string so Map keys match JSON object keys from getPageFields.
+    const sectionKey = field.section == null || field.section === '' ? 'default' : String(field.section)
+    const sectionConfig = sectionsById[sectionKey]
+
+    if (sectionConfig?.hidden === true) {
+      continue
+    }
+
+    if (!grouped.has(sectionKey)) {
+      grouped.set(sectionKey, {
+        // Fallback identity when section is missing from the map; API `key` (section_key) wins via spread.
+        key: sectionKey,
+        ...(sectionConfig || {}),
+        fields: [],
+      })
+    }
+
+    grouped.get(sectionKey).fields.push(field)
+  }
+
+  const sections = Array.from(grouped.values())
+
+  sections.sort((a, b) => {
+    const sortA = Number.isFinite(Number(a.sort_order)) ? Number(a.sort_order) : Number.MAX_SAFE_INTEGER
+    const sortB = Number.isFinite(Number(b.sort_order)) ? Number(b.sort_order) : Number.MAX_SAFE_INTEGER
+    if (sortA !== sortB) {
+      return sortA - sortB
+    }
+
+    const idA = Number(a.id ?? a.key)
+    const idB = Number(b.id ?? b.key)
+    if (Number.isFinite(idA) && Number.isFinite(idB) && idA !== idB) {
+      return idA - idB
+    }
+
+    return String(a.id ?? a.key).localeCompare(String(b.id ?? b.key))
+  })
+
+  return sections
+}

--- a/vueManager/src/utils/groupProductDataSections.test.js
+++ b/vueManager/src/utils/groupProductDataSections.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupProductDataSections } from './groupProductDataSections.js'
+
+describe('groupProductDataSections', () => {
+  it('orders sections by sort_order even when section ids ascend differently', () => {
+    const sectionsById = {
+      1: { id: 1, key: 'main', sort_order: 20, label: 'Main' },
+      3: { id: 3, key: 'first', sort_order: 10, label: 'First' },
+      5: { id: 5, key: 'currency', sort_order: 15, label: 'Currency' },
+    }
+    const fields = [
+      { name: 'article', section: 1 },
+      { name: 'price', section: 3 },
+      { name: 'currency', section: 5 },
+    ]
+
+    const result = groupProductDataSections(fields, sectionsById)
+
+    expect(result.map(s => s.id)).toEqual([3, 5, 1])
+    expect(result.map(s => s.key)).toEqual(['first', 'currency', 'main'])
+    expect(result.map(s => s.label)).toEqual(['First', 'Currency', 'Main'])
+  })
+
+  it('skips hidden sections', () => {
+    const sectionsById = {
+      1: { id: 1, key: 'main', sort_order: 10, hidden: false },
+      2: { id: 2, key: 'hidden', sort_order: 5, hidden: true },
+    }
+    const fields = [
+      { name: 'a', section: 1 },
+      { name: 'b', section: 2 },
+    ]
+
+    expect(groupProductDataSections(fields, sectionsById).map(s => s.id)).toEqual([1])
+  })
+
+  it('keeps fields inside a section in input order', () => {
+    const sectionsById = {
+      1: { id: 1, sort_order: 10 },
+    }
+    const fields = [
+      { name: 'second', section: 1, sort_order: 20 },
+      { name: 'first', section: 1, sort_order: 10 },
+    ]
+
+    expect(groupProductDataSections(fields, sectionsById)[0].fields.map(f => f.name)).toEqual([
+      'second',
+      'first',
+    ])
+  })
+
+  it('falls back to default section when field.section is missing', () => {
+    const result = groupProductDataSections([{ name: 'orphan' }], {})
+    expect(result).toHaveLength(1)
+    expect(result[0].key).toBe('default')
+    expect(result[0].fields[0].name).toBe('orphan')
+  })
+})


### PR DESCRIPTION
## Описание

На странице товара секции полей игнорировали порядок из **Утилиты → Поля товара** и шли по возрастанию ID секции.

`getPageFields` отдаёт `sections` объектом с числовыми ключами. Группировка в plain object + `v-for` в JS перечисляет integer-like keys по id, а не по `sort_order`.

Исправление: `groupProductDataSections` собирает секции в массив и сортирует по `sort_order` (tie-break по id). `ProductDataFields` рендерит этот массив.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #611

## Как это было протестировано?

- Vitest: `vueManager/src/utils/groupProductDataSections.test.js` (4/4)
- ESLint по изменённым Vue/JS файлам
- Live на `project.test`, товар id=2021: до фикса `… → Дополнительно → Валюта` (id-order); после — `… → Валюта (sort 25) → Дополнительно (sort 40)`

Локальный CI-гейт (без полной установки MODX/MySQL), PHP lint + vueManager jobs из `.github/workflows/ci.yml`:

```bash
cd vueManager
npm test -- --run src/utils/groupProductDataSections.test.js
npx eslint src/utils/groupProductDataSections.js src/utils/groupProductDataSections.test.js src/components/ProductDataFields.vue
```

- [x] Ручное тестирование
- [x] Автоматические тесты (`npm test` Vitest по util)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: branch `fix/issue-611-product-section-sort-order`
- MODX: 3.2.0-pl (project.test)
- PHP: 8.x (окружение project.test)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требуются
- [ ] PHPStan проходит без новых ошибок — PHP не менялся
- [x] ESLint проходит без ошибок по затронутым путям
- [ ] Обновлён CHANGELOG.md — не трогали (по правилу репо: при релизе)

## Дополнительные заметки

Routing issue-to-pr: plan=`cursor-grok-4.6-high-fast`, make=`composer-2.5-fast`, review=`gpt-5.6-sol-medium` + thermo=`cursor-grok-4.6-high-fast`. Reviews: APPROVE.