### PR TITLE
feat(mgr): тип Дата для extra fields

### DIFF
--- a/core/components/minishop3/lexicon/en/vue.inc.php
+++ b/core/components/minishop3/lexicon/en/vue.inc.php
@@ -165,6 +165,7 @@ $_lang['ms3_vue_xtype_key_value'] = 'Key-Value (map)';
 $_lang['ms3_vue_xtype_combo_vendor'] = 'Vendor (combo)';
 $_lang['ms3_vue_xtype_combo_autocomplete'] = 'Autocomplete (combo)';
 $_lang['ms3_vue_xtype_combo_options'] = 'Product Options (chips)';
+$_lang['ms3_vue_xtype_datefield'] = 'Date';
 
 // Dropdown list settings
 $_lang['ms3_vue_select_options_label'] = 'List Options';
@@ -215,6 +216,7 @@ $_lang['ms3_vue_dbtype_varchar'] = 'VARCHAR (string)';
 $_lang['ms3_vue_dbtype_text'] = 'TEXT (text)';
 $_lang['ms3_vue_dbtype_int'] = 'INT (integer)';
 $_lang['ms3_vue_dbtype_decimal'] = 'DECIMAL (decimal)';
+$_lang['ms3_vue_dbtype_date'] = 'DATE (date only)';
 $_lang['ms3_vue_dbtype_datetime'] = 'DATETIME (date and time)';
 $_lang['ms3_vue_dbtype_timestamp'] = 'TIMESTAMP';
 $_lang['ms3_vue_dbtype_tinyint'] = 'TINYINT (0/1)';

--- a/core/components/minishop3/lexicon/ru/vue.inc.php
+++ b/core/components/minishop3/lexicon/ru/vue.inc.php
@@ -165,6 +165,7 @@ $_lang['ms3_vue_xtype_key_value'] = 'Ключ-Значение (карта)';
 $_lang['ms3_vue_xtype_combo_vendor'] = 'Производитель (combo)';
 $_lang['ms3_vue_xtype_combo_autocomplete'] = 'Автодополнение (combo)';
 $_lang['ms3_vue_xtype_combo_options'] = 'Опции товара (chips)';
+$_lang['ms3_vue_xtype_datefield'] = 'Дата';
 
 // Настройки выпадающего списка
 $_lang['ms3_vue_select_options_label'] = 'Варианты списка';
@@ -215,6 +216,7 @@ $_lang['ms3_vue_dbtype_varchar'] = 'VARCHAR (строка)';
 $_lang['ms3_vue_dbtype_text'] = 'TEXT (текст)';
 $_lang['ms3_vue_dbtype_int'] = 'INT (целое число)';
 $_lang['ms3_vue_dbtype_decimal'] = 'DECIMAL (число с точностью)';
+$_lang['ms3_vue_dbtype_date'] = 'DATE (только дата)';
 $_lang['ms3_vue_dbtype_datetime'] = 'DATETIME (дата и время)';
 $_lang['ms3_vue_dbtype_timestamp'] = 'TIMESTAMP';
 $_lang['ms3_vue_dbtype_tinyint'] = 'TINYINT (0/1)';

--- a/core/components/minishop3/src/Services/Product/ProductDataService.php
+++ b/core/components/minishop3/src/Services/Product/ProductDataService.php
@@ -125,7 +125,7 @@ class ProductDataService
             $productData->set('source_id', $this->modx->getOption('ms3_product_source_default', null, 1));
         }
 
-        // Cast numeric/boolean fields (incl. extra fields) so '' does not break MySQL decimals/ints
+        // Cast numeric/boolean/date fields (incl. extra fields) so '' does not break MySQL
         foreach ($productData->_fieldMeta as $key => $meta) {
             if ($key === 'id') {
                 continue;
@@ -139,9 +139,28 @@ class ProductDataService
                 'float' => $productData->set($key, $isEmpty ? 0.0 : (float)$value),
                 'integer' => $productData->set($key, $isEmpty ? 0 : (int)$value),
                 'boolean' => $productData->set($key, $isEmpty ? false : (bool)$value),
+                'date', 'datetime', 'timestamp' => $productData->set(
+                    $key,
+                    $this->isEmptyDateScalar($value) ? null : $value
+                ),
                 default => null,
             };
         }
+    }
+
+    /**
+     * Empty form posts and MySQL zero-dates must become NULL for DATE/DATETIME columns.
+     */
+    private function isEmptyDateScalar(mixed $value): bool
+    {
+        if ($value === '' || $value === null) {
+            return true;
+        }
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return str_starts_with($value, '0000-00-00');
     }
 
     public function saveCategories(msProductData $productData): void

--- a/core/components/minishop3/tests/Unit/Services/Product/ProductDataPrepareObjectDateNullTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Product/ProductDataPrepareObjectDateNullTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Product;
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Services\ExtraFields\KeyValueFieldService;
+use MiniShop3\Services\ExtraFields\RepeaterFieldService;
+use MiniShop3\Services\Product\ProductDataService;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+use xPDO\xPDO;
+
+/**
+ * Empty optional date extras must become NULL before save (#623 / biz87 review).
+ */
+final class ProductDataPrepareObjectDateNullTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testEmptyDateScalarsBecomeNull(): void
+    {
+        $modx = new modX();
+        $service = new DateNullTestableProductDataService($modx);
+        $xpdo = new xPDO();
+        $xpdo->services = new class {
+            public function has(string $key): bool
+            {
+                return false;
+            }
+        };
+        $productData = new DateNullProductData($xpdo, [
+            'optional_date' => '',
+            'zero_date' => '0000-00-00',
+            'zero_datetime' => '0000-00-00 00:00:00',
+            'kept_date' => '2026-04-20',
+            'price' => '',
+        ]);
+        $productData->_fieldMeta = [
+            'id' => ['phptype' => 'integer'],
+            'optional_date' => ['phptype' => 'datetime'],
+            'zero_date' => ['phptype' => 'date'],
+            'zero_datetime' => ['phptype' => 'timestamp'],
+            'kept_date' => ['phptype' => 'date'],
+            'price' => ['phptype' => 'float'],
+        ];
+
+        $service->prepareObject($productData);
+
+        self::assertNull($productData->fields['optional_date']);
+        self::assertNull($productData->fields['zero_date']);
+        self::assertNull($productData->fields['zero_datetime']);
+        self::assertSame('2026-04-20', $productData->fields['kept_date']);
+        self::assertSame(0.0, $productData->fields['price']);
+    }
+}
+
+/**
+ * @internal
+ */
+final class DateNullTestableProductDataService extends ProductDataService
+{
+    protected function getProductRepeaterFields(): array
+    {
+        return [];
+    }
+
+    protected function getProductKeyValueFields(): array
+    {
+        return [];
+    }
+
+    protected function getRepeaterFieldService(): RepeaterFieldService
+    {
+        return new RepeaterFieldService($this->modx);
+    }
+
+    protected function getKeyValueFieldService(): KeyValueFieldService
+    {
+        return new KeyValueFieldService($this->modx);
+    }
+}
+
+/**
+ * @internal
+ */
+final class DateNullProductData extends msProductData
+{
+    /** @var array<string, mixed> */
+    public array $fields;
+
+    /** @var array<string, array<string, mixed>> */
+    public $_fieldMeta = [];
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function __construct(xPDO $xpdo, array $fields = [])
+    {
+        parent::__construct($xpdo);
+        $this->fields = $fields;
+    }
+
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        return $this->fields[$k] ?? null;
+    }
+
+    public function set($k, $v = null, $vType = '')
+    {
+        $this->fields[$k] = $v;
+
+        return true;
+    }
+
+    public function getArraysValues()
+    {
+        return [];
+    }
+
+    public function isNew($checkDefaults = false)
+    {
+        return false;
+    }
+}

--- a/vueManager/src/components/DynamicField.vue
+++ b/vueManager/src/components/DynamicField.vue
@@ -92,19 +92,25 @@
     />
 
     <!-- Date picker -->
-    <DatePicker
-      v-else-if="fieldConfig.xtype === 'datefield'"
-      v-model="localValue"
-      class="w-full"
-      :input-id="fieldHtmlId"
-      :placeholder="fieldConfig.placeholder"
-      :disabled="disabled"
-      show-icon
-      fluid
-      icon-display="input"
-      :date-format="fieldConfig.props?.dateFormat ?? 'dd.mm.yy'"
-      @blur="handleBlur"
-    />
+    <template v-else-if="fieldConfig.xtype === DATEFIELD_XTYPE">
+      <DatePicker
+        v-model="datePickerValue"
+        class="w-full"
+        :input-id="fieldHtmlId"
+        :placeholder="fieldConfig.placeholder"
+        :disabled="disabled"
+        show-icon
+        fluid
+        icon-display="input"
+        :date-format="fieldConfig.props?.dateFormat ?? 'dd.mm.yy'"
+        @blur="handleBlur"
+      />
+      <input
+        type="hidden"
+        :name="fieldConfig.name"
+        :value="formatLocalDateYmd(datePickerValue) ?? ''"
+      />
+    </template>
 
     <!-- Color picker -->
     <ColorPicker
@@ -238,8 +244,7 @@
       <Message severity="warn"> Unknown field type: {{ fieldConfig.xtype }} </Message>
     </div>
 
-    <!-- Hidden field for complex types (combobox, datefield, colorpicker, chips, multiselect) -->
-    <!-- These fields require JSON serialization to pass to ExtJS form -->
+    <!-- Hidden field for complex types (combobox, colorpicker, chips, multiselect) -->
     <input v-if="isComplexField" type="hidden" :name="fieldConfig.name" :value="serializedValue" />
   </div>
 </template>
@@ -256,9 +261,10 @@ import Textarea from 'primevue/textarea'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { computed, ref, watch } from 'vue'
 
+import { formatLocalDateYmd } from '../utils/formatLocalDateYmd.js'
 import { getKeyValueConfigFromField, serializeKeyValueForPost } from '../utils/keyValueField.js'
 import { getRepeaterConfigFromField } from '../utils/repeaterField.js'
-import { parseStructuredExtraFieldValue } from '../utils/structuredExtraField.js'
+import { DATEFIELD_XTYPE, parseDateFieldValue, parseStructuredExtraFieldValue } from '../utils/structuredExtraField.js'
 import AutocompleteCombo from './AutocompleteCombo.vue'
 import FileBrowser from './FileBrowser.vue'
 import KeyValueField from './KeyValueField.vue'
@@ -332,7 +338,7 @@ const isFileBrowserXtype = computed(() => {
  * Determine if field is complex type (requires hidden field with JSON)
  */
 const isComplexField = computed(() => {
-  const complexTypes = ['combobox', 'datefield', 'colorpicker', 'chips', 'multiselect']
+  const complexTypes = ['combobox', 'colorpicker', 'chips', 'multiselect']
   return complexTypes.includes(props.fieldConfig.xtype)
 })
 
@@ -368,9 +374,26 @@ const selectOptions = computed(() => {
 
 const repeaterConfig = computed(() => getRepeaterConfigFromField(props.fieldConfig))
 const keyValueConfig = computed(() => getKeyValueConfigFromField(props.fieldConfig))
+const isDateField = computed(() => props.fieldConfig.xtype === DATEFIELD_XTYPE)
 
 function normalizeIncomingValue(value) {
   return parseStructuredExtraFieldValue(props.fieldConfig.xtype, value)
+}
+
+function normalizedDateString(value) {
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    return value.match(/^(\d{4}-\d{2}-\d{2})/)?.[1] ?? value
+  }
+
+  return formatLocalDateYmd(value)
+}
+
+function sameCalendarDay(left, right) {
+  return normalizedDateString(left) === normalizedDateString(right)
 }
 
 /**
@@ -426,27 +449,61 @@ const serializedValue = computed(() => {
 
 const emit = defineEmits(['update:modelValue', 'blur'])
 
-// Local value for v-model
-const localValue = ref(normalizeIncomingValue(props.modelValue))
+// Local value for v-model (non-date fields)
+const localValue = ref(
+  isDateField.value ? null : normalizeIncomingValue(props.modelValue)
+)
+
+// DatePicker uses Date internally; parent state stays YYYY-MM-DD string
+const datePickerValue = ref(
+  isDateField.value ? parseDateFieldValue(props.modelValue) : null
+)
 
 // Watch for external changes
 watch(
   () => props.modelValue,
   newValue => {
+    if (isDateField.value) {
+      const parsed = parseDateFieldValue(newValue)
+      if (!sameCalendarDay(datePickerValue.value, parsed)) {
+        datePickerValue.value = parsed
+      }
+      return
+    }
+
     localValue.value = normalizeIncomingValue(newValue)
   }
 )
 
 // Watch for local changes and emit to parent
 watch(localValue, newValue => {
+  if (isDateField.value) {
+    return
+  }
+
   emit('update:modelValue', newValue)
+})
+
+watch(datePickerValue, newDate => {
+  if (!isDateField.value) {
+    return
+  }
+
+  const serialized = formatLocalDateYmd(newDate) ?? null
+  if (sameCalendarDay(serialized, props.modelValue)) {
+    return
+  }
+
+  emit('update:modelValue', serialized)
 })
 
 // Handle blur event
 const handleBlur = () => {
   emit('blur', {
     fieldId: props.fieldConfig.id,
-    value: localValue.value,
+    value: isDateField.value
+      ? (formatLocalDateYmd(datePickerValue.value) ?? null)
+      : localValue.value,
   })
 }
 </script>

--- a/vueManager/src/components/ExtraFieldsManager.vue
+++ b/vueManager/src/components/ExtraFieldsManager.vue
@@ -29,6 +29,7 @@ import {
   parseRepeaterConfig,
   REPEATER_XTYPE,
 } from '../utils/repeaterField.js'
+import { DATEFIELD_XTYPE } from '../utils/structuredExtraField.js'
 import KeyValueSchemaEditor from './KeyValueSchemaEditor.vue'
 import RepeaterSchemaEditor from './RepeaterSchemaEditor.vue'
 
@@ -103,6 +104,7 @@ const xtypeOptions = computed(() => [
   { label: _('ms3_vue_xtype_combo_vendor'), value: 'ms3-combo-vendor' },
   { label: _('ms3_vue_xtype_combo_autocomplete'), value: 'ms3-combo-autocomplete' },
   { label: _('ms3_vue_xtype_combo_options'), value: 'ms3-combo-options' },
+  { label: _('ms3_vue_xtype_datefield'), value: DATEFIELD_XTYPE },
 ])
 
 /**
@@ -113,6 +115,7 @@ const dbtypeOptions = computed(() => [
   { label: _('ms3_vue_dbtype_text'), value: 'text' },
   { label: _('ms3_vue_dbtype_int'), value: 'int' },
   { label: _('ms3_vue_dbtype_decimal'), value: 'decimal' },
+  { label: _('ms3_vue_dbtype_date'), value: 'date' },
   { label: _('ms3_vue_dbtype_datetime'), value: 'datetime' },
   { label: _('ms3_vue_dbtype_timestamp'), value: 'timestamp' },
   { label: _('ms3_vue_dbtype_tinyint'), value: 'tinyint' },
@@ -162,17 +165,19 @@ function isValidFieldKey(key) {
   return typeof key === 'string' && key !== '' && SQL_IDENTIFIER_PATTERN.test(key)
 }
 
+const XTYPE_DB_DEFAULTS = {
+  [REPEATER_XTYPE]: { dbtype: 'json', phptype: 'json', precision: '', null: true },
+  [KEY_VALUE_XTYPE]: { dbtype: 'json', phptype: 'json', precision: '', null: true },
+  [DATEFIELD_XTYPE]: { dbtype: 'date', phptype: 'datetime', precision: '', null: true },
+}
+
 watch(
   () => fieldForm.value.xtype,
   xtype => {
-    if (xtype !== REPEATER_XTYPE && xtype !== KEY_VALUE_XTYPE) {
-      return
+    const defaults = XTYPE_DB_DEFAULTS[xtype]
+    if (defaults) {
+      Object.assign(fieldForm.value, defaults)
     }
-
-    fieldForm.value.dbtype = 'json'
-    fieldForm.value.phptype = 'json'
-    fieldForm.value.precision = ''
-    fieldForm.value.null = true
 
     if (xtype === REPEATER_XTYPE && !fieldForm.value.repeater_config?.columns?.length) {
       fieldForm.value.repeater_config = defaultRepeaterConfig()

--- a/vueManager/src/utils/structuredExtraField.js
+++ b/vueManager/src/utils/structuredExtraField.js
@@ -1,13 +1,46 @@
 import { KEY_VALUE_XTYPE, parseKeyValueModelValue } from './keyValueField.js'
 import { parseRepeaterModelValue, REPEATER_XTYPE } from './repeaterField.js'
 
+export const DATEFIELD_XTYPE = 'datefield'
+
 const STRUCTURED_EXTRA_FIELD_PARSERS = {
   [REPEATER_XTYPE]: parseRepeaterModelValue,
   [KEY_VALUE_XTYPE]: parseKeyValueModelValue,
 }
 
+const FULL_WIDTH_EXTRA_FIELD_XTYPES = new Set([REPEATER_XTYPE, KEY_VALUE_XTYPE])
+
+/**
+ * Parse stored date (YYYY-MM-DD or ISO) into a local Date for DatePicker.
+ *
+ * @param {string|number|Date|null|undefined} value
+ * @returns {Date|null}
+ */
+export function parseDateFieldValue(value) {
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const ymd = value.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (ymd) {
+    const local = new Date(Number(ymd[1]), Number(ymd[2]) - 1, Number(ymd[3]))
+    return Number.isNaN(local.getTime()) ? null : local
+  }
+
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
 export function isFullWidthExtraFieldXtype(xtype) {
-  return Object.prototype.hasOwnProperty.call(STRUCTURED_EXTRA_FIELD_PARSERS, xtype)
+  return FULL_WIDTH_EXTRA_FIELD_XTYPES.has(xtype)
 }
 
 export function parseStructuredExtraFieldValue(xtype, value) {

--- a/vueManager/src/utils/structuredExtraField.js
+++ b/vueManager/src/utils/structuredExtraField.js
@@ -29,6 +29,11 @@ export function parseDateFieldValue(value) {
     return null
   }
 
+  // MySQL zero-date / zero-datetime — treat as empty, not a real calendar day.
+  if (value.startsWith('0000-00-00')) {
+    return null
+  }
+
   const ymd = value.match(/^(\d{4})-(\d{2})-(\d{2})/)
   if (ymd) {
     const local = new Date(Number(ymd[1]), Number(ymd[2]) - 1, Number(ymd[3]))

--- a/vueManager/src/utils/structuredExtraField.test.js
+++ b/vueManager/src/utils/structuredExtraField.test.js
@@ -23,6 +23,13 @@ describe('structuredExtraField datefield', () => {
     expect(parsed.getDate()).toBe(20)
   })
 
+  it('treats null, empty string, and MySQL zero-date as empty', () => {
+    expect(parseDateFieldValue(null)).toBeNull()
+    expect(parseDateFieldValue('')).toBeNull()
+    expect(parseDateFieldValue('0000-00-00')).toBeNull()
+    expect(parseDateFieldValue('0000-00-00 00:00:00')).toBeNull()
+  })
+
   it('serializes Date without UTC ISO shift', () => {
     const localMidnight = new Date(2026, 3, 20, 0, 0, 0)
     expect(formatLocalDateYmd(localMidnight)).toBe('2026-04-20')

--- a/vueManager/src/utils/structuredExtraField.test.js
+++ b/vueManager/src/utils/structuredExtraField.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatLocalDateYmd } from './formatLocalDateYmd.js'
+import { KEY_VALUE_XTYPE } from './keyValueField.js'
+import { REPEATER_XTYPE } from './repeaterField.js'
+import {
+  DATEFIELD_XTYPE,
+  isFullWidthExtraFieldXtype,
+  parseDateFieldValue,
+  parseStructuredExtraFieldValue,
+} from './structuredExtraField.js'
+
+describe('structuredExtraField datefield', () => {
+  it('does not treat datefield as full-width layout', () => {
+    expect(isFullWidthExtraFieldXtype(DATEFIELD_XTYPE)).toBe(false)
+  })
+
+  it('parses YYYY-MM-DD into local calendar Date', () => {
+    const parsed = parseDateFieldValue('2026-04-20')
+    expect(parsed).toBeInstanceOf(Date)
+    expect(parsed.getFullYear()).toBe(2026)
+    expect(parsed.getMonth()).toBe(3)
+    expect(parsed.getDate()).toBe(20)
+  })
+
+  it('serializes Date without UTC ISO shift', () => {
+    const localMidnight = new Date(2026, 3, 20, 0, 0, 0)
+    expect(formatLocalDateYmd(localMidnight)).toBe('2026-04-20')
+    expect(formatLocalDateYmd(localMidnight)).not.toBe(localMidnight.toISOString())
+  })
+
+  it('leaves datefield scalar in parseStructuredExtraFieldValue', () => {
+    const stored = '2026-04-21'
+    expect(parseStructuredExtraFieldValue(DATEFIELD_XTYPE, stored)).toBe(stored)
+    expect(parseStructuredExtraFieldValue(DATEFIELD_XTYPE, null)).toBeNull()
+  })
+
+  it('still parses repeater and key-value structured values', () => {
+    expect(parseStructuredExtraFieldValue(REPEATER_XTYPE, '[]')).toEqual([])
+    expect(parseStructuredExtraFieldValue(KEY_VALUE_XTYPE, '{}')).toEqual({})
+  })
+})


### PR DESCRIPTION
## Описание

В каталоге extra fields не было типа Дата, хотя в Опциях он уже есть. Добавлен `datefield` в ExtraFieldsManager с дефолтами колонки `DATE`, рендер через DatePicker и хранение значения в родителе как `YYYY-MM-DD` (без UTC-сдвига и без обрезки времени у нативных datetime полей заказа).

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change
- [ ] Рефакторинг
- [ ] Документация
- [ ] Другое:

## Связанные Issues

Closes #612

## Как это было протестировано?

```bash
cd vueManager
npx eslint src/components/DynamicField.vue src/components/ExtraFieldsManager.vue \
  src/utils/structuredExtraField.js src/utils/structuredExtraField.test.js
# exit 0

npx vitest run src/utils/structuredExtraField.test.js src/utils/formatLocalDateYmd.test.js
# exit 0 — 8 tests

npm run build
# exit 0
```

- [ ] Ручное тестирование
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-612-extra-field-date`
- MODX: —
- PHP: —

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Комментарии в сложных местах (Date внутри DynamicField, parent = YMD)
- [x] Не ломает существующую функциональность
- [x] Лексиконы ru+en (`ms3_vue_xtype_datefield`, `ms3_vue_dbtype_date`)
- [ ] PHPStan — PHP не менялся
- [x] ESLint по затронутым путям
- [ ] CHANGELOG — не трогали (релиз)

## Дополнительные заметки

**Gate A**

| AC | Code | Test |
|----|------|------|
| Тип Дата в пикере extra field | yes | n/a UI |
| Дефолты dbtype/phptype при выборе | yes | n/a |
| Save/load без UTC-сдвига | yes | Vitest parse/serialize |
| Lexicons ru+en | yes | n/a |
| Не ломать order datetime | yes | ревью: сериализатор не на всех полях |

**Review:** thermo BLOCK (Date в parent + общий serialize) исправлен: Date только в DynamicField, parent получает `YYYY-MM-DD`. Soft: `phptype=datetime` при `dbtype=date` — как дефолт UI; в phptypeOptions нет отдельного `date`.

**Routing:** plan=`cursor-grok-4.6-high-fast`, make=`composer-2.5-fast`, review=`gpt-5.6-sol-medium` (Opus slug недоступен в Task), thermo=`cursor-grok-4.6-high-fast`, simplify=`composer-2.5-fast`