### PR TITLE
Индивидуальный menuindex для товаров в дополнительных категориях

### DIFF
--- a/core/components/minishop3/elements/snippets/ms3_products.php
+++ b/core/components/minishop3/elements/snippets/ms3_products.php
@@ -6,7 +6,9 @@ use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductFile;
 use MiniShop3\Model\msProductLink;
 use MiniShop3\Model\msProductOption;
+use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Utils\EventGate;
 use MiniShop3\Utils\ProductThumbnailJoin;
@@ -154,6 +156,31 @@ if ($_ms3Parents !== '' && $_ms3Parents !== '0' && $modx->services->has('ms3_cat
     if ($_ms3CategoryIds !== []) {
         $where[] = $scopeService->buildMsProductsWhereForCategories($_ms3CategoryIds);
         $scriptProperties['parents'] = 0;
+    }
+}
+
+// Per-category menuindex for additional categories when sorting by menuindex (#625).
+$_ms3MenuindexCategoryIds = [];
+if (isset($_ms3CategoryIds) && $_ms3CategoryIds !== []) {
+    $_ms3MenuindexCategoryIds = $_ms3CategoryIds;
+} else {
+    $_ms3SingleParent = (int)($scriptProperties['parent'] ?? $scriptProperties['category'] ?? 0);
+    if ($_ms3SingleParent > 0) {
+        $_ms3MenuindexCategoryIds = [$_ms3SingleParent];
+    }
+}
+$_ms3SortBy = (string)($scriptProperties['sortby'] ?? '');
+if ($_ms3MenuindexCategoryIds !== [] && preg_match('/\bmenuindex\b/i', $_ms3SortBy)) {
+    $memberAlias = CategoryProductMenuindexService::MEMBER_JOIN_ALIAS;
+    $leftJoin[$memberAlias] = [
+        'class' => msCategoryMember::class,
+        'on' => CategoryProductMenuindexService::memberJoinOnCategories($_ms3MenuindexCategoryIds, $memberAlias),
+    ];
+    $effectiveSql = CategoryProductMenuindexService::effectiveMenuindexSqlForCategories($_ms3MenuindexCategoryIds);
+    if (preg_match('/\bmsProduct\.menuindex\b/i', $_ms3SortBy)) {
+        $scriptProperties['sortby'] = preg_replace('/\bmsProduct\.menuindex\b/i', $effectiveSql, $_ms3SortBy);
+    } elseif (preg_match('/\bmenuindex\b/i', $_ms3SortBy) && !str_contains($_ms3SortBy, 'CASE WHEN')) {
+        $scriptProperties['sortby'] = preg_replace('/\bmenuindex\b/i', $effectiveSql, $_ms3SortBy, 1);
     }
 }
 

--- a/core/components/minishop3/migrations/20260822120000_add_menuindex_to_product_categories.php
+++ b/core/components/minishop3/migrations/20260822120000_add_menuindex_to_product_categories.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Per-category menuindex for additional product categories (#625).
+ */
+final class AddMenuindexToProductCategories extends AbstractMigration
+{
+    private const TABLE = 'ms3_product_categories';
+
+    private const INDEX_CATEGORY_MENUINDEX = 'category_menuindex';
+
+    public function up(): void
+    {
+        $table = $this->table(self::TABLE);
+        $columnAdded = false;
+
+        if (!$table->hasColumn('menuindex')) {
+            $table->addColumn('menuindex', 'integer', [
+                'signed' => false,
+                'null' => false,
+                'default' => 0,
+                'after' => 'category_id',
+            ]);
+            $table->update();
+            $columnAdded = true;
+        }
+
+        if ($columnAdded) {
+            $this->backfillMenuindexFromProducts();
+        }
+
+        $table = $this->table(self::TABLE);
+        if (!$table->hasIndexByName(self::INDEX_CATEGORY_MENUINDEX)) {
+            $table->addIndex(['category_id', 'menuindex'], [
+                'name' => self::INDEX_CATEGORY_MENUINDEX,
+            ]);
+            $table->update();
+        }
+    }
+
+    public function down(): void
+    {
+        $table = $this->table(self::TABLE);
+
+        if ($table->hasIndexByName(self::INDEX_CATEGORY_MENUINDEX)) {
+            $table->removeIndexByName(self::INDEX_CATEGORY_MENUINDEX);
+        }
+
+        if ($table->hasColumn('menuindex')) {
+            $table->removeColumn('menuindex');
+        }
+
+        $table->update();
+    }
+
+    private function backfillMenuindexFromProducts(): void
+    {
+        if (!$this->hasTable(self::TABLE)) {
+            return;
+        }
+
+        $prefix = (string) ($this->getAdapter()->getOption('table_prefix') ?? '');
+        $members = '`' . $prefix . self::TABLE . '`';
+        $resources = '`' . $prefix . 'site_content`';
+
+        $this->execute(
+            "UPDATE {$members} AS m "
+            . "INNER JOIN {$resources} AS sc ON sc.id = m.product_id "
+            . 'SET m.menuindex = sc.menuindex'
+        );
+    }
+}

--- a/core/components/minishop3/schema/minishop3.mysql.schema.xml
+++ b/core/components/minishop3/schema/minishop3.mysql.schema.xml
@@ -106,10 +106,16 @@
                index="pk"/>
         <field key="category_id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"
                index="pk"/>
+        <field key="menuindex" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false"
+               default="0"/>
 
         <index alias="product" name="product" primary="true" unique="true" type="BTREE">
             <column key="product_id" length="" collation="A" null="false"/>
             <column key="category_id" length="" collation="A" null="false"/>
+        </index>
+        <index alias="category_menuindex" name="category_menuindex" primary="false" unique="false" type="BTREE">
+            <column key="category_id" length="" collation="A" null="false"/>
+            <column key="menuindex" length="" collation="A" null="false"/>
         </index>
 
         <aggregate alias="Product" class="MiniShop3\Model\msProduct" local="product_id" foreign="id" cardinality="one" owner="foreign"/>

--- a/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CategoryProductsController.php
@@ -8,6 +8,7 @@ use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Category\CategoryProductActionPermissions;
 use MiniShop3\Services\Category\CategoryProductDocumentPolicy;
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Services\Category\CategoryProductsListService;
 use MiniShop3\Services\FilterConfigManager;
@@ -165,6 +166,7 @@ class CategoryProductsController
         $policyDenied = 0;
 
         $scope = $this->scopeService();
+        $menuindexService = new CategoryProductMenuindexService($this->modx);
 
         foreach ($items as $item) {
             $productId = (int) ($item['id'] ?? 0);
@@ -186,8 +188,7 @@ class CategoryProductsController
                 continue;
             }
 
-            $product->set('menuindex', $menuindex);
-            if ($product->save()) {
+            if ($menuindexService->setMenuindexInCategory($productId, $categoryId, $menuindex)) {
                 $updated++;
             }
         }

--- a/core/components/minishop3/src/Model/msCategoryMember.php
+++ b/core/components/minishop3/src/Model/msCategoryMember.php
@@ -9,6 +9,7 @@ use xPDO\Om\xPDOObject;
  *
  * @property integer $product_id
  * @property integer $category_id
+ * @property integer $menuindex
  *
  * @package MiniShop3\Model
  */

--- a/core/components/minishop3/src/Model/mysql/msCategoryMember.php
+++ b/core/components/minishop3/src/Model/mysql/msCategoryMember.php
@@ -17,6 +17,7 @@ class msCategoryMember extends \MiniShop3\Model\msCategoryMember
             [
                 'product_id' => null,
                 'category_id' => null,
+                'menuindex' => 0,
             ],
         'fieldMeta' =>
             [
@@ -38,6 +39,15 @@ class msCategoryMember extends \MiniShop3\Model\msCategoryMember
                         'null' => false,
                         'index' => 'pk',
                     ],
+                'menuindex' =>
+                    [
+                        'dbtype' => 'int',
+                        'precision' => '10',
+                        'attributes' => 'unsigned',
+                        'phptype' => 'integer',
+                        'null' => false,
+                        'default' => 0,
+                    ],
             ],
         'indexes' =>
             [
@@ -56,6 +66,28 @@ class msCategoryMember extends \MiniShop3\Model\msCategoryMember
                                         'null' => false,
                                     ],
                                 'category_id' =>
+                                    [
+                                        'length' => '',
+                                        'collation' => 'A',
+                                        'null' => false,
+                                    ],
+                            ],
+                    ],
+                'category_menuindex' =>
+                    [
+                        'alias' => 'category_menuindex',
+                        'primary' => false,
+                        'unique' => false,
+                        'type' => 'BTREE',
+                        'columns' =>
+                            [
+                                'category_id' =>
+                                    [
+                                        'length' => '',
+                                        'collation' => 'A',
+                                        'null' => false,
+                                    ],
+                                'menuindex' =>
                                     [
                                         'length' => '',
                                         'collation' => 'A',

--- a/core/components/minishop3/src/Processors/Product/Category.php
+++ b/core/components/minishop3/src/Processors/Product/Category.php
@@ -3,6 +3,7 @@
 namespace MiniShop3\Processors\Product;
 
 use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MODX\Revolution\Processors\Model\CreateProcessor;
 
 class Category extends CreateProcessor
@@ -22,13 +23,10 @@ class Category extends CreateProcessor
             /** @var msCategoryMember $res */
             $res = $this->modx->getObject(msCategoryMember::class, ['category_id' => $cid, 'product_id' => $pid]);
             if (!$res) {
-                $res = $this->modx->newObject(msCategoryMember::class);
-                $res->set('product_id', $pid);
-                $res->set('category_id', $cid);
-                $res->save();
+                $menuindexService = new CategoryProductMenuindexService($this->modx);
+                $menuindexService->ensureMember((int) $pid, (int) $cid);
             } else {
-                $table = $this->modx->getTableName(msCategoryMember::class);
-                $this->modx->exec("DELETE FROM {$table} WHERE `product_id` = {$pid} AND `category_id` = {$cid};");
+                $res->remove();
             }
         }
 

--- a/core/components/minishop3/src/Services/Category/CategoryProductMenuindexService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductMenuindexService.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Category;
+
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msProduct;
+use MODX\Revolution\modX;
+use xPDO\Om\xPDOQuery;
+
+/**
+ * Per-category menuindex: native parent uses resource menuindex, member links use msCategoryMember.menuindex (#625).
+ */
+final class CategoryProductMenuindexService
+{
+    public const MEMBER_JOIN_ALIAS = 'CategoryMember';
+
+    public function __construct(private modX $modx)
+    {
+    }
+
+    public static function isNativeInCategory(int $productParent, int $categoryId): bool
+    {
+        return $productParent === $categoryId;
+    }
+
+    /**
+     * @param list<int> $categoryIds
+     */
+    public static function isNativeInCategories(int $productParent, array $categoryIds): bool
+    {
+        return in_array($productParent, $categoryIds, true);
+    }
+
+    /**
+     * Effective sort/select expression for a single category grid context.
+     */
+    public static function effectiveMenuindexSql(
+        int $categoryId,
+        string $productAlias = 'msProduct',
+        string $memberAlias = self::MEMBER_JOIN_ALIAS,
+    ): string {
+        return self::effectiveMenuindexCase(
+            "{$productAlias}.parent = " . max(0, $categoryId),
+            "{$memberAlias}.menuindex",
+            $productAlias,
+        );
+    }
+
+    /**
+     * Effective sort/select when multiple category IDs define the catalog scope.
+     *
+     * @param list<int> $categoryIds
+     */
+    public static function effectiveMenuindexSqlForCategories(
+        array $categoryIds,
+        string $productAlias = 'msProduct',
+        string $memberAlias = self::MEMBER_JOIN_ALIAS,
+    ): string {
+        $categoryIds = self::normalizeCategoryIds($categoryIds);
+        if ($categoryIds === []) {
+            return "{$productAlias}.menuindex";
+        }
+
+        if (count($categoryIds) === 1) {
+            return self::effectiveMenuindexSql($categoryIds[0], $productAlias, $memberAlias);
+        }
+
+        return self::effectiveMenuindexCase(
+            "{$productAlias}.parent IN (" . implode(',', $categoryIds) . ')',
+            "MIN({$memberAlias}.menuindex)",
+            $productAlias,
+        );
+    }
+
+    public static function memberJoinOn(int $categoryId, string $memberAlias = self::MEMBER_JOIN_ALIAS): string
+    {
+        $categoryId = max(0, $categoryId);
+
+        return "`{$memberAlias}`.product_id = msProduct.id AND `{$memberAlias}`.category_id = {$categoryId}";
+    }
+
+    /**
+     * @param list<int> $categoryIds
+     */
+    public static function memberJoinOnCategories(array $categoryIds, string $memberAlias = self::MEMBER_JOIN_ALIAS): string
+    {
+        $categoryIds = self::normalizeCategoryIds($categoryIds);
+        if ($categoryIds === []) {
+            return '1=0';
+        }
+
+        if (count($categoryIds) === 1) {
+            return self::memberJoinOn($categoryIds[0], $memberAlias);
+        }
+
+        return "`{$memberAlias}`.product_id = msProduct.id AND `{$memberAlias}`.category_id IN ("
+            . implode(',', $categoryIds)
+            . ')';
+    }
+
+    /**
+     * LEFT JOIN msCategoryMember for catalog/list scope and return effective menuindex SQL.
+     *
+     * @param list<int> $categoryIds
+     */
+    public static function applyMemberJoin(xPDOQuery $query, array $categoryIds): string
+    {
+        $memberAlias = self::MEMBER_JOIN_ALIAS;
+        $query->leftJoin(
+            msCategoryMember::class,
+            $memberAlias,
+            self::memberJoinOnCategories($categoryIds, $memberAlias)
+        );
+
+        return self::effectiveMenuindexSqlForCategories($categoryIds);
+    }
+
+    /**
+     * @param list<int> $categoryIds
+     * @return list<int>
+     */
+    private static function normalizeCategoryIds(array $categoryIds): array
+    {
+        return array_values(array_unique(array_filter(array_map('intval', $categoryIds))));
+    }
+
+    private static function effectiveMenuindexCase(
+        string $nativeParentCondition,
+        string $memberMenuindexExpression,
+        string $productAlias,
+    ): string {
+        return 'CASE WHEN '
+            . "{$nativeParentCondition} "
+            . "THEN {$productAlias}.menuindex "
+            . "ELSE COALESCE({$memberMenuindexExpression}, {$productAlias}.menuindex) "
+            . 'END';
+    }
+
+    public function getNextMemberMenuindex(int $categoryId): int
+    {
+        if ($categoryId <= 0) {
+            return 0;
+        }
+
+        $maxNative = $this->fetchMaxMenuindex(
+            msProduct::class,
+            ['parent' => $categoryId],
+        );
+        $maxMember = $this->fetchMaxMenuindex(
+            msCategoryMember::class,
+            ['category_id' => $categoryId],
+        );
+
+        return max($maxNative, $maxMember) + 1;
+    }
+
+    public function ensureMember(int $productId, int $categoryId): bool
+    {
+        if ($productId <= 0 || $categoryId <= 0) {
+            return false;
+        }
+
+        $existing = $this->modx->getObject(msCategoryMember::class, [
+            'category_id' => $categoryId,
+            'product_id' => $productId,
+        ]);
+        if ($existing) {
+            return true;
+        }
+
+        /** @var msCategoryMember $member */
+        $member = $this->modx->newObject(msCategoryMember::class);
+        $member->set('product_id', $productId);
+        $member->set('category_id', $categoryId);
+        $member->set('menuindex', $this->getNextMemberMenuindex($categoryId));
+
+        return (bool) $member->save();
+    }
+
+    /**
+     * @param class-string $classKey
+     * @param array<string, mixed> $criteria
+     */
+    private function fetchMaxMenuindex(string $classKey, array $criteria): int
+    {
+        $query = $this->modx->newQuery($classKey);
+        $query->where($criteria);
+        $query->select('MAX(menuindex)');
+
+        if (!$query->prepare() || !$query->stmt->execute()) {
+            return -1;
+        }
+
+        $max = $query->stmt->fetchColumn();
+
+        return $max !== false ? (int) $max : -1;
+    }
+
+    public function setMenuindexInCategory(int $productId, int $categoryId, int $menuindex): bool
+    {
+        if ($productId <= 0 || $categoryId <= 0) {
+            return false;
+        }
+
+        /** @var msProduct|null $product */
+        $product = $this->modx->getObject(msProduct::class, $productId);
+        if (!$product) {
+            return false;
+        }
+
+        if (self::isNativeInCategory((int) $product->get('parent'), $categoryId)) {
+            $product->set('menuindex', $menuindex);
+
+            return (bool) $product->save();
+        }
+
+        /** @var msCategoryMember|null $member */
+        $member = $this->modx->getObject(msCategoryMember::class, [
+            'category_id' => $categoryId,
+            'product_id' => $productId,
+        ]);
+        if (!$member) {
+            return false;
+        }
+
+        $member->set('menuindex', $menuindex);
+
+        return (bool) $member->save();
+    }
+}

--- a/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductScopeService.php
@@ -232,20 +232,11 @@ class CategoryProductScopeService
     }
 
     /**
-     * menuindex reorder applies only to direct children (not additional-category-only links).
+     * Whether drag-drop menuindex reorder is allowed in this category grid (#625).
      */
     public function canReorderInCategory(int $productId, int $categoryId): bool
     {
-        if ($productId <= 0 || $categoryId <= 0) {
-            return false;
-        }
-
-        $product = $this->modx->getObject(msProduct::class, $productId);
-        if (!$product) {
-            return false;
-        }
-
-        return (int) $product->get('parent') === $categoryId;
+        return $this->findInCategory($categoryId, $productId, false) !== null;
     }
 
     /**

--- a/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
+++ b/core/components/minishop3/src/Services/Category/CategoryProductsListService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MiniShop3\Services\Category;
 
 use MiniShop3\Model\msCategory;
+use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
 use MiniShop3\Model\msProductOption;
@@ -48,15 +49,20 @@ final class CategoryProductsListService
         $optionSpecs = GridOptionColumnResolver::resolve($gridFields);
         $relationSpecs = GridRelationColumnResolver::resolve($this->modx, $gridFields);
 
-        $c = $this->buildProductListQuery($categoryId, $params, $nested, $optionSpecs, $relationSpecs);
+        $scopeCategoryIds = $nested
+            ? $this->treeService()->productParentIds($categoryId, true)
+            : [$categoryId];
 
-        $countQuery = $this->buildProductListQuery($categoryId, $params, $nested, $optionSpecs, $relationSpecs);
+        $c = $this->buildProductListQuery($scopeCategoryIds, $params, $optionSpecs, $relationSpecs);
+
+        $countQuery = $this->buildProductListQuery($scopeCategoryIds, $params, $optionSpecs, $relationSpecs);
         $countQuery->select('COUNT(DISTINCT msProduct.id)');
         $countQuery->prepare();
         $countQuery->stmt->execute();
         $total = (int) $countQuery->stmt->fetchColumn();
 
-        $sortField = $this->mapSortField($sortBy, $optionSpecs, $relationSpecs);
+        $effectiveMenuindexSql = CategoryProductMenuindexService::effectiveMenuindexSqlForCategories($scopeCategoryIds);
+        $sortField = $this->mapSortField($sortBy, $optionSpecs, $relationSpecs, $effectiveMenuindexSql);
         $c->sortby($sortField, $sortDir);
         $c->limit($limit, $start);
 
@@ -80,9 +86,10 @@ final class CategoryProductsListService
         foreach ($relationSpecs as $spec) {
             $selectParts[] = $spec->selectExpression();
         }
+        $selectParts[] = "{$effectiveMenuindexSql} AS effective_menuindex";
         // xPDOQuery::select() declares string, accepts both at runtime but PHPStan is strict.
         $c->select(implode(', ', $selectParts));
-        if ($optionSpecs !== []) {
+        if ($optionSpecs !== [] || count($scopeCategoryIds) > 1) {
             $c->groupby('msProduct.id');
         }
 
@@ -114,8 +121,12 @@ final class CategoryProductsListService
      * @param list<OptionColumnSpec>    $optionSpecs
      * @param list<RelationColumnSpec>  $relationSpecs
      */
-    private function mapSortField(string $sortBy, array $optionSpecs, array $relationSpecs): string
-    {
+    private function mapSortField(
+        string $sortBy,
+        array $optionSpecs,
+        array $relationSpecs,
+        string $effectiveMenuindexSql,
+    ): string {
         foreach ($optionSpecs as $spec) {
             if ($spec->fieldName === $sortBy) {
                 return $this->aggregateOptionValueSql($spec->alias);
@@ -126,7 +137,10 @@ final class CategoryProductsListService
                 return $spec->sortExpression();
             }
         }
-        $productFields = ['id', 'pagetitle', 'menuindex', 'published', 'createdon', 'editedon'];
+        if ($sortBy === 'menuindex') {
+            return $effectiveMenuindexSql;
+        }
+        $productFields = ['id', 'pagetitle', 'published', 'createdon', 'editedon'];
         if (in_array($sortBy, $productFields, true)) {
             return "msProduct.{$sortBy}";
         }
@@ -139,13 +153,13 @@ final class CategoryProductsListService
     }
 
     /**
-     * @param list<OptionColumnSpec>    $optionSpecs
-     * @param list<RelationColumnSpec>  $relationSpecs
+     * @param list<int>               $scopeCategoryIds
+     * @param list<OptionColumnSpec>  $optionSpecs
+     * @param list<RelationColumnSpec> $relationSpecs
      */
     private function buildProductListQuery(
-        int $categoryId,
+        array $scopeCategoryIds,
         array $params,
-        bool $nested,
         array $optionSpecs,
         array $relationSpecs,
     ): xPDOQuery {
@@ -167,15 +181,17 @@ final class CategoryProductsListService
             $c->leftJoin($spec->modelClass, $spec->alias, $spec->joinCondition());
         }
 
+        $memberAlias = CategoryProductMenuindexService::MEMBER_JOIN_ALIAS;
+        $c->leftJoin(
+            msCategoryMember::class,
+            $memberAlias,
+            CategoryProductMenuindexService::memberJoinOnCategories($scopeCategoryIds, $memberAlias)
+        );
+
         $c->where(['msProduct.class_key' => msProduct::class]);
 
         $scopeService = $this->getCategoryProductScopeService();
-        if ($nested) {
-            $categoryIds = $this->treeService()->productParentIds($categoryId, true);
-            $scopeService->applyProductCategoryScope($c, $categoryIds);
-        } else {
-            $scopeService->applyProductCategoryScope($c, [$categoryId]);
-        }
+        $scopeService->applyProductCategoryScope($c, $scopeCategoryIds);
 
         if ($query !== '') {
             $c->where([
@@ -308,7 +324,7 @@ final class CategoryProductsListService
             'longtitle' => $row['longtitle'] ?? '',
             'alias' => $row['alias'] ?? '',
             'parent' => (int) ($row['parent'] ?? 0),
-            'menuindex' => (int) ($row['menuindex'] ?? 0),
+            'menuindex' => (int) ($row['effective_menuindex'] ?? $row['menuindex'] ?? 0),
             'published' => (bool) ($row['published'] ?? false),
             'deleted' => (bool) ($row['deleted'] ?? false),
             'hidemenu' => (bool) ($row['hidemenu'] ?? false),

--- a/core/components/minishop3/src/Services/Product/ProductCatalogService.php
+++ b/core/components/minishop3/src/Services/Product/ProductCatalogService.php
@@ -6,7 +6,9 @@ namespace MiniShop3\Services\Product;
 
 use MiniShop3\Model\msProduct;
 use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Services\Catalog\CatalogQuery;
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MiniShop3\Services\Option\OptionService;
 use MODX\Revolution\modX;
@@ -218,7 +220,7 @@ class ProductCatalogService
 
         $listQuery = $this->buildListQuery($params, $filters);
         $this->applyListSelect($listQuery, $includeContent);
-        $this->applySort($listQuery, $params);
+        $this->applySort($listQuery, $params, $filters);
         $listQuery->limit($limit, $offset);
 
         /** @var array<int|string, msProduct> $products */
@@ -407,10 +409,71 @@ class ProductCatalogService
     /**
      * @param array<string, mixed> $params
      */
-    private function applySort(xPDOQuery $query, array $params): void
+    private function applySort(xPDOQuery $query, array $params, ProductCatalogFilterSpec $filters): void
     {
+        $sortKey = strtolower(trim((string) ($params['sort'] ?? 'menuindex')));
+        if ($sortKey === 'menuindex') {
+            $categoryIds = $this->resolveMenuindexCategoryIds($params, $filters);
+            if ($categoryIds !== []) {
+                $this->applyEffectiveMenuindexSort($query, $categoryIds, $params, $filters);
+
+                return;
+            }
+        }
+
         [$sortField, $dir] = self::resolveSort($params);
         $query->sortby($sortField, $dir);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return list<int>
+     */
+    public function resolveMenuindexCategoryIds(array $params, ProductCatalogFilterSpec $filters): array
+    {
+        if ($filters->hasParents()) {
+            $depth = $filters->nested ? ProductCatalogFilterApplier::NESTED_DEPTH : 0;
+            $parentsCsv = implode(',', $filters->parentIds);
+
+            return $this->categoryScopeService()->resolveCategoryIdsFromParents($parentsCsv, $depth);
+        }
+
+        $parent = (int) ($params['parent'] ?? $params['category'] ?? 0);
+        if ($parent > 0) {
+            return [$parent];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<int> $categoryIds
+     * @param array<string, mixed> $params
+     */
+    private function applyEffectiveMenuindexSort(
+        xPDOQuery $query,
+        array $categoryIds,
+        array $params,
+        ProductCatalogFilterSpec $filters,
+    ): void {
+        $memberAlias = CategoryProductMenuindexService::MEMBER_JOIN_ALIAS;
+        $sortSql = CategoryProductMenuindexService::applyMemberJoin($query, $categoryIds);
+
+        [, $dir] = self::resolveSort($params);
+
+        if (count($categoryIds) > 1 || $filters->options !== []) {
+            $query->groupby('msProduct.id');
+        }
+
+        $query->sortby($sortSql, $dir);
+    }
+
+    private function categoryScopeService(): CategoryProductScopeService
+    {
+        /** @var CategoryProductScopeService $scope */
+        $scope = $this->modx->services->get('ms3_category_product_scope');
+
+        return $scope;
     }
 
     /**

--- a/core/components/minishop3/src/Services/Product/ProductCategoryMembershipWriter.php
+++ b/core/components/minishop3/src/Services/Product/ProductCategoryMembershipWriter.php
@@ -6,6 +6,7 @@ namespace MiniShop3\Services\Product;
 
 use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msProductData;
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
 use MODX\Revolution\modX;
 
 /**
@@ -15,17 +16,19 @@ class ProductCategoryMembershipWriter
 {
     use ProductDataExplicitFieldsTrait;
 
-    protected modX $modx;
+    private CategoryProductMenuindexService $menuindexService;
 
-    public function __construct(modX $modx)
-    {
-        $this->modx = $modx;
+    public function __construct(
+        private modX $modx,
+    ) {
+        $this->menuindexService = new CategoryProductMenuindexService($modx);
     }
 
     /**
      * Save additional product categories.
      *
      * If `categories` was not sent, leave msCategoryMember untouched.
+     * Preserves menuindex for kept pairs; new members get MAX(menuindex)+1 in that category.
      */
     public function saveCategories(msProductData $productData): void
     {
@@ -34,33 +37,59 @@ class ProductCategoryMembershipWriter
             return;
         }
 
-        $productId = $productData->get('id');
-        $categories = $this->normalizeList($fields['categories']);
+        $productId = (int) $productData->get('id');
+        $desiredCategoryIds = $this->normalizeCategoryIds($fields['categories']);
+        $desiredCategorySet = array_flip($desiredCategoryIds);
 
-        $this->modx->removeCollection(msCategoryMember::class, ['product_id' => $productId]);
+        /** @var array<int, msCategoryMember> $existingByCategory */
+        $existingByCategory = [];
+        /** @var msCategoryMember $member */
+        foreach ($this->modx->getCollection(msCategoryMember::class, ['product_id' => $productId]) as $member) {
+            $existingByCategory[(int) $member->get('category_id')] = $member;
+        }
 
-        foreach ($categories as $categoryId) {
-            if (empty($categoryId) || !is_numeric($categoryId)) {
+        foreach ($existingByCategory as $categoryId => $member) {
+            if (!isset($desiredCategorySet[$categoryId])) {
+                $member->remove();
+            }
+        }
+
+        foreach ($desiredCategoryIds as $categoryId) {
+            if (array_key_exists($categoryId, $existingByCategory)) {
                 continue;
             }
 
             /** @var msCategoryMember $member */
             $member = $this->modx->newObject(msCategoryMember::class);
             $member->set('product_id', $productId);
-            $member->set('category_id', (int)$categoryId);
+            $member->set('category_id', $categoryId);
+            $member->set('menuindex', $this->menuindexService->getNextMemberMenuindex($categoryId));
             $member->save();
         }
     }
 
     /**
-     * @return list<mixed>
+     * @return list<int>
      */
-    private function normalizeList(mixed $value): array
+    private function normalizeCategoryIds(mixed $value): array
     {
         if (is_string($value)) {
             $value = json_decode($value, true);
         }
 
-        return is_array($value) ? $value : [];
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($value as $categoryId) {
+            if (empty($categoryId) || !is_numeric($categoryId)) {
+                continue;
+            }
+
+            $ids[] = (int) $categoryId;
+        }
+
+        return array_values(array_unique($ids));
     }
 }

--- a/core/components/minishop3/tests/CategoryProductMenuindexServiceTest.php
+++ b/core/components/minishop3/tests/CategoryProductMenuindexServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * CategoryProductMenuindexService SQL helpers (#625).
+ *
+ * Run: php tests/CategoryProductMenuindexServiceTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/stubs/ProductCategoryMembershipModxStub.php';
+
+use MiniShop3\Services\Category\CategoryProductMenuindexService;
+use MiniShop3\Tests\Stubs\ProductCategoryMembershipModxStub;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$assertTrue = static function (bool $value, string $case) use ($fail): void {
+    if (!$value) {
+        $fail($case);
+    }
+};
+
+$assertSame(true, CategoryProductMenuindexService::isNativeInCategory(5, 5), 'native same category');
+$assertSame(false, CategoryProductMenuindexService::isNativeInCategory(5, 9), 'not native');
+$assertSame(true, CategoryProductMenuindexService::isNativeInCategories(3, [1, 3, 7]), 'native in list');
+
+$singleSql = CategoryProductMenuindexService::effectiveMenuindexSql(12);
+$assertTrue(str_contains($singleSql, 'msProduct.parent = 12'), 'single category parent check');
+$assertTrue(str_contains($singleSql, 'COALESCE(CategoryMember.menuindex, msProduct.menuindex)'), 'single coalesce');
+
+$multiSql = CategoryProductMenuindexService::effectiveMenuindexSqlForCategories([4, 8]);
+$assertTrue(str_contains($multiSql, 'msProduct.parent IN (4,8)'), 'multi parent in');
+$assertTrue(str_contains($multiSql, 'MIN(CategoryMember.menuindex)'), 'multi uses min');
+
+$joinSingle = CategoryProductMenuindexService::memberJoinOn(15);
+$assertSame(
+    '`CategoryMember`.product_id = msProduct.id AND `CategoryMember`.category_id = 15',
+    $joinSingle,
+    'single member join'
+);
+
+$joinMulti = CategoryProductMenuindexService::memberJoinOnCategories([2, 6]);
+$assertSame(
+    '`CategoryMember`.product_id = msProduct.id AND `CategoryMember`.category_id IN (2,6)',
+    $joinMulti,
+    'multi member join'
+);
+
+$menuindexModx = new ProductCategoryMembershipModxStub();
+$menuindexService = new CategoryProductMenuindexService($menuindexModx);
+
+$assertSame(0, $menuindexService->getNextMemberMenuindex(99), 'empty category next is 0');
+
+$menuindexModx->members = [
+    ['product_id' => 1, 'category_id' => 10, 'menuindex' => 4],
+    ['product_id' => 2, 'category_id' => 10, 'menuindex' => 7],
+];
+$assertSame(8, $menuindexService->getNextMemberMenuindex(10), 'next after member max');
+
+$menuindexModx->nativeProducts = [
+    ['parent' => 11, 'menuindex' => 12],
+];
+$menuindexModx->members = [];
+$assertSame(13, $menuindexService->getNextMemberMenuindex(11), 'next after native max');
+
+$menuindexModx->nativeProducts = [
+    ['parent' => 12, 'menuindex' => 3],
+];
+$menuindexModx->members = [
+    ['product_id' => 5, 'category_id' => 12, 'menuindex' => 9],
+];
+$assertSame(10, $menuindexService->getNextMemberMenuindex(12), 'next after greater of native and member');
+
+fwrite(STDOUT, "OK: CategoryProductMenuindexServiceTest\n");

--- a/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
+++ b/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
@@ -121,4 +121,18 @@ $assertSame(
     'admin scope parent or member ids'
 );
 
+$modx->products = [
+    ['id' => 30, 'parent' => 2],
+];
+$modx->members = [
+    ['product_id' => 30, 'category_id' => 1, 'menuindex' => 4],
+];
+$scopeWithMember = new CategoryProductScopeService($modx);
+$memberProduct = $scopeWithMember->findInCategory(1, 30, false);
+if (!$memberProduct instanceof StubMsProduct) {
+    $fail('member link should resolve product in category scope');
+}
+$assertSame(true, $scopeWithMember->canReorderInCategory(30, 1), 'member can reorder in category');
+$assertSame(false, $scopeWithMember->canReorderInCategory(30, 99), 'member cannot reorder outside category');
+
 fwrite(STDOUT, "OK: CategoryProductScopeServiceTest\n");

--- a/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
+++ b/core/components/minishop3/tests/CategoryProductScopeServiceTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 require __DIR__ . '/stubs/ModxStub.php';
 require __DIR__ . '/stubs/StubMsProduct.php';
 require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
+require __DIR__ . '/stubs/StubMsCategoryMember.php';
 require __DIR__ . '/../vendor/autoload.php';
 
 use MiniShop3\Model\msProduct;

--- a/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
+++ b/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
@@ -12,6 +12,7 @@ require __DIR__ . '/stubs/ModxStub.php';
 require __DIR__ . '/stubs/StubMsProduct.php';
 require __DIR__ . '/stubs/StubMsCategory.php';
 require __DIR__ . '/stubs/CategoryProductScopeModxStub.php';
+require __DIR__ . '/stubs/StubMsCategoryMember.php';
 require __DIR__ . '/../vendor/autoload.php';
 
 use MiniShop3\Controllers\Api\Manager\CategoryProductsController;

--- a/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
+++ b/core/components/minishop3/tests/CategoryProductsControllerScopeTest.php
@@ -90,6 +90,39 @@ $sort = $controller->sort([
 $assertSame(true, $sort['success'] ?? null, 'sort success');
 $assertSame(1, $sort['data']['updated'] ?? null, 'sort updated count');
 
+// sort member product: updates link menuindex only, not resource menuindex (#625)
+$modx->products = [
+    ['id' => 999, 'parent' => 2, 'published' => 0],
+    ['id' => 100, 'parent' => 1, 'published' => 0, 'menuindex' => 5],
+    ['id' => 101, 'parent' => 2, 'published' => 0],
+    ['id' => 150, 'parent' => 2, 'published' => 0, 'menuindex' => 1],
+    ['id' => 200, 'parent' => 1, 'published' => 0, 'policies' => ['save' => false]],
+];
+$modx->members = [
+    ['product_id' => 150, 'category_id' => 1, 'menuindex' => 2],
+];
+$memberSort = $controller->sort([
+    'id' => 1,
+    'items' => [['id' => 150, 'menuindex' => 9]],
+]);
+$assertSame(true, $memberSort['success'] ?? null, 'member sort success');
+$assertSame(1, $memberSort['data']['updated'] ?? null, 'member sort updated');
+$product150Menuindex = null;
+foreach ($modx->products as $row) {
+    if ((int) $row['id'] === 150) {
+        $product150Menuindex = (int) ($row['menuindex'] ?? 0);
+        break;
+    }
+}
+$assertSame(1, $product150Menuindex, 'native resource menuindex unchanged');
+$memberMenuindex = null;
+foreach ($modx->members as $row) {
+    if ((int) $row['product_id'] === 150 && (int) $row['category_id'] === 1) {
+        $memberMenuindex = (int) ($row['menuindex'] ?? 0);
+    }
+}
+$assertSame(9, $memberMenuindex, 'member menuindex updated in category B');
+
 // updateProductData: in-scope product with document save policy denied → 403 (#473 pattern)
 $modx->getObjectCalls = [];
 $aclDenied = $controller->updateProductData([

--- a/core/components/minishop3/tests/ProductCatalogServiceTest.php
+++ b/core/components/minishop3/tests/ProductCatalogServiceTest.php
@@ -105,5 +105,8 @@ $assertSame(
     'whitelist omits content/options when flags off'
 );
 
+$effectiveSingle = \MiniShop3\Services\Category\CategoryProductMenuindexService::effectiveMenuindexSql(42);
+$assertSame(true, str_contains($effectiveSingle, 'msProduct.parent = 42'), 'catalog effective menuindex uses category context');
+
 fwrite(STDOUT, "OK ProductCatalogServiceTest\n");
 exit(0);

--- a/core/components/minishop3/tests/ProductCategoryMembershipWriterTest.php
+++ b/core/components/minishop3/tests/ProductCategoryMembershipWriterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * ProductCategoryMembershipWriter preserves member menuindex on re-save (#625).
+ *
+ * Run: php tests/ProductCategoryMembershipWriterTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/support/xpdo_stub.php';
+require __DIR__ . '/support/xpdo_om_stub.php';
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/stubs/ProductCategoryMembershipModxStub.php';
+
+use MiniShop3\Model\msProductData;
+use MiniShop3\Services\Product\ProductCategoryMembershipWriter;
+use MiniShop3\Tests\Stubs\ProductCategoryMembershipModxStub;
+
+final class WriterTestProductData extends msProductData
+{
+    /** @var array<string, mixed> */
+    public array $_fields = [];
+
+    public function get($key, $format = null, $formatString = '')
+    {
+        if ($key === 'id') {
+            return 100;
+        }
+
+        return parent::get($key, $format, $formatString);
+    }
+}
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $case) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail($case . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+};
+
+$modx = new ProductCategoryMembershipModxStub();
+$modx->members = [
+    ['product_id' => 100, 'category_id' => 2, 'menuindex' => 7],
+    ['product_id' => 100, 'category_id' => 3, 'menuindex' => 4],
+];
+$modx->nativeProducts = [
+    ['parent' => 5, 'menuindex' => 2],
+];
+
+$writer = new ProductCategoryMembershipWriter($modx);
+$xpdo = new class extends \xPDO\xPDO {
+    public object $services;
+
+    public function __construct()
+    {
+        $this->services = new class {
+            public function has(string $key): bool
+            {
+                return false;
+            }
+
+            public function get(string $key): null
+            {
+                return null;
+            }
+        };
+    }
+};
+
+$setExplicitCategories = static function (WriterTestProductData $productData, array $categories): void {
+    $productData->_fields = [
+        'id' => 100,
+        'categories' => $categories,
+    ];
+};
+
+$productData = new WriterTestProductData($xpdo);
+$setExplicitCategories($productData, [2, 3, 5]);
+
+$writer->saveCategories($productData);
+
+$byCategory = [];
+foreach ($modx->members as $row) {
+    $byCategory[(int) $row['category_id']] = (int) $row['menuindex'];
+}
+
+$assertSame(7, $byCategory[2] ?? null, 'kept menuindex for category 2');
+$assertSame(4, $byCategory[3] ?? null, 'kept menuindex for category 3');
+$assertSame(3, $byCategory[5] ?? null, 'new member gets next menuindex after native product in category 5');
+
+$productData2 = new WriterTestProductData($xpdo);
+$setExplicitCategories($productData2, [2]);
+
+$writer->saveCategories($productData2);
+
+$remainingCategories = array_map(
+    static fn(array $row): int => (int) $row['category_id'],
+    $modx->members
+);
+sort($remainingCategories);
+$assertSame([2], $remainingCategories, 'removed unlisted categories');
+$assertSame(7, $modx->members[0]['menuindex'], 'menuindex still preserved after shrink');
+
+fwrite(STDOUT, "OK: ProductCategoryMembershipWriterTest\n");

--- a/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
+++ b/core/components/minishop3/tests/stubs/CategoryProductScopeModxStub.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MiniShop3\Tests\Stubs;
 
 use MiniShop3\Model\msCategory;
+use MiniShop3\Model\msCategoryMember;
 use MiniShop3\Model\msProduct;
 use MODX\Revolution\modX;
 
@@ -16,8 +17,11 @@ class CategoryProductScopeModxStub extends modX
     /** @var object|null */
     public $lexicon;
 
-    /** @var list<array{id: int, parent: int, published?: int, deleted?: int, policies?: array<string, bool>}> */
+    /** @var list<array{id: int, parent: int, published?: int, deleted?: int, menuindex?: int, policies?: array<string, bool>}> */
     public array $products = [];
+
+    /** @var list<array{product_id: int, category_id: int, menuindex?: int}> */
+    public array $members = [];
 
     /** @var list<array{id: int, parent: int}> */
     public array $categories = [];
@@ -74,6 +78,19 @@ class CategoryProductScopeModxStub extends modX
     {
         $this->getObjectCalls[] = ['class' => $className, 'criteria' => $criteria];
 
+        if ($className === msCategoryMember::class && is_array($criteria)) {
+            $productId = (int) ($criteria['product_id'] ?? 0);
+            $categoryId = (int) ($criteria['category_id'] ?? 0);
+
+            foreach ($this->members as $row) {
+                if ((int) $row['product_id'] === $productId && (int) $row['category_id'] === $categoryId) {
+                    return new StubMsCategoryMember($row, $this);
+                }
+            }
+
+            return null;
+        }
+
         if ($className === msCategory::class) {
             $categoryId = is_array($criteria)
                 ? (int) ($criteria['id'] ?? 0)
@@ -110,6 +127,18 @@ class CategoryProductScopeModxStub extends modX
             foreach ($this->products as $row) {
                 if ((int) $row['id'] === $productId && (int) $row['parent'] === $parentId) {
                     return new StubMsProduct($row, $row['policies'] ?? null);
+                }
+            }
+
+            if ($parentId > 0) {
+                return null;
+            }
+
+            if ($productId > 0) {
+                foreach ($this->products as $row) {
+                    if ((int) $row['id'] === $productId) {
+                        return new StubMsProduct($row, $row['policies'] ?? null);
+                    }
                 }
             }
 

--- a/core/components/minishop3/tests/stubs/ProductCategoryMembershipModxStub.php
+++ b/core/components/minishop3/tests/stubs/ProductCategoryMembershipModxStub.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProduct;
+use MODX\Revolution\modX;
+
+/**
+ * modX stub for ProductCategoryMembershipWriter upsert tests (#625).
+ */
+class ProductCategoryMembershipModxStub extends modX
+{
+    /** @var list<array{product_id: int, category_id: int, menuindex: int}> */
+    public array $members = [];
+
+    /** @var list<array{parent: int, menuindex: int}> */
+    public array $nativeProducts = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @param class-string $className
+     * @return list<StubMsCategoryMemberForWriter>
+     */
+    public function getCollection($className, $criteria = null, $cacheFlag = false)
+    {
+        if ($className !== msCategoryMember::class || !is_array($criteria)) {
+            return [];
+        }
+
+        $productId = (int) ($criteria['product_id'] ?? 0);
+
+        return array_map(
+            fn(array $row): StubMsCategoryMemberForWriter => new StubMsCategoryMemberForWriter($row, $this),
+            array_values(array_filter(
+                $this->members,
+                static fn(array $row): bool => (int) $row['product_id'] === $productId
+            ))
+        );
+    }
+
+    /**
+     * @param class-string $className
+     */
+    public function newObject($className = '', $fields = [])
+    {
+        if ($className !== msCategoryMember::class) {
+            return null;
+        }
+
+        return new StubMsCategoryMemberForWriter([
+            'product_id' => 0,
+            'category_id' => 0,
+            'menuindex' => 0,
+        ], $this);
+    }
+
+    public function newQuery($class = '', $criteria = null)
+    {
+        return new MembershipWriterQueryStub($this, (string) $class);
+    }
+}
+
+class StubMsCategoryMemberForWriter
+{
+    /** @var array<string, mixed> */
+    private array $data;
+
+    private ?ProductCategoryMembershipModxStub $modx;
+
+    private bool $removed = false;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data, ?ProductCategoryMembershipModxStub $modx = null)
+    {
+        $this->data = $data;
+        $this->modx = $modx;
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function save(): bool
+    {
+        if ($this->removed || $this->modx === null) {
+            return false;
+        }
+
+        $productId = (int) $this->data['product_id'];
+        $categoryId = (int) $this->data['category_id'];
+        $found = false;
+
+        foreach ($this->modx->members as $index => $row) {
+            if ((int) $row['product_id'] === $productId && (int) $row['category_id'] === $categoryId) {
+                $this->modx->members[$index] = [
+                    'product_id' => $productId,
+                    'category_id' => $categoryId,
+                    'menuindex' => (int) ($this->data['menuindex'] ?? 0),
+                ];
+                $found = true;
+                break;
+            }
+        }
+
+        if (!$found) {
+            $this->modx->members[] = [
+                'product_id' => $productId,
+                'category_id' => $categoryId,
+                'menuindex' => (int) ($this->data['menuindex'] ?? 0),
+            ];
+        }
+
+        return true;
+    }
+
+    public function remove(): void
+    {
+        if ($this->modx === null) {
+            return;
+        }
+
+        $this->removed = true;
+        $productId = (int) $this->data['product_id'];
+        $categoryId = (int) $this->data['category_id'];
+        $this->modx->members = array_values(array_filter(
+            $this->modx->members,
+            static fn(array $row): bool => !((int) $row['product_id'] === $productId && (int) $row['category_id'] === $categoryId)
+        ));
+    }
+}
+
+class MembershipWriterQueryStub
+{
+    /** @var array<string, mixed> */
+    private array $where = [];
+
+    /** @var MembershipWriterStatementStub|null */
+    public $stmt;
+
+    public function __construct(
+        private ProductCategoryMembershipModxStub $modxStub,
+        private string $class,
+    ) {
+    }
+
+    public function where($conditions = '', $conj = '', $binding = null)
+    {
+        if (is_array($conditions)) {
+            $this->where = array_merge($this->where, $conditions);
+        }
+
+        return $this;
+    }
+
+    public function select($columns = '*')
+    {
+        return $this;
+    }
+
+    public function prepare($bindings = null)
+    {
+        $this->stmt = new MembershipWriterStatementStub($this->modxStub, $this->class, $this->where);
+
+        return true;
+    }
+}
+
+class MembershipWriterStatementStub
+{
+    public function __construct(
+        private ProductCategoryMembershipModxStub $modxStub,
+        private string $class,
+        /** @var array<string, mixed> */
+        private array $where,
+    ) {
+    }
+
+    public function execute($params = null)
+    {
+        return true;
+    }
+
+    public function fetchColumn($column = 0)
+    {
+        if ($this->class === msCategoryMember::class) {
+            $categoryId = (int) ($this->where['category_id'] ?? 0);
+            $max = -1;
+            foreach ($this->modxStub->members as $row) {
+                if ((int) $row['category_id'] === $categoryId) {
+                    $max = max($max, (int) $row['menuindex']);
+                }
+            }
+
+            return $max >= 0 ? $max : false;
+        }
+
+        if ($this->class === msProduct::class) {
+            $parent = (int) ($this->where['parent'] ?? 0);
+            $max = -1;
+            foreach ($this->modxStub->nativeProducts as $row) {
+                if ((int) $row['parent'] === $parent) {
+                    $max = max($max, (int) $row['menuindex']);
+                }
+            }
+
+            return $max >= 0 ? $max : false;
+        }
+
+        return false;
+    }
+}

--- a/core/components/minishop3/tests/stubs/StubMsCategoryMember.php
+++ b/core/components/minishop3/tests/stubs/StubMsCategoryMember.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Stubs;
+
+/**
+ * Minimal msCategoryMember stand-in for scope / menuindex smoke tests.
+ */
+class StubMsCategoryMember
+{
+    /** @var array<string, mixed> */
+    private array $data;
+
+    private CategoryProductScopeModxStub $modx;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data, CategoryProductScopeModxStub $modx)
+    {
+        $this->data = $data;
+        $this->modx = $modx;
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function save(): bool
+    {
+        $productId = (int) $this->data['product_id'];
+        $categoryId = (int) $this->data['category_id'];
+
+        foreach ($this->modx->members as $index => $row) {
+            if ((int) $row['product_id'] === $productId && (int) $row['category_id'] === $categoryId) {
+                $this->modx->members[$index] = $this->data;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Описание

У товара был один глобальный `menuindex` в ресурсе. Связь с доп. категориями (`ms3_product_categories`) не хранила порядок. DnD в категории B переписывал ресурсный `menuindex` и ломал выкладку в основной категории A. На витрине `sortby=menuindex` тоже смотрел только на ресурс.

Теперь:
- колонка `menuindex` на `ms3_product_categories` (+ миграция с backfill только при первом добавлении колонки);
- native (`parent = категория`) пишет `msProduct.menuindex`, member — только связь;
- грид/каталог/`ms3_products` сортируют по effective `CASE … COALESCE(member, product)`;
- nested-грид использует весь scope category IDs для join/sort;
- upsert membership сохраняет существующий порядок; новые member получают `MAX(native, member)+1`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #625

## Как это было протестировано?

```bash
cd core/components/minishop3
php tests/CategoryProductMenuindexServiceTest.php          # exit 0
php tests/ProductCategoryMembershipWriterTest.php          # exit 0
php tests/CategoryProductScopeServiceTest.php              # exit 0
php tests/CategoryProductsControllerScopeTest.php          # exit 0
php tests/ProductCatalogServiceTest.php                    # exit 0
php -l …touched PHP…                                       # exit 0
```

- [ ] Ручное тестирование (DnD в доп. категории после миграции)
- [x] Автоматические тесты (smoke выше)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `fix/issue-625-category-member-menuindex` от `beta`
- MODX: n/a (smoke)
- PHP: 8.4.17

## Скриншоты (если применимо)

N/A (модель данных / API / сортировка).

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы — новых UI-строк нет
- [ ] PHPStan — прогон в CI
- [x] ESLint — Vue не тронут
- [ ] CHANGELOG.md — на релизе

## Дополнительные заметки

- Нужен прогон Phinx на стенде перед ручной проверкой DnD.
- ExtJS `Processors/Product/Sort.php` не менялся (вне scope; Vue REST path покрыт).
- Gate F: HIGH nested join/sort и MEDIUM next-index/backfill исправлены. Отложено: полный единый apply-API для regex-ветки `ms3_products` (thermo soft).