### PR TITLE
fix(settings): связка способа оплаты с доставкой в менеджере

### DIFF
--- a/core/components/minishop3/src/Services/Reference/Ms3ReferenceCrudService.php
+++ b/core/components/minishop3/src/Services/Reference/Ms3ReferenceCrudService.php
@@ -315,7 +315,9 @@ class Ms3ReferenceCrudService
         }
 
         $member = $this->modx->newObject(msDeliveryMember::class);
-        $member->fromArray($criteria);
+        // Composite PK: xPDO fromArray() skips PK fields unless setPrimaryKeys is true.
+        $member->set($this->config->memberOwnFk, $ownId);
+        $member->set($this->config->memberPeerFk, $peerId);
 
         if (!$member->save()) {
             return Response::error(

--- a/core/components/minishop3/tests/Unit/Services/Reference/Ms3ReferenceCrudServiceAddLinkTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Reference/Ms3ReferenceCrudServiceAddLinkTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Reference;
+
+use MiniShop3\Model\msDeliveryMember;
+use MiniShop3\Services\Reference\Ms3ReferenceCrudService;
+use MiniShop3\Services\Reference\ReferenceResourceConfig;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * addLink() must persist msDeliveryMember composite PK via set(), not fromArray() without setPrimaryKeys.
+ */
+final class Ms3ReferenceCrudServiceAddLinkTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testAddLinkPersistsCompositePrimaryKeysForDeliveryPayment(): void
+    {
+        $saved = [];
+        $service = new Ms3ReferenceCrudService(
+            $this->modxForAddLink($saved),
+            ReferenceResourceConfig::forDeliveries()
+        );
+
+        $result = $service->addLink(['delivery_id' => 1, 'payment_id' => 42]);
+
+        self::assertTrue($result['success'] ?? false);
+        self::assertSame([
+            ['delivery_id' => 1, 'payment_id' => 42],
+        ], $saved);
+    }
+
+    public function testAddLinkPersistsCompositePrimaryKeysForPaymentDelivery(): void
+    {
+        $saved = [];
+        $service = new Ms3ReferenceCrudService(
+            $this->modxForAddLink($saved),
+            ReferenceResourceConfig::forPayments()
+        );
+
+        $result = $service->addLink(['payment_id' => 5, 'delivery_id' => 9]);
+
+        self::assertTrue($result['success'] ?? false);
+        self::assertSame([
+            ['delivery_id' => 9, 'payment_id' => 5],
+        ], $saved);
+    }
+
+    public function testAddLinkSaveFailureReturnsError(): void
+    {
+        $saved = [];
+        $service = new Ms3ReferenceCrudService(
+            $this->modxForAddLink($saved, false),
+            ReferenceResourceConfig::forDeliveries()
+        );
+
+        $result = $service->addLink(['delivery_id' => 1, 'payment_id' => 42]);
+
+        self::assertFalse($result['success'] ?? true);
+        self::assertSame('Failed to add payment to delivery', $result['message'] ?? null);
+        self::assertSame([], $saved);
+    }
+
+    /**
+     * @param list<array{delivery_id: int, payment_id: int}> $saved
+     */
+    private function modxForAddLink(array &$saved, bool $saveOk = true): modX
+    {
+        return new class ($saved, $saveOk) extends modX {
+            /**
+             * @param list<array{delivery_id: int, payment_id: int}> $saved
+             */
+            public function __construct(
+                private array &$saved,
+                private bool $saveOk,
+            ) {
+                parent::__construct();
+            }
+
+            public function getObject($className, $criteria = null, $cacheFlag = true)
+            {
+                if ($className !== msDeliveryMember::class || !is_array($criteria)) {
+                    return null;
+                }
+
+                foreach ($this->saved as $row) {
+                    if (
+                        $row['delivery_id'] === (int) ($criteria['delivery_id'] ?? 0)
+                        && $row['payment_id'] === (int) ($criteria['payment_id'] ?? 0)
+                    ) {
+                        return new \stdClass();
+                    }
+                }
+
+                return null;
+            }
+
+            public function newObject($className, $fields = [])
+            {
+                return new DeliveryMemberSaveProbe($this->saved, $this->saveOk);
+            }
+        };
+    }
+}
+
+/**
+ * Records composite PK fields. fromArray() skips PK keys unless $setPrimaryKeys (xPDO).
+ */
+final class DeliveryMemberSaveProbe
+{
+    /** @var array<string, mixed> */
+    private array $fields = [];
+
+    /**
+     * @param list<array{delivery_id: int, payment_id: int}> $saved
+     */
+    public function __construct(
+        private array &$saved,
+        private bool $saveOk,
+    ) {
+    }
+
+    public function set($key, $value = null): bool
+    {
+        $this->fields[(string) $key] = $value;
+
+        return true;
+    }
+
+    public function fromArray($fields, $keyPrefix = '', $setPrimaryKeys = false): bool
+    {
+        $pk = ['delivery_id', 'payment_id'];
+        foreach ((array) $fields as $key => $value) {
+            if (!$setPrimaryKeys && in_array((string) $key, $pk, true)) {
+                continue;
+            }
+            $this->fields[(string) $key] = $value;
+        }
+
+        return true;
+    }
+
+    public function save(): bool
+    {
+        $row = [
+            'delivery_id' => (int) ($this->fields['delivery_id'] ?? 0),
+            'payment_id' => (int) ($this->fields['payment_id'] ?? 0),
+        ];
+        if (!$this->saveOk || $row['delivery_id'] <= 0 || $row['payment_id'] <= 0) {
+            return false;
+        }
+
+        $this->saved[] = $row;
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Описание

В `Ms3ReferenceCrudService::addLink()` при создании связи `msDeliveryMember` использовался `fromArray($criteria)` без `setPrimaryKeys = true`. Для таблицы с составным PK (`delivery_id`, `payment_id`) xPDO не записывает поля первичного ключа, `save()` возвращает `false`, API отдаёт «Failed to add payment to delivery».

Правка: явный `set()` для `memberOwnFk` и `memberPeerFk`, как уже сделано в `replaceLinks()` и в `ProductLinkService::addLink()`.

Closes #628

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #628

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php
# exit 0 — php -l (628 files), 89 smoke OK, PHPUnit 257 tests / 609 assertions OK
composer test -- --filter Ms3ReferenceCrudServiceAddLinkTest
# exit 0 — 3 tests, 7 assertions
```

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка fix/issue-628-delivery-payment-link
- MODX: не требовалось для unit-тестов
- PHP: 8.4.17

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| Toast «Failed to add payment to delivery» при включении оплаты в доставке | Связь сохраняется (проверено unit-тестом на composite PK) |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуются
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не затронут
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Затронутые эндпойнты:
- `POST /api/mgr/deliveries/{id}/payments`
- `POST /api/mgr/payments/{id}/deliveries`

Регрессионный тест: `tests/Unit/Services/Reference/Ms3ReferenceCrudServiceAddLinkTest.php` (probe имитирует xPDO: `fromArray()` без PK → `save()` false).