### PR TITLE
fix(vue): удаление из грида настроек без двойного confirm

### DIFF
--- a/vueManager/src/components/DeliveriesGrid.vue
+++ b/vueManager/src/components/DeliveriesGrid.vue
@@ -18,7 +18,6 @@ import Tabs from 'primevue/tabs'
 import Textarea from 'primevue/textarea'
 import Toast from 'primevue/toast'
 import ToggleSwitch from 'primevue/toggleswitch'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 import draggable from 'vuedraggable'
@@ -31,15 +30,19 @@ import { useSortableList } from '../composables/useSortableList.js'
 import request from '../request.js'
 import { resolveAddCostPriceBadgeKind } from '../utils/addCostPriceBadgeKind.js'
 import { formatValue, getDisplayName, normalizeImagePath } from '../utils/displayFormatters.js'
+import { applyDeleteConfirmDefaults, gridDeleteAction } from '../utils/gridDeleteAction.js'
 import ActionsColumn from './ActionsColumn.vue'
 import FileBrowser from './FileBrowser.vue'
 import ValidationRulesEditor from './ValidationRulesEditor.vue'
 
 const toast = useToast()
-const confirm = useConfirm()
 const { _ } = useLexicon()
 
 const CONFIRM_GROUP = 'settings-deliveries'
+
+const DELIVERY_GRID_DELETE_ACTION = gridDeleteAction({
+  confirmMessage: 'delivery_delete_confirm_message',
+})
 
 // Bulk selection
 const {
@@ -200,14 +203,7 @@ function getFallbackColumns() {
       width: '7.5rem',
       actions: [
         { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: 'edit' },
-        {
-          name: 'delete',
-          handler: 'delete',
-          icon: 'pi-trash',
-          label: 'delete',
-          severity: 'danger',
-          confirm: false,
-        },
+        { ...DELIVERY_GRID_DELETE_ACTION },
       ],
     },
   ]
@@ -342,38 +338,27 @@ async function saveDelivery() {
 }
 
 /**
- * Delete delivery with confirmation
+ * Delete delivery (called after confirmation in ActionsColumn / useActions)
  */
-function deleteDelivery(delivery) {
-  confirm.require({
-    group: CONFIRM_GROUP,
-    message: _('delivery_delete_confirm_message').replace('{name}', delivery.name),
-    header: _('confirm_delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: _('delete'),
-    rejectLabel: _('cancel'),
-    acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await request.delete(`/api/mgr/deliveries/${delivery.id}`)
-        toast.add({
-          severity: 'success',
-          summary: _('success'),
-          detail: _('delivery_deleted'),
-          life: 3000,
-        })
-        loadDeliveries()
-      } catch (error) {
-        console.error('[DeliveriesGrid] Error deleting delivery:', error)
-        toast.add({
-          severity: 'error',
-          summary: _('error'),
-          detail: error.message || _('error_deleting_data'),
-          life: 5000,
-        })
-      }
-    },
-  })
+async function deleteDelivery(delivery) {
+  try {
+    await request.delete(`/api/mgr/deliveries/${delivery.id}`)
+    toast.add({
+      severity: 'success',
+      summary: _('success'),
+      detail: _('delivery_deleted'),
+      life: 3000,
+    })
+    await loadDeliveries()
+  } catch (error) {
+    console.error('[DeliveriesGrid] Error deleting delivery:', error)
+    toast.add({
+      severity: 'error',
+      summary: _('error'),
+      detail: error.message || _('error_deleting_data'),
+      life: 5000,
+    })
+  }
 }
 
 /**
@@ -391,15 +376,15 @@ function clearFilters() {
   resetPageAndLoad()
 }
 
-/**
- * Get actions config for ActionsColumn
- */
 function getActionsConfig(column) {
   const config = column.actions || []
-  return config.map(action => ({
-    ...action,
-    label: _(action.label) || action.label,
-  }))
+  return applyDeleteConfirmDefaults(
+    config.map(action => ({
+      ...action,
+      label: _(action.label) || action.label,
+    })),
+    { confirmMessage: 'delivery_delete_confirm_message' }
+  )
 }
 
 /**

--- a/vueManager/src/components/LinksGrid.vue
+++ b/vueManager/src/components/LinksGrid.vue
@@ -11,7 +11,6 @@ import Paginator from 'primevue/paginator'
 import Select from 'primevue/select'
 import Textarea from 'primevue/textarea'
 import Toast from 'primevue/toast'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 
@@ -19,13 +18,17 @@ import { useCrudDialog } from '../composables/useCrudDialog.js'
 import { useResourceList } from '../composables/useResourceList.js'
 import { useSelection } from '../composables/useSelection.js'
 import request from '../request.js'
+import { gridDeleteAction } from '../utils/gridDeleteAction.js'
 import ActionsColumn from './ActionsColumn.vue'
 
 const toast = useToast()
-const confirm = useConfirm()
 const { _ } = useLexicon()
 
 const CONFIRM_GROUP = 'settings-links'
+
+const LINK_GRID_DELETE_ACTION = gridDeleteAction({
+  confirmMessage: 'link_delete_confirm_message',
+})
 
 // Bulk selection
 const {
@@ -146,38 +149,27 @@ async function saveLink() {
 }
 
 /**
- * Delete link with confirmation
+ * Delete link (called after confirmation in ActionsColumn / useActions)
  */
-function deleteLink(link) {
-  confirm.require({
-    group: CONFIRM_GROUP,
-    message: _('link_delete_confirm_message').replace('{name}', link.name),
-    header: _('confirm_delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: _('delete'),
-    rejectLabel: _('cancel'),
-    acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await request.delete(`/api/mgr/links/${link.id}`)
-        toast.add({
-          severity: 'success',
-          summary: _('success'),
-          detail: _('link_deleted'),
-          life: 3000,
-        })
-        loadLinks()
-      } catch (error) {
-        console.error('[LinksGrid] Error deleting link:', error)
-        toast.add({
-          severity: 'error',
-          summary: _('error'),
-          detail: error.message || _('error_deleting_data'),
-          life: 5000,
-        })
-      }
-    },
-  })
+async function deleteLink(link) {
+  try {
+    await request.delete(`/api/mgr/links/${link.id}`)
+    toast.add({
+      severity: 'success',
+      summary: _('success'),
+      detail: _('link_deleted'),
+      life: 3000,
+    })
+    await loadLinks()
+  } catch (error) {
+    console.error('[LinksGrid] Error deleting link:', error)
+    toast.add({
+      severity: 'error',
+      summary: _('error'),
+      detail: error.message || _('error_deleting_data'),
+      life: 5000,
+    })
+  }
 }
 
 /**
@@ -186,14 +178,7 @@ function deleteLink(link) {
 function getActionsConfig() {
   return [
     { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: _('edit') },
-    {
-      name: 'delete',
-      handler: 'delete',
-      icon: 'pi-trash',
-      label: _('delete'),
-      severity: 'danger',
-      confirm: false,
-    },
+    { ...LINK_GRID_DELETE_ACTION, label: _('delete') },
   ]
 }
 

--- a/vueManager/src/components/PaymentsGrid.vue
+++ b/vueManager/src/components/PaymentsGrid.vue
@@ -17,7 +17,6 @@ import Tabs from 'primevue/tabs'
 import Textarea from 'primevue/textarea'
 import Toast from 'primevue/toast'
 import ToggleSwitch from 'primevue/toggleswitch'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 import draggable from 'vuedraggable'
@@ -30,14 +29,18 @@ import { useSortableList } from '../composables/useSortableList.js'
 import request from '../request.js'
 import { resolveAddCostPriceBadgeKind } from '../utils/addCostPriceBadgeKind.js'
 import { formatValue, getDisplayName, normalizeImagePath } from '../utils/displayFormatters.js'
+import { applyDeleteConfirmDefaults, gridDeleteAction } from '../utils/gridDeleteAction.js'
 import ActionsColumn from './ActionsColumn.vue'
 import FileBrowser from './FileBrowser.vue'
 
 const toast = useToast()
-const confirm = useConfirm()
 const { _ } = useLexicon()
 
 const CONFIRM_GROUP = 'settings-payments'
+
+const PAYMENT_GRID_DELETE_ACTION = gridDeleteAction({
+  confirmMessage: 'payment_delete_confirm_message',
+})
 
 // Bulk selection
 const {
@@ -175,14 +178,7 @@ function getFallbackColumns() {
       width: '7.5rem',
       actions: [
         { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: 'edit' },
-        {
-          name: 'delete',
-          handler: 'delete',
-          icon: 'pi-trash',
-          label: 'delete',
-          severity: 'danger',
-          confirm: false,
-        },
+        { ...PAYMENT_GRID_DELETE_ACTION },
       ],
     },
   ]
@@ -310,38 +306,27 @@ async function savePayment() {
 }
 
 /**
- * Delete payment with confirmation
+ * Delete payment (called after confirmation in ActionsColumn / useActions)
  */
-function deletePayment(payment) {
-  confirm.require({
-    group: CONFIRM_GROUP,
-    message: _('payment_delete_confirm_message').replace('{name}', payment.name),
-    header: _('confirm_delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: _('delete'),
-    rejectLabel: _('cancel'),
-    acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await request.delete(`/api/mgr/payments/${payment.id}`)
-        toast.add({
-          severity: 'success',
-          summary: _('success'),
-          detail: _('payment_deleted'),
-          life: 3000,
-        })
-        loadPayments()
-      } catch (error) {
-        console.error('[PaymentsGrid] Error deleting payment:', error)
-        toast.add({
-          severity: 'error',
-          summary: _('error'),
-          detail: error.message || _('error_deleting_data'),
-          life: 5000,
-        })
-      }
-    },
-  })
+async function deletePayment(payment) {
+  try {
+    await request.delete(`/api/mgr/payments/${payment.id}`)
+    toast.add({
+      severity: 'success',
+      summary: _('success'),
+      detail: _('payment_deleted'),
+      life: 3000,
+    })
+    await loadPayments()
+  } catch (error) {
+    console.error('[PaymentsGrid] Error deleting payment:', error)
+    toast.add({
+      severity: 'error',
+      summary: _('error'),
+      detail: error.message || _('error_deleting_data'),
+      life: 5000,
+    })
+  }
 }
 
 /**
@@ -359,15 +344,15 @@ function clearFilters() {
   resetPageAndLoad()
 }
 
-/**
- * Get actions config for ActionsColumn
- */
 function getActionsConfig(column) {
   const config = column.actions || []
-  return config.map(action => ({
-    ...action,
-    label: _(action.label) || action.label,
-  }))
+  return applyDeleteConfirmDefaults(
+    config.map(action => ({
+      ...action,
+      label: _(action.label) || action.label,
+    })),
+    { confirmMessage: 'payment_delete_confirm_message' }
+  )
 }
 
 /**

--- a/vueManager/src/components/StatusesGrid.vue
+++ b/vueManager/src/components/StatusesGrid.vue
@@ -9,7 +9,6 @@ import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 import Toast from 'primevue/toast'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { onMounted, ref } from 'vue'
 import draggable from 'vuedraggable'
@@ -19,13 +18,17 @@ import { useResourceList } from '../composables/useResourceList.js'
 import { useSelection } from '../composables/useSelection.js'
 import { useSortableList } from '../composables/useSortableList.js'
 import request from '../request.js'
+import { gridDeleteAction } from '../utils/gridDeleteAction.js'
 import ActionsColumn from './ActionsColumn.vue'
 
 const toast = useToast()
-const confirm = useConfirm()
 const { _ } = useLexicon()
 
 const CONFIRM_GROUP = 'settings-statuses'
+
+const STATUS_GRID_DELETE_ACTION = gridDeleteAction({
+  confirmMessage: 'status_delete_confirm_message',
+})
 
 // Bulk selection
 const {
@@ -152,38 +155,27 @@ async function saveStatus() {
 }
 
 /**
- * Delete status with confirmation
+ * Delete status (called after confirmation in ActionsColumn / useActions)
  */
-function deleteStatus(status) {
-  confirm.require({
-    group: CONFIRM_GROUP,
-    message: _('status_delete_confirm_message').replace('{name}', status.name),
-    header: _('confirm_delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: _('delete'),
-    rejectLabel: _('cancel'),
-    acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await request.delete(`/api/mgr/statuses/${status.id}`)
-        toast.add({
-          severity: 'success',
-          summary: _('success'),
-          detail: _('status_deleted'),
-          life: 3000,
-        })
-        loadStatuses()
-      } catch (error) {
-        console.error('[StatusesGrid] Error deleting status:', error)
-        toast.add({
-          severity: 'error',
-          summary: _('error'),
-          detail: error.message || _('error_deleting_data'),
-          life: 5000,
-        })
-      }
-    },
-  })
+async function deleteStatus(status) {
+  try {
+    await request.delete(`/api/mgr/statuses/${status.id}`)
+    toast.add({
+      severity: 'success',
+      summary: _('success'),
+      detail: _('status_deleted'),
+      life: 3000,
+    })
+    await loadStatuses()
+  } catch (error) {
+    console.error('[StatusesGrid] Error deleting status:', error)
+    toast.add({
+      severity: 'error',
+      summary: _('error'),
+      detail: error.message || _('error_deleting_data'),
+      life: 5000,
+    })
+  }
 }
 
 /**
@@ -210,14 +202,7 @@ function selectColor(color) {
 function getActionsConfig() {
   return [
     { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: _('edit') },
-    {
-      name: 'delete',
-      handler: 'delete',
-      icon: 'pi-trash',
-      label: _('delete'),
-      severity: 'danger',
-      confirm: false,
-    },
+    { ...STATUS_GRID_DELETE_ACTION, label: _('delete') },
   ]
 }
 

--- a/vueManager/src/components/VendorsGrid.vue
+++ b/vueManager/src/components/VendorsGrid.vue
@@ -14,7 +14,6 @@ import TabPanels from 'primevue/tabpanels'
 import Tabs from 'primevue/tabs'
 import Textarea from 'primevue/textarea'
 import Toast from 'primevue/toast'
-import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref } from 'vue'
 import draggable from 'vuedraggable'
@@ -25,15 +24,19 @@ import { useSelection } from '../composables/useSelection.js'
 import { useSortableList } from '../composables/useSortableList.js'
 import request from '../request.js'
 import { formatValue, normalizeImagePath } from '../utils/displayFormatters.js'
+import { applyDeleteConfirmDefaults, gridDeleteAction } from '../utils/gridDeleteAction.js'
 import ActionsColumn from './ActionsColumn.vue'
 import DynamicField from './DynamicField.vue'
 import FileBrowser from './FileBrowser.vue'
 
 const toast = useToast()
-const confirm = useConfirm()
 const { _ } = useLexicon()
 
 const CONFIRM_GROUP = 'settings-vendors'
+
+const VENDOR_GRID_DELETE_ACTION = gridDeleteAction({
+  confirmMessage: 'vendor_delete_confirm_message',
+})
 
 // Bulk selection
 const {
@@ -309,38 +312,27 @@ async function saveVendor() {
 }
 
 /**
- * Delete vendor with confirmation
+ * Delete vendor (called after confirmation in ActionsColumn / useActions)
  */
-function deleteVendor(vendor) {
-  confirm.require({
-    group: CONFIRM_GROUP,
-    message: _('vendor_delete_confirm_message').replace('{name}', vendor.name),
-    header: _('confirm_delete'),
-    icon: 'pi pi-exclamation-triangle',
-    acceptLabel: _('delete'),
-    rejectLabel: _('cancel'),
-    acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await request.delete(`/api/mgr/vendors/${vendor.id}`)
-        toast.add({
-          severity: 'success',
-          summary: _('success'),
-          detail: _('vendor_deleted'),
-          life: 3000,
-        })
-        loadVendors()
-      } catch (error) {
-        console.error('[VendorsGrid] Error deleting vendor:', error)
-        toast.add({
-          severity: 'error',
-          summary: _('error'),
-          detail: error.message || _('error_deleting_data'),
-          life: 5000,
-        })
-      }
-    },
-  })
+async function deleteVendor(vendor) {
+  try {
+    await request.delete(`/api/mgr/vendors/${vendor.id}`)
+    toast.add({
+      severity: 'success',
+      summary: _('success'),
+      detail: _('vendor_deleted'),
+      life: 3000,
+    })
+    await loadVendors()
+  } catch (error) {
+    console.error('[VendorsGrid] Error deleting vendor:', error)
+    toast.add({
+      severity: 'error',
+      summary: _('error'),
+      detail: error.message || _('error_deleting_data'),
+      life: 5000,
+    })
+  }
 }
 
 /**
@@ -369,30 +361,22 @@ function onSelectAllChange() {
   }
 }
 
-/**
- * Get actions config for ActionsColumn
- */
 function getActionsConfig(column) {
   // Fallback actions if not configured
   if (!column.actions || column.actions.length === 0) {
     return [
       { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: _('edit') },
-      {
-        name: 'delete',
-        handler: 'delete',
-        icon: 'pi-trash',
-        label: _('delete'),
-        severity: 'danger',
-        confirm: false,
-        confirmMessage: 'vendor_delete_confirm_message',
-      },
+      { ...VENDOR_GRID_DELETE_ACTION, label: _('delete') },
     ]
   }
 
-  return column.actions.map(action => ({
-    ...action,
-    label: _(action.label) || action.label,
-  }))
+  return applyDeleteConfirmDefaults(
+    column.actions.map(action => ({
+      ...action,
+      label: _(action.label) || action.label,
+    })),
+    { confirmMessage: 'vendor_delete_confirm_message' }
+  )
 }
 
 /**
@@ -444,15 +428,7 @@ function getDefaultColumns() {
       type: 'actions',
       actions: [
         { name: 'edit', handler: 'edit', icon: 'pi-pencil', label: 'edit' },
-        {
-          name: 'delete',
-          handler: 'delete',
-          icon: 'pi-trash',
-          label: 'delete',
-          severity: 'danger',
-          confirm: false,
-          confirmMessage: 'vendor_delete_confirm_message',
-        },
+        { ...VENDOR_GRID_DELETE_ACTION },
       ],
     },
   ]

--- a/vueManager/src/utils/gridDeleteAction.js
+++ b/vueManager/src/utils/gridDeleteAction.js
@@ -1,0 +1,39 @@
+/**
+ * Shared delete-action config for settings grids (ActionsColumn / useActions confirm).
+ *
+ * Row handlers must not call confirm.require — confirmation happens once in useActions.
+ */
+export function gridDeleteAction({
+  confirmMessage,
+  confirmTitle = 'confirm_delete',
+  confirmAccept = 'delete',
+}) {
+  return {
+    name: 'delete',
+    handler: 'delete',
+    icon: 'pi-trash',
+    label: 'delete',
+    severity: 'danger',
+    confirm: true,
+    confirmTitle,
+    confirmMessage,
+    confirmAccept,
+  }
+}
+
+export function applyDeleteConfirmDefaults(
+  actions,
+  { confirmMessage, confirmTitle = 'confirm_delete', confirmAccept = 'delete' }
+) {
+  return actions.map(action => {
+    const handler = action.handler || action.name
+    if (handler !== 'delete') return action
+    return {
+      ...action,
+      confirm: true,
+      confirmTitle: action.confirmTitle || confirmTitle,
+      confirmMessage: action.confirmMessage || confirmMessage,
+      confirmAccept: action.confirmAccept || confirmAccept,
+    }
+  })
+}

--- a/vueManager/src/utils/gridDeleteAction.test.js
+++ b/vueManager/src/utils/gridDeleteAction.test.js
@@ -1,22 +1,23 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
+import { describe, expect, it } from 'vitest'
 
 import { applyDeleteConfirmDefaults, gridDeleteAction } from './gridDeleteAction.js'
 
-test('gridDeleteAction builds confirm delete action', () => {
-  const action = gridDeleteAction({ confirmMessage: 'delivery_delete_confirm_message' })
-  assert.equal(action.handler, 'delete')
-  assert.equal(action.confirm, true)
-  assert.equal(action.confirmMessage, 'delivery_delete_confirm_message')
-  assert.equal(action.confirmTitle, 'confirm_delete')
-})
+describe('gridDeleteAction', () => {
+  it('builds confirm delete action', () => {
+    const action = gridDeleteAction({ confirmMessage: 'delivery_delete_confirm_message' })
+    expect(action.handler).toBe('delete')
+    expect(action.confirm).toBe(true)
+    expect(action.confirmMessage).toBe('delivery_delete_confirm_message')
+    expect(action.confirmTitle).toBe('confirm_delete')
+  })
 
-test('applyDeleteConfirmDefaults merges delete action from API config', () => {
-  const actions = applyDeleteConfirmDefaults(
-    [{ name: 'edit', handler: 'edit' }, { name: 'delete', handler: 'delete', confirm: false }],
-    { confirmMessage: 'payment_delete_confirm_message' }
-  )
-  assert.equal(actions[1].confirm, true)
-  assert.equal(actions[1].confirmMessage, 'payment_delete_confirm_message')
-  assert.equal(actions[0].confirm, undefined)
+  it('applyDeleteConfirmDefaults merges delete action from API config', () => {
+    const actions = applyDeleteConfirmDefaults(
+      [{ name: 'edit', handler: 'edit' }, { name: 'delete', handler: 'delete', confirm: false }],
+      { confirmMessage: 'payment_delete_confirm_message' }
+    )
+    expect(actions[1].confirm).toBe(true)
+    expect(actions[1].confirmMessage).toBe('payment_delete_confirm_message')
+    expect(actions[0].confirm).toBeUndefined()
+  })
 })

--- a/vueManager/src/utils/gridDeleteAction.test.js
+++ b/vueManager/src/utils/gridDeleteAction.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { applyDeleteConfirmDefaults, gridDeleteAction } from './gridDeleteAction.js'
+
+test('gridDeleteAction builds confirm delete action', () => {
+  const action = gridDeleteAction({ confirmMessage: 'delivery_delete_confirm_message' })
+  assert.equal(action.handler, 'delete')
+  assert.equal(action.confirm, true)
+  assert.equal(action.confirmMessage, 'delivery_delete_confirm_message')
+  assert.equal(action.confirmTitle, 'confirm_delete')
+})
+
+test('applyDeleteConfirmDefaults merges delete action from API config', () => {
+  const actions = applyDeleteConfirmDefaults(
+    [{ name: 'edit', handler: 'edit' }, { name: 'delete', handler: 'delete', confirm: false }],
+    { confirmMessage: 'payment_delete_confirm_message' }
+  )
+  assert.equal(actions[1].confirm, true)
+  assert.equal(actions[1].confirmMessage, 'payment_delete_confirm_message')
+  assert.equal(actions[0].confirm, undefined)
+})

--- a/vueManager/tests/settingsConfirmGroups.test.js
+++ b/vueManager/tests/settingsConfirmGroups.test.js
@@ -16,6 +16,15 @@ const GRIDS = [
   ['LinksGrid.vue', 'settings-links'],
 ]
 
+/** Grids that confirm row delete only via ActionsColumn / useActions (#630). */
+const ROW_DELETE_VIA_ACTIONS = new Set([
+  'DeliveriesGrid.vue',
+  'PaymentsGrid.vue',
+  'StatusesGrid.vue',
+  'VendorsGrid.vue',
+  'LinksGrid.vue',
+])
+
 function read(name) {
   return fs.readFileSync(path.join(srcRoot, name), 'utf8')
 }
@@ -34,11 +43,13 @@ test('settings tab grids isolate ConfirmDialog with unique groups (#548)', () =>
 
     assert.match(text, /<ConfirmDialog[^>]*:group="CONFIRM_GROUP"/, `${file} ConfirmDialog must bind :group`)
 
-    const requireAt = [...text.matchAll(/confirm\.require\s*\(/g)]
-    assert.ok(requireAt.length > 0, `${file} must have confirm.require`)
-    for (const match of requireAt) {
-      const snippet = text.slice(match.index, match.index + 400)
-      assert.match(snippet, /\bgroup:\s*CONFIRM_GROUP/, `${file} confirm.require must pass group: CONFIRM_GROUP`)
+    if (!ROW_DELETE_VIA_ACTIONS.has(file)) {
+      const requireAt = [...text.matchAll(/confirm\.require\s*\(/g)]
+      assert.ok(requireAt.length > 0, `${file} must have confirm.require`)
+      for (const match of requireAt) {
+        const snippet = text.slice(match.index, match.index + 400)
+        assert.match(snippet, /\bgroup:\s*CONFIRM_GROUP/, `${file} confirm.require must pass group: CONFIRM_GROUP`)
+      }
     }
 
     if (text.includes('<ActionsColumn')) {

--- a/vueManager/tests/settingsGridDeleteHandlers.test.js
+++ b/vueManager/tests/settingsGridDeleteHandlers.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const srcRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'components')
+
+/** Grids that delete via ActionsColumn + useActions confirm (#630). */
+const ROW_DELETE_HANDLERS = [
+  ['DeliveriesGrid.vue', 'deleteDelivery'],
+  ['PaymentsGrid.vue', 'deletePayment'],
+  ['StatusesGrid.vue', 'deleteStatus'],
+  ['VendorsGrid.vue', 'deleteVendor'],
+  ['LinksGrid.vue', 'deleteLink'],
+]
+
+function read(name) {
+  return fs.readFileSync(path.join(srcRoot, name), 'utf8')
+}
+
+test('settings grids row delete: single confirm via ActionsColumn, not handler (#630)', () => {
+  for (const [file, fnName] of ROW_DELETE_HANDLERS) {
+    const text = read(file)
+    const fnRe = new RegExp(`async function ${fnName}[\\s\\S]*?^}`, 'm')
+    const match = text.match(fnRe)
+    assert.ok(match, `${file} must define async function ${fnName}`)
+    assert.ok(
+      !match[0].includes('confirm.require'),
+      `${file} ${fnName} must not open a second ConfirmDialog`
+    )
+    assert.match(text, /confirm:\s*true/, `${file} delete action must use confirm: true in grid config`)
+  }
+})

--- a/vueManager/tests/settingsGridDeleteHandlers.test.js
+++ b/vueManager/tests/settingsGridDeleteHandlers.test.js
@@ -29,6 +29,10 @@ test('settings grids row delete: single confirm via ActionsColumn, not handler (
       !match[0].includes('confirm.require'),
       `${file} ${fnName} must not open a second ConfirmDialog`
     )
-    assert.match(text, /confirm:\s*true/, `${file} delete action must use confirm: true in grid config`)
+    assert.match(
+      text,
+      /gridDeleteAction\s*\(/,
+      `${file} must use gridDeleteAction() for row delete confirm (not handler confirm.require)`
+    )
   }
 })


### PR DESCRIPTION
## Описание

Удаление строки через колонку «Действия» в гридах Настроек (доставки, оплаты, статусы, производители, связи) не работало: конфиг из БД задаёт `confirm: true` для delete, `useActions` показывал первый диалог, а handler (`deleteDelivery` и др.) открывал второй `confirm.require()` — DELETE не выполнялся.

Правка выравнивает паттерн с `CustomersGrid` / `OrdersGrid`: один confirm в `ActionsColumn` / `useActions`, handler только выполняет DELETE.

Closes #630

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #630

## Как это было протестировано?

```bash
cd vueManager
npm run lint:ci          # exit 0
npm test                 # exit 0, 34 tests
node --test tests/settingsGridDeleteHandlers.test.js tests/settingsConfirmGroups.test.js
```

- [ ] Ручное тестирование
- [x] Автоматические тесты
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация:** ветка `fix/issue-630-grid-delete-confirm`, Node 18+

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы — не требуются
- [ ] PHPStan — PHP не затронут
- [x] ESLint (`npm run lint:ci`)

## Дополнительные заметки

- Общий хелпер `vueManager/src/utils/gridDeleteAction.js` (`gridDeleteAction`, `applyDeleteConfirmDefaults`).
- Затронуты: `DeliveriesGrid`, `PaymentsGrid`, `StatusesGrid`, `VendorsGrid`, `LinksGrid`.
- Массовое удаление через `useSelection` без изменений.