### PR TITLE
fix(web-api): CORS preflight OPTIONS до CorsMiddleware

### DIFF
--- a/core/components/minishop3/config/ms3.routes.d/web/example-addon.php.dist
+++ b/core/components/minishop3/config/ms3.routes.d/web/example-addon.php.dist
@@ -36,13 +36,24 @@
  */
 
 use MiniShop3\Router\Response;
+use MiniShop3\Middleware\CorsMiddleware;
 use MiniShop3\Middleware\TokenMiddleware;
 
-// Пример: группа с префиксом и middleware (раскомментируйте после копирования в .php)
+// Пример: группа с префиксом и middleware (раскомментируйте после копирования в .php).
+// CorsMiddleware обязателен, если в группе есть TokenMiddleware / RateLimitMiddleware:
+// без него Router не запускает стек на OPTIONS (405), иначе preflight мог бы минтить токен.
 /*
+$corsMiddleware = new CorsMiddleware([
+    'allowed_origins' => $modx->getOption('ms3_cors_allowed_origins', null, ''),
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'MS3TOKEN'],
+    'allow_credentials' => true,
+    'max_age' => 86400,
+]);
+
 $router->group('/api/v1/myaddon', function ($router) use ($modx) {
     $router->get('/ping', function (array $vars, \MODX\Revolution\modX $modx) {
         return Response::success(['ok' => true]);
     });
-}, [new TokenMiddleware($modx)]);
+}, [$corsMiddleware, new TokenMiddleware($modx)]);
 */

--- a/core/components/minishop3/src/Middleware/CorsMiddleware.php
+++ b/core/components/minishop3/src/Middleware/CorsMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Middleware;
 
+use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Middleware\MiddlewareInterface;
 use MiniShop3\Router\Response;
 use MiniShop3\Utils\CorsConfig;
@@ -56,11 +57,10 @@ class CorsMiddleware implements MiddlewareInterface
             $this->setCorsHeaders($origin);
         }
 
-        // For preflight requests (OPTIONS) immediately return 200
+        // Preflight: stop middleware chain with 200 (Router/api.php sends the envelope).
         $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         if ($method === 'OPTIONS') {
-            http_response_code(200);
-            exit;
+            return Response::success(null, null, HttpStatus::OK);
         }
 
         return null; // Continue execution

--- a/core/components/minishop3/src/Middleware/RateLimitMiddleware.php
+++ b/core/components/minishop3/src/Middleware/RateLimitMiddleware.php
@@ -48,6 +48,11 @@ class RateLimitMiddleware implements MiddlewareInterface
      */
     public function handle(array $params)
     {
+        // CORS preflight must not consume rate-limit quota (#634).
+        if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
+            return null;
+        }
+
         $key = $this->resolveRequestKey();
 
         $state = $this->store->read($key);

--- a/core/components/minishop3/src/Middleware/TokenMiddleware.php
+++ b/core/components/minishop3/src/Middleware/TokenMiddleware.php
@@ -72,6 +72,11 @@ class TokenMiddleware implements MiddlewareInterface
      */
     public function handle(array $params)
     {
+        // CORS preflight must not mint tokens or touch session (#634).
+        if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
+            return null;
+        }
+
         $this->stripQueryStringApiTokens();
 
         // Cookie injection: make cookie token available via $_REQUEST for backward compat

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -402,11 +402,10 @@ class Router
      * Answer browser CORS preflight when FastRoute has no OPTIONS handler.
      *
      * Runs the matched route's middleware chain only if it includes CorsMiddleware.
-     * Without CorsMiddleware the stack is not invoked (405, same as before this fix),
-     * so TokenMiddleware / RateLimitMiddleware cannot mint tokens or open sessions
-     * on unauthenticated OPTIONS. The route handler is never called (#634).
-     *
-     * On stock /api/v1 routes CorsMiddleware is first and returns 200, stopping the chain.
+     * Without CorsMiddleware the stack is not invoked (405, same as before this fix).
+     * TokenMiddleware / RateLimitMiddleware short-circuit on OPTIONS so they cannot
+     * mint tokens, open sessions, or consume rate-limit quota during preflight —
+     * regardless of middleware order. The route handler is never called (#634).
      *
      * @param list<string> $allowedMethods
      */

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -4,6 +4,7 @@ namespace MiniShop3\Router;
 
 use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
+use MiniShop3\Middleware\CorsMiddleware;
 use MODX\Revolution\modX;
 use function FastRoute\simpleDispatcher;
 
@@ -398,10 +399,14 @@ class Router
     }
 
     /**
-     * Run middleware for a valid storefront path when FastRoute has no OPTIONS handler.
+     * Answer browser CORS preflight when FastRoute has no OPTIONS handler.
      *
-     * Never invokes the route handler: preflight must not trigger POST/GET side effects (#634).
-     * CorsMiddleware (first on stock /api/v1 routes) returns 200 and stops the chain.
+     * Runs the matched route's middleware chain only if it includes CorsMiddleware.
+     * Without CorsMiddleware the stack is not invoked (405, same as before this fix),
+     * so TokenMiddleware / RateLimitMiddleware cannot mint tokens or open sessions
+     * on unauthenticated OPTIONS. The route handler is never called (#634).
+     *
+     * On stock /api/v1 routes CorsMiddleware is first and returns 200, stopping the chain.
      *
      * @param list<string> $allowedMethods
      */
@@ -418,9 +423,14 @@ class Router
             return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
         }
 
+        $middlewares = $probeInfo[1]['middlewares'] ?? [];
+        if (!$this->middlewareStackHasCors($middlewares)) {
+            return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
+        }
+
         $vars = array_merge($_GET, $probeInfo[2] ?? []);
 
-        foreach ($probeInfo[1]['middlewares'] ?? [] as $middleware) {
+        foreach ($middlewares as $middleware) {
             $result = $this->resolveMiddleware($middleware)->handle($vars);
 
             if ($result instanceof Response) {
@@ -429,6 +439,23 @@ class Router
         }
 
         return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * @param list<object|string> $middlewares
+     */
+    protected function middlewareStackHasCors(array $middlewares): bool
+    {
+        foreach ($middlewares as $middleware) {
+            if ($middleware instanceof CorsMiddleware) {
+                return true;
+            }
+            if (is_string($middleware) && is_a($middleware, CorsMiddleware::class, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/core/components/minishop3/src/Router/Router.php
+++ b/core/components/minishop3/src/Router/Router.php
@@ -381,6 +381,10 @@ class Router
                 return Response::error('Route not found', HttpStatus::NOT_FOUND);
 
             case Dispatcher::METHOD_NOT_ALLOWED:
+                if ($httpMethod === 'OPTIONS') {
+                    return $this->dispatchOptionsPreflight($uri, $routeInfo[1] ?? []);
+                }
+
                 return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
 
             case Dispatcher::FOUND:
@@ -391,6 +395,40 @@ class Router
         }
 
         return Response::error('Unknown error', HttpStatus::INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Run middleware for a valid storefront path when FastRoute has no OPTIONS handler.
+     *
+     * Never invokes the route handler: preflight must not trigger POST/GET side effects (#634).
+     * CorsMiddleware (first on stock /api/v1 routes) returns 200 and stops the chain.
+     *
+     * @param list<string> $allowedMethods
+     */
+    protected function dispatchOptionsPreflight(string $uri, array $allowedMethods): Response
+    {
+        if (!self::isStorefrontRoute($uri) || $allowedMethods === []) {
+            return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
+        }
+
+        $probeMethod = $allowedMethods[0];
+        $probeInfo = $this->dispatcher->dispatch($probeMethod, $uri);
+
+        if ($probeInfo[0] !== Dispatcher::FOUND) {
+            return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
+        }
+
+        $vars = array_merge($_GET, $probeInfo[2] ?? []);
+
+        foreach ($probeInfo[1]['middlewares'] ?? [] as $middleware) {
+            $result = $this->resolveMiddleware($middleware)->handle($vars);
+
+            if ($result instanceof Response) {
+                return $result;
+            }
+        }
+
+        return Response::error('Method not allowed', HttpStatus::METHOD_NOT_ALLOWED);
     }
 
     /**

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
@@ -94,6 +94,36 @@ final class HeadlessStorefrontCorsRouterTest extends WebApiTestCase
         self::assertSame(405, $response->getStatusCode());
     }
 
+    /**
+     * Addon pattern from ms3.routes.d/web/example-addon.php.dist: TokenMiddleware without
+     * CorsMiddleware must not mint an anonymous token on OPTIONS (#634 review).
+     */
+    public function testOptionsPreflightWithTokenMiddlewareButNoCorsDoesNotMintToken(): void
+    {
+        unset($_REQUEST['ms3_token'], $_SESSION['ms3']);
+        $handlerCalled = false;
+        $router = new \MiniShop3\Router\Router($this->modx);
+        $router->group('/api/v1', function ($router) use (&$handlerCalled) {
+            $router->post('/addon-probe', function () use (&$handlerCalled) {
+                $handlerCalled = true;
+
+                return \MiniShop3\Router\Response::success(['ok' => true]);
+            });
+        }, [new \MiniShop3\Middleware\TokenMiddleware($this->modx)]);
+        $router->build();
+
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $_SERVER['REQUEST_URI'] = '/api/v1/addon-probe';
+        $_SERVER['HTTP_ORIGIN'] = 'https://evil.example';
+        $_REQUEST = ['route' => '/api/v1/addon-probe'];
+
+        $response = $router->dispatch('/api/v1/addon-probe', 'OPTIONS');
+
+        self::assertFalse($handlerCalled);
+        self::assertSame(405, $response->getStatusCode());
+        self::assertArrayNotHasKey('ms3_token', $_REQUEST);
+    }
+
     public function testGetHealthStillWorksAfterCorsChanges(): void
     {
         $res = $this->dispatch('GET', '/api/v1/health');

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
@@ -124,6 +124,40 @@ final class HeadlessStorefrontCorsRouterTest extends WebApiTestCase
         self::assertArrayNotHasKey('ms3_token', $_REQUEST);
     }
 
+    /**
+     * Cors present but after TokenMiddleware: preflight must still not mint a token (#634 review).
+     */
+    public function testOptionsPreflightWithTokenBeforeCorsDoesNotMintToken(): void
+    {
+        unset($_REQUEST['ms3_token'], $_SESSION['ms3']);
+        $handlerCalled = false;
+        $router = new \MiniShop3\Router\Router($this->modx);
+        $router->group('/api/v1', function ($router) use (&$handlerCalled) {
+            $router->post('/addon-probe-reversed', function () use (&$handlerCalled) {
+                $handlerCalled = true;
+
+                return \MiniShop3\Router\Response::success(['ok' => true]);
+            });
+        }, [
+            new \MiniShop3\Middleware\TokenMiddleware($this->modx),
+            new \MiniShop3\Middleware\CorsMiddleware([
+                'allowed_origins' => ['https://trusted.example'],
+            ]),
+        ]);
+        $router->build();
+
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $_SERVER['REQUEST_URI'] = '/api/v1/addon-probe-reversed';
+        $_SERVER['HTTP_ORIGIN'] = 'https://evil.example';
+        $_REQUEST = ['route' => '/api/v1/addon-probe-reversed'];
+
+        $response = $router->dispatch('/api/v1/addon-probe-reversed', 'OPTIONS');
+
+        self::assertFalse($handlerCalled);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayNotHasKey('ms3_token', $_REQUEST);
+    }
+
     public function testGetHealthStillWorksAfterCorsChanges(): void
     {
         $res = $this->dispatch('GET', '/api/v1/health');

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsRouterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi;
+
+/**
+ * Router-level CORS preflight (#634).
+ */
+final class HeadlessStorefrontCorsRouterTest extends WebApiTestCase
+{
+    public function testOptionsPreflightOnHealthReturns200(): void
+    {
+        $res = $this->dispatch(
+            'OPTIONS',
+            '/api/v1/health',
+            [],
+            [],
+            [
+                'Origin' => 'https://shop.example',
+                'Access-Control-Request-Method' => 'POST',
+            ],
+        );
+
+        self::assertSame(200, $res['status']);
+        self::assertTrue($res['success']);
+    }
+
+    public function testOptionsPreflightOnPostOnlyCartAddReturns200(): void
+    {
+        $res = $this->dispatch(
+            'OPTIONS',
+            '/api/v1/cart/add',
+            [],
+            [],
+            [
+                'Origin' => 'https://shop.example',
+                'Access-Control-Request-Method' => 'POST',
+            ],
+        );
+
+        self::assertSame(200, $res['status']);
+        self::assertTrue($res['success']);
+    }
+
+    public function testOptionsPreflightOnUnknownStorefrontPathReturns404(): void
+    {
+        $res = $this->dispatch(
+            'OPTIONS',
+            '/api/v1/no-such-endpoint',
+            [],
+            [],
+            ['Origin' => 'https://shop.example'],
+        );
+
+        self::assertSame(404, $res['status']);
+        self::assertFalse($res['success']);
+    }
+
+    public function testOptionsPreflightDisallowedOriginStillReturns200Envelope(): void
+    {
+        $res = $this->dispatch(
+            'OPTIONS',
+            '/api/v1/health',
+            [],
+            [],
+            ['Origin' => 'https://evil.example'],
+        );
+
+        self::assertSame(200, $res['status']);
+        self::assertTrue($res['success']);
+    }
+
+    public function testOptionsPreflightDoesNotInvokeHandlerWithoutCorsMiddleware(): void
+    {
+        $handlerCalled = false;
+        $router = new \MiniShop3\Router\Router($this->modx);
+        $router->group('/api/v1', function ($router) use (&$handlerCalled) {
+            $router->post('/probe-mutation', function () use (&$handlerCalled) {
+                $handlerCalled = true;
+
+                return \MiniShop3\Router\Response::success(['mutated' => true]);
+            });
+        }, []);
+        $router->build();
+
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $_SERVER['REQUEST_URI'] = '/api/v1/probe-mutation';
+        $_REQUEST = ['route' => '/api/v1/probe-mutation'];
+
+        $response = $router->dispatch('/api/v1/probe-mutation', 'OPTIONS');
+
+        self::assertFalse($handlerCalled);
+        self::assertSame(405, $response->getStatusCode());
+    }
+
+    public function testGetHealthStillWorksAfterCorsChanges(): void
+    {
+        $res = $this->dispatch('GET', '/api/v1/health');
+
+        self::assertSame(200, $res['status']);
+        self::assertTrue($res['success']);
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontCorsTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace MiniShop3\Tests\Integration\WebApi;
 
 use MiniShop3\Middleware\CorsMiddleware;
+use MiniShop3\Router\HttpStatus;
+use MiniShop3\Router\Response;
 use MiniShop3\Utils\CorsConfig;
 use PHPUnit\Framework\TestCase;
 
 /**
- * CORS smoke adjacent to journey suite (#574 / #335).
- *
- * Full Router OPTIONS cannot run in-process: CorsMiddleware exits after 200.
+ * CORS smoke adjacent to journey suite (#574 / #335, #634).
  */
 final class HeadlessStorefrontCorsTest extends TestCase
 {
@@ -26,67 +26,21 @@ final class HeadlessStorefrontCorsTest extends TestCase
         self::assertFalse($cfg['allow_credentials']);
     }
 
-    public function testPreflightOptionsExitsWithHttp200ForAllowlistedOrigin(): void
+    public function testPreflightOptionsReturnsHttp200Response(): void
     {
-        $script = <<<'PHP'
-<?php
-declare(strict_types=1);
-error_reporting(E_ALL & ~E_DEPRECATED);
-require $argv[1];
-use MiniShop3\Middleware\CorsMiddleware;
-use MiniShop3\Utils\CorsConfig;
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $_SERVER['HTTP_ORIGIN'] = 'https://shop.example';
 
-$_SERVER['REQUEST_METHOD'] = 'OPTIONS';
-$_SERVER['HTTP_ORIGIN'] = 'https://shop.example';
+        $mw = new CorsMiddleware([
+            'allowed_origins' => 'https://shop.example',
+            'allow_credentials' => true,
+        ]);
 
-$mw = new CorsMiddleware([
-    'allowed_origins' => 'https://shop.example',
-    'allow_credentials' => true,
-]);
-$originOk = CorsConfig::isOriginAllowed('https://shop.example', ['https://shop.example']) ? '1' : '0';
+        $result = $mw->handle([]);
 
-register_shutdown_function(static function () use ($originOk): void {
-    echo 'HTTP_CODE=' . (string) http_response_code() . "\n";
-    echo 'ORIGIN_OK=' . $originOk . "\n";
-});
-
-$mw->handle([]);
-fwrite(STDERR, "OPTIONS did not exit\n");
-exit(2);
-PHP;
-
-        $autoload = dirname(__DIR__, 3) . '/vendor/autoload.php';
-
-        $tmp = tempnam(sys_get_temp_dir(), 'ms3-cors-');
-        self::assertNotFalse($tmp);
-        file_put_contents($tmp, $script);
-
-        $cmd = sprintf(
-            '%s %s %s',
-            escapeshellarg(PHP_BINARY),
-            escapeshellarg($tmp),
-            escapeshellarg($autoload)
-        );
-
-        $descriptors = [
-            0 => ['pipe', 'r'],
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
-        ];
-        $proc = proc_open($cmd, $descriptors, $pipes, dirname($tmp));
-        self::assertIsResource($proc);
-        fclose($pipes[0]);
-        $stdout = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
-        $code = proc_close($proc);
-        @unlink($tmp);
-
-        self::assertSame(0, $code, $stderr);
-        self::assertStringContainsString('HTTP_CODE=200', (string) $stdout);
-        self::assertStringContainsString('ORIGIN_OK=1', (string) $stdout);
-        self::assertStringNotContainsString('OPTIONS did not exit', (string) $stderr);
+        self::assertInstanceOf(Response::class, $result);
+        self::assertSame(HttpStatus::OK, $result->getStatusCode());
+        self::assertTrue($result->getData()['success'] ?? false);
     }
 
     public function testNormalizeEmptyOriginsDisallowsAll(): void

--- a/core/components/minishop3/tests/Unit/Middleware/RateLimitMiddlewareTest.php
+++ b/core/components/minishop3/tests/Unit/Middleware/RateLimitMiddlewareTest.php
@@ -24,6 +24,7 @@ final class RateLimitMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        unset($_SERVER['REQUEST_METHOD']);
         foreach (glob($this->storagePath . '/*') ?: [] as $file) {
             if (is_file($file)) {
                 unlink($file);
@@ -72,5 +73,22 @@ final class RateLimitMiddlewareTest extends TestCase
         $response = $middleware->handle([]);
         self::assertInstanceOf(Response::class, $response);
         self::assertSame(HttpStatus::TOO_MANY_REQUESTS, $response->getStatusCode());
+    }
+
+    public function testOptionsPreflightDoesNotConsumeQuota(): void
+    {
+        $store = new FileRateLimitStore($this->storagePath, 60);
+        $middleware = new RateLimitMiddleware(1, 60, $store);
+
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        self::assertNull($middleware->handle([]));
+        self::assertNull($middleware->handle([]));
+
+        $key = 'rate_limit:' . md5('127.0.0.1');
+        self::assertSame(0, $store->read($key)['attempts']);
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        self::assertNull($middleware->handle([]));
+        self::assertSame(1, $store->read($key)['attempts']);
     }
 }


### PR DESCRIPTION
## Описание

Браузерный CORS preflight (`OPTIONS`) к Web API получал **405** `Method not allowed`: FastRoute отдавал `METHOD_NOT_ALLOWED` до запуска group middleware, и `CorsMiddleware` не успевал ответить.

Теперь `Router::dispatch()` на `OPTIONS` для известных storefront-путей (`/api/v1/*`) прогоняет **только middleware** найденного маршрута. Handler не вызывается — preflight не триггерит POST/GET side effects. `CorsMiddleware` возвращает `Response` 200 вместо `exit`, чтобы Router и PHPUnit могли обработать ответ.

Closes #634

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #634

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0 — php -l, smoke (89), PHPUnit 260 tests
```

Добавлены `HeadlessStorefrontCorsRouterTest`: OPTIONS на `/api/v1/health`, POST-only `/api/v1/cart/add`, неизвестный path → 404, handler не вызывается без CorsMiddleware.

- [x] Автоматические тесты (`composer ci:php`)

**Конфигурация тестирования:**
- MiniShop3: beta
- PHP: 8.4.17 (локально)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы (не требуются)
- [ ] CHANGELOG (релиз maintainer)

## Дополнительные заметки

Кастомные роуты в `ms3.routes.d/web` без `CorsMiddleware` по-прежнему получат 405 на OPTIONS (handler не выполняется). Для headless-витрины аддон должен вешать тот же CORS stack, что и `web.php`.