### PR TITLE
fix(web-api): normalize options JSON string in cart/change-option

### DIFF
--- a/core/components/minishop3/lexicon/en/default.inc.php
+++ b/core/components/minishop3/lexicon/en/default.inc.php
@@ -168,6 +168,7 @@ $_lang['ms3_message_close_all'] = 'close all';
 $_lang['ms3_err_unknown'] = 'Unknown error';
 $_lang['ms3_err_ns'] = 'This field is required';
 $_lang['ms3_err_product_key_required'] = 'Product key is required';
+$_lang['ms3_err_cart_options'] = 'options must be an object or a JSON string';
 $_lang['ms3_err_field_key_required'] = 'Field key is required';
 $_lang['ms3_err_extra_field_class_unsupported'] = 'This model class cannot host extra fields. Use a model with its own database table (e.g. msProductData).';
 $_lang['ms3_err_extra_field_key_invalid'] = 'Field key must contain only Latin letters, digits, and underscores.';
@@ -175,7 +176,6 @@ $_lang['ms3_err_fields_required'] = 'Fields array is required';
 $_lang['ms3_err_field_nf'] = 'Field not found';
 $_lang['ms3_err_ae'] = 'This field must be unique';
 $_lang['ms3_err_json'] = 'This field requires JSON string';
-$_lang['ms3_err_cart_options'] = 'options must be an object or a JSON string';
 $_lang['ms3_repeater_validation_error'] = 'Repeater field "[[+field]]": [[+error]]';
 $_lang['ms3_key_value_validation_error'] = 'Key-value field "[[+field]]": [[+error]]';
 

--- a/core/components/minishop3/lexicon/ru/default.inc.php
+++ b/core/components/minishop3/lexicon/ru/default.inc.php
@@ -168,6 +168,7 @@ $_lang['ms3_message_close_all'] = 'закрыть все';
 $_lang['ms3_err_unknown'] = 'Неизвестная ошибка';
 $_lang['ms3_err_ns'] = 'Это поле обязательно';
 $_lang['ms3_err_product_key_required'] = 'Не указан ключ товара';
+$_lang['ms3_err_cart_options'] = 'options должен быть объектом или JSON-строкой';
 $_lang['ms3_err_field_key_required'] = 'Не указан ключ поля';
 $_lang['ms3_err_extra_field_class_unsupported'] = 'Этот класс модели не может содержать дополнительные поля. Используйте модель с собственной таблицей БД (например, msProductData).';
 $_lang['ms3_err_extra_field_key_invalid'] = 'Ключ поля может содержать только латинские буквы, цифры и подчёркивание.';
@@ -175,7 +176,6 @@ $_lang['ms3_err_fields_required'] = 'Требуется массив полей'
 $_lang['ms3_err_field_nf'] = 'Поле не найдено';
 $_lang['ms3_err_ae'] = 'Это поле должно быть уникально';
 $_lang['ms3_err_json'] = 'Это поле требует JSON строку';
-$_lang['ms3_err_cart_options'] = 'options должен быть объектом или JSON-строкой';
 $_lang['ms3_repeater_validation_error'] = 'Поле повторителя «[[+field]]»: [[+error]]';
 $_lang['ms3_key_value_validation_error'] = 'Поле key-value «[[+field]]»: [[+error]]';
 

--- a/core/components/minishop3/src/Controllers/Api/Web/CartController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CartController.php
@@ -127,14 +127,23 @@ class CartController
             );
         }
 
-        if (!is_array($options) || $options === []) {
+        if (!is_array($options) && !is_string($options)) {
+            return Response::error(
+                $this->modx->lexicon('ms3_err_cart_options'),
+                HttpStatus::BAD_REQUEST
+            );
+        }
+
+        $ms3 = $this->modx->services->get('ms3');
+        $options = CartItemManager::normalizeOptions($options);
+
+        if ($options === []) {
             return Response::error(
                 $this->modx->lexicon('ms3_cart_change_options_error'),
                 HttpStatus::BAD_REQUEST
             );
         }
 
-        $ms3 = $this->modx->services->get('ms3');
         $cart = $ms3->cart;
         $cart->initialize($this->pageContextKey(), $token);
 

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
@@ -67,7 +67,7 @@ final class HeadlessStorefrontErrorsTest extends WebApiTestCase
         $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_cart_change_options_error');
     }
 
-    #[DataProvider('cartAddOptionsJsonStringCases')]
+#[DataProvider('cartAddOptionsJsonStringCases')]
     public function testCartAddOptionsJsonString(string $options, array $expectedOptions): void
     {
         $res = $this->dispatch('POST', '/api/v1/cart/add', [], [
@@ -111,6 +111,52 @@ final class HeadlessStorefrontErrorsTest extends WebApiTestCase
                 'count' => 1,
                 'options' => 1,
             ],
+            [],
+            $token
+        );
+        $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_err_cart_options');
+    }
+
+    public function testChangeOptionJsonStringOptionsReturns200(): void
+    {
+        $add = $this->dispatch('POST', '/api/v1/cart/add', [], [
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'count' => 1,
+            'options' => ['size' => 'M'],
+        ]);
+        $token = $this->lastMs3Token();
+        $key = (string) ($add['data']['last_key'] ?? '');
+
+        $res = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change-option',
+            [],
+            ['product_key' => $key, 'options' => '{"size":"L"}'],
+            [],
+            $token
+        );
+
+        self::assertSame(HttpStatus::OK, $res['status']);
+        self::assertTrue($res['success']);
+        $newKey = (string) ($res['data']['last_key'] ?? $key);
+        self::assertSame('L', $res['data']['cart'][$newKey]['options']['size'] ?? null);
+    }
+
+    public function testChangeOptionInvalidOptionsTypeReturns400(): void
+    {
+        $add = $this->dispatch('POST', '/api/v1/cart/add', [], [
+            'id' => JourneyProductCatalog::FIXTURE_PRODUCT_ID,
+            'count' => 1,
+            'options' => ['size' => 'M'],
+        ]);
+        $token = $this->lastMs3Token();
+        $key = (string) ($add['data']['last_key'] ?? '');
+
+        $res = $this->dispatch(
+            'POST',
+            '/api/v1/cart/change-option',
+            [],
+            ['product_key' => $key, 'options' => 42],
             [],
             $token
         );

--- a/core/components/minishop3/tests/Unit/Services/Cart/CartItemManagerPureTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Cart/CartItemManagerPureTest.php
@@ -58,7 +58,7 @@ final class CartItemManagerPureTest extends TestCase
 
     public function testNormalizeOptions(): void
     {
-        self::assertSame([], CartItemManager::normalizeOptions('[]'));
+self::assertSame([], CartItemManager::normalizeOptions('[]'));
         self::assertSame([], CartItemManager::normalizeOptions('{}'));
         self::assertSame(['color' => 'red'], CartItemManager::normalizeOptions('{"color":"red"}'));
         self::assertSame(['a' => 1], CartItemManager::normalizeOptions(['a' => 1]));


### PR DESCRIPTION
## Описание

`POST /api/v1/cart/change-option` принимает `options` как JSON-строку (например `"{\"size\":\"L\"}"`), а не только как объект. Нормализация через `CartItemManager::normalizeOptions()` на HTTP-границе, по тому же принципу, что и `cart/add` в #632/#633.

Невалидный PHP-тип (`42`, `true`) → **400** с `ms3_err_cart_options`. Пустая карта после decode → **400** с `ms3_cart_change_options_error` (как раньше).

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #635

Связано: #632, #633 (симметрия `cart/add`).

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0 — php -l (627 files), smoke (89), PHPUnit 256 tests
```

Новые тесты в `HeadlessStorefrontErrorsTest`:
- `testChangeOptionJsonStringOptionsReturns200`
- `testChangeOptionInvalidOptionsTypeReturns400`

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-635-cart-change-option-options-string`
- MODX: journey stub (PHPUnit integration)
- PHP: 8.4.17

## Скриншоты (если применимо)

Не применимо (API).

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

`CartItemManager::normalizeOptions()` сделан `static`, чтобы контроллер мог вызывать его без инстанса `MiniShop3` (в journey-тестах `JourneyMs3` не наследует `MiniShop3`). `CartMutationHandler::add` по-прежнему вызывает `$this->itemManager->normalizeOptions()` — DI-подмена `ms3_cart_item_manager` сохраняется.

Невалидная JSON-строка (`"{bad"`) по-прежнему даёт пустой map и `ms3_cart_change_options_error` — поведение как у пустого `[]`, в scope issue не менялось.