### PR TITLE
feat(web-api): prefill order draft from customer profile after auth

### DIFF
--- a/core/components/minishop3/src/Services/Customer/AuthManager.php
+++ b/core/components/minishop3/src/Services/Customer/AuthManager.php
@@ -6,6 +6,8 @@ use MiniShop3\Controllers\Auth\AuthProviderInterface;
 use MiniShop3\Controllers\Auth\PasswordAuthProvider;
 use MiniShop3\Model\msCustomer;
 use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Services\Cart\CartDraftContext;
+use MiniShop3\Services\Order\OrderAddressManager;
 use MiniShop3\Services\Order\OrderDraftManager;
 use MiniShop3\Services\TokenService;
 use MiniShop3\Utils\CookieHelper;
@@ -256,10 +258,46 @@ class AuthManager
             session_regenerate_id(true);
         }
 
+        $this->prefillOrderDraftFromCustomer($customer, $tokenString, $draftManager);
+
         return [
             'token' => $tokenString,
             'expires_at' => $tokenObj->get('expires_at'),
         ];
+    }
+
+    /**
+     * Copy empty profile fields from the authenticated customer into their draft order.
+     *
+     * Failures are logged and must not block login/register.
+     */
+    private function prefillOrderDraftFromCustomer(
+        msCustomer $customer,
+        string $token,
+        OrderDraftManager $draftManager
+    ): void {
+        if ($token === '' || !$this->modx->services->has('ms3_order_address_manager')) {
+            return;
+        }
+
+        try {
+            $pageCtx = $this->modx->context->key ?? CartDraftContext::DEFAULT_CONTEXT;
+            $ctx = CartDraftContext::resolve($this->modx, $pageCtx);
+            $draft = $draftManager->findDraftByToken($token, $ctx);
+            if (!$draft) {
+                return;
+            }
+
+            /** @var OrderAddressManager $addressManager */
+            $addressManager = $this->modx->services->get('ms3_order_address_manager');
+            $addressManager->prefillProfileFieldsFromCustomer($draft, $customer);
+        } catch (\Throwable $e) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[AuthManager] prefillOrderDraftFromCustomer failed for customer #'
+                . (int) $customer->get('id') . ': ' . $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/core/components/minishop3/src/Services/Order/OrderAddressManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderAddressManager.php
@@ -3,8 +3,10 @@
 namespace MiniShop3\Services\Order;
 
 use MiniShop3\MiniShop3;
+use MiniShop3\Model\msCustomer;
 use MiniShop3\Model\msCustomerAddress;
 use MiniShop3\Model\msOrder;
+use MiniShop3\Services\Customer\CustomerPublicDto;
 use MODX\Revolution\modX;
 
 /**
@@ -183,6 +185,34 @@ class OrderAddressManager
                 $orderData[$orderField] = $customerData[$customerField];
             }
         }
+    }
+
+    /**
+     * Prefill empty checkout profile fields on the customer's draft from their public profile.
+     *
+     * Only fills fields that are still empty in the draft (does not overwrite checkout edits).
+     */
+    public function prefillProfileFieldsFromCustomer(msOrder $draft, msCustomer $customer): void
+    {
+        $draftCustomerId = (int) $draft->get('customer_id');
+        $customerId = (int) $customer->get('id');
+        if ($draftCustomerId <= 0 || $draftCustomerId !== $customerId) {
+            return;
+        }
+
+        $customerData = [];
+        foreach (CustomerPublicDto::CORE_PROFILE_EDITABLE_FIELDS as $field) {
+            $value = $customer->get($field);
+            if ($value !== null && $value !== '') {
+                $customerData[$field] = $value;
+            }
+        }
+        if ($customerData === []) {
+            return;
+        }
+
+        $orderData = $this->draftManager->toArray($draft);
+        $this->fillFromCustomer($draft, $orderData, $customerData);
     }
 
     /**

--- a/core/components/minishop3/src/Services/Order/OrderDraftManager.php
+++ b/core/components/minishop3/src/Services/Order/OrderDraftManager.php
@@ -30,6 +30,24 @@ class OrderDraftManager
     }
 
     /**
+     * Find draft order by session token only (no customer_id fallback).
+     */
+    public function findDraftByToken(string $token, string $ctx = 'web'): ?msOrder
+    {
+        if ($token === '') {
+            return null;
+        }
+
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
+
+        return $this->modx->getObject(msOrder::class, [
+            'token' => $token,
+            'status_id' => $statusDraft,
+            'context' => $ctx,
+        ]);
+    }
+
+    /**
      * Get existing draft order by token
      *
      * Hybrid search strategy:
@@ -43,27 +61,20 @@ class OrderDraftManager
             return null;
         }
 
-        $status_draft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
-
-        // 1. Try to find by token first (primary method)
-        $draft = $this->modx->getObject(msOrder::class, [
-            'token' => $token,
-            'status_id' => $status_draft,
-            'context' => $ctx,
-        ]);
-
+        $draft = $this->findDraftByToken($token, $ctx);
         if ($draft) {
             return $draft;
         }
 
         // 2. Fallback: search by customer_id for authenticated customers
         //    Sort by id DESC to get the most recent draft when multiple exist
+        $statusDraft = (int) $this->modx->getOption('ms3_status_draft', null, 1) ?: 1;
         $customerId = (int)($_SESSION['ms3']['customer_id'] ?? 0);
         if ($customerId > 0) {
             $q = $this->modx->newQuery(msOrder::class);
             $q->where([
                 'customer_id' => $customerId,
-                'status_id' => $status_draft,
+                'status_id' => $statusDraft,
                 'context' => $ctx,
             ]);
             $q->sortby('id', 'DESC');

--- a/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
+++ b/core/components/minishop3/tests/Integration/Customer/AuthManagerLifecycleTest.php
@@ -6,7 +6,9 @@ namespace MiniShop3\Tests\Integration\Customer;
 
 use MiniShop3\Model\msCustomer;
 use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Model\msOrder;
 use MiniShop3\Services\Customer\AuthManager;
+use MiniShop3\Services\Order\OrderAddressManager;
 use MiniShop3\Services\Order\OrderDraftManager;
 use MiniShop3\Services\TokenService;
 use MiniShop3\Tests\Support\CustomerAuthPdoStore;
@@ -26,6 +28,8 @@ class AuthManagerLifecycleTest extends TestCase
 
     /** @var list<string> */
     private array $draftCalls = [];
+
+    private int $prefillCalls = 0;
 
     protected function setUp(): void
     {
@@ -49,6 +53,7 @@ class AuthManagerLifecycleTest extends TestCase
         $this->store = $this->createStore();
         $this->store->reset();
         $this->draftCalls = [];
+        $this->prefillCalls = 0;
     }
 
     protected function tearDown(): void
@@ -128,6 +133,7 @@ class AuthManagerLifecycleTest extends TestCase
         self::assertNull($this->store->findToken(['token' => $guestToken, 'type' => msCustomerToken::TYPE_API]));
         self::assertSame(1, $this->store->countTokens((int) $customer->id, msCustomerToken::TYPE_API));
         self::assertContains('transfer:' . $guestToken . '=>' . $loginToken, $this->draftCalls);
+        self::assertSame(1, $this->prefillCalls);
 
         self::assertTrue($auth->logoutCurrentCustomer());
         self::assertSame(0, (int) ($_SESSION['ms3']['customer_id'] ?? 0));
@@ -319,6 +325,12 @@ class AuthManagerLifecycleTest extends TestCase
     {
         $store = $this->store;
         $draftCalls = &$this->draftCalls;
+        $prefillCalls = &$this->prefillCalls;
+
+        $draft = $this->createStub(msOrder::class);
+        $draft->method('get')->willReturnMap([
+            ['customer_id', 1],
+        ]);
 
         $orderDraftManager = $this->createStub(OrderDraftManager::class);
         $orderDraftManager->method('transferDraftToToken')->willReturnCallback(
@@ -335,8 +347,17 @@ class AuthManagerLifecycleTest extends TestCase
                 return true;
             }
         );
+        $orderDraftManager->method('getDraft')->willReturn($draft);
+        $orderDraftManager->method('findDraftByToken')->willReturn($draft);
 
-        $modx = new class ($store, $options, $orderDraftManager) extends modX {
+        $addressManager = $this->createStub(OrderAddressManager::class);
+        $addressManager->method('prefillProfileFieldsFromCustomer')->willReturnCallback(
+            static function () use (&$prefillCalls): void {
+                $prefillCalls++;
+            }
+        );
+
+        $modx = new class ($store, $options, $orderDraftManager, $addressManager) extends modX {
             /**
              * @param array<string, mixed> $options
              */
@@ -344,19 +365,25 @@ class AuthManagerLifecycleTest extends TestCase
                 private CustomerAuthPdoStore $store,
                 private array $options,
                 OrderDraftManager $orderDraftManager,
+                OrderAddressManager $addressManager,
             ) {
                 parent::__construct();
                 $tokenService = new TokenService($this);
-                $this->services = new class ($tokenService, $orderDraftManager) {
+                $this->services = new class ($tokenService, $orderDraftManager, $addressManager) {
                     public function __construct(
                         private TokenService $tokenService,
                         private OrderDraftManager $orderDraftManager,
+                        private OrderAddressManager $addressManager,
                     ) {
                     }
 
                     public function has(string $key): bool
                     {
-                        return in_array($key, ['ms3_token_service', 'ms3_order_draft_manager'], true);
+                        return in_array($key, [
+                            'ms3_token_service',
+                            'ms3_order_draft_manager',
+                            'ms3_order_address_manager',
+                        ], true);
                     }
 
                     public function get(string $key): mixed
@@ -364,6 +391,7 @@ class AuthManagerLifecycleTest extends TestCase
                         return match ($key) {
                             'ms3_token_service' => $this->tokenService,
                             'ms3_order_draft_manager' => $this->orderDraftManager,
+                            'ms3_order_address_manager' => $this->addressManager,
                             default => null,
                         };
                     }

--- a/core/components/minishop3/tests/Unit/Services/Order/OrderAddressManagerProfilePrefillTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Order/OrderAddressManagerProfilePrefillTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Services\Order;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Services\Order\OrderAddressManager;
+use MiniShop3\Services\Order\OrderDraftManager;
+use MiniShop3\Services\Order\OrderFieldManager;
+use MODX\Revolution\modX;
+use PHPUnit\Framework\TestCase;
+
+final class OrderAddressManagerProfilePrefillTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(modX::class, false)) {
+            require_once dirname(__DIR__, 3) . '/stubs/ModxStub.php';
+        }
+    }
+
+    public function testFillFromCustomerSkipsNonEmptyOrderFields(): void
+    {
+        $manager = $this->makeManager();
+        $draft = $this->createStub(msOrder::class);
+        $orderData = [
+            'address_first_name' => 'Guest',
+            'address_last_name' => '',
+            'address_email' => '',
+            'address_phone' => '',
+        ];
+
+        $manager->fillFromCustomer($draft, $orderData, [
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'email' => 'jane@example.com',
+            'phone' => '+79990001122',
+        ]);
+
+        self::assertSame('Guest', $orderData['address_first_name']);
+        self::assertSame('Doe', $orderData['address_last_name']);
+        self::assertSame('jane@example.com', $orderData['address_email']);
+        self::assertSame('+79990001122', $orderData['address_phone']);
+    }
+
+    public function testPrefillProfileFieldsFromCustomerRefusesForeignDraft(): void
+    {
+        $fieldManager = $this->createMock(OrderFieldManager::class);
+        $fieldManager->expects(self::never())->method('add');
+
+        $manager = $this->makeManager($fieldManager);
+        $draft = $this->createStub(msOrder::class);
+        $draft->method('get')->willReturnMap([
+            ['customer_id', 99],
+        ]);
+        $customer = $this->createStub(msCustomer::class);
+        $customer->method('get')->willReturnMap([
+            ['id', 42],
+            ['first_name', 'Jane'],
+            ['last_name', 'Doe'],
+            ['email', 'jane@example.com'],
+        ]);
+
+        $manager->prefillProfileFieldsFromCustomer($draft, $customer);
+    }
+
+    public function testPrefillProfileFieldsFromCustomerFillsEmptyDraftFields(): void
+    {
+        $fieldManager = $this->createMock(OrderFieldManager::class);
+        $fieldManager->expects(self::exactly(3))
+            ->method('add')
+            ->willReturn(['success' => true, 'message' => '', 'data' => []]);
+
+        $manager = $this->makeManager($fieldManager);
+        $draft = $this->createStub(msOrder::class);
+        $draft->method('get')->willReturnMap([
+            ['customer_id', 42],
+        ]);
+        $customer = $this->createStub(msCustomer::class);
+        $customer->method('get')->willReturnMap([
+            ['id', 42],
+            ['first_name', 'Jane'],
+            ['last_name', 'Doe'],
+            ['email', 'jane@example.com'],
+            ['password', 'must-not-leak'],
+        ]);
+
+        $manager->prefillProfileFieldsFromCustomer($draft, $customer);
+    }
+
+    private function makeManager(?OrderFieldManager $fieldManager = null): OrderAddressManager
+    {
+        $modx = $this->createStub(modX::class);
+        $ms3 = $this->createStub(MiniShop3::class);
+
+        $draftManager = $this->createStub(OrderDraftManager::class);
+        $draftManager->method('toArray')->willReturn([
+            'customer_id' => 42,
+            'address_first_name' => '',
+            'address_last_name' => '',
+            'address_email' => '',
+            'address_phone' => '',
+        ]);
+
+        $fieldManager ??= $this->createStub(OrderFieldManager::class);
+        if (!($fieldManager instanceof \PHPUnit\Framework\MockObject\MockObject)) {
+            $fieldManager->method('add')->willReturn(['success' => true, 'message' => '', 'data' => []]);
+        }
+
+        return new OrderAddressManager($modx, $ms3, $draftManager, $fieldManager);
+    }
+}


### PR DESCRIPTION
## Описание

После успешного `POST /api/v1/customer/login` или `register` пустые поля черновика заказа (`email`, `first_name`, `last_name`, `phone`) заполняются из профиля клиента. Уже заполненные в checkout значения не перезаписываются.

Реализация: `AuthManager::establishCustomerSession()` → `OrderAddressManager::prefillProfileFieldsFromCustomer()` (существующий `fillFromCustomer()`). Поиск черновика только по токену (`findDraftByToken`) с учётом `CartDraftContext`, без fallback по `customer_id`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #636

## Как это было протестировано?

```bash
cd core/components/minishop3
composer ci:php   # exit 0 — php -l, smoke (89), PHPUnit 257 tests
```

Новые/обновлённые тесты:
- `OrderAddressManagerProfilePrefillTest` — пустые поля, отказ при чужом `customer_id`, allowlist без `password`
- `AuthManagerLifecycleTest` — prefill вызывается при `establishCustomerSession`

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: `feat/issue-636-order-draft-profile-sync`
- PHP: 8.4.17

## Скриншоты (если применимо)

Не применимо.

## Чеклист

- [x] Код соответствует стилю проекта
- [ ] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок
- [ ] ESLint проходит без ошибок
- [ ] Обновлён CHANGELOG.md

## Дополнительные заметки

- Сбой prefill логируется и не блокирует login/register.
- Поля читаются через `customer->get()` по allowlist `CustomerPublicDto::CORE_PROFILE_EDITABLE_FIELDS`, не через полный `toArray()`.
- `OrderDraftManager::findDraftByToken()` вынесен из `getDraft()` для token-only lookup без перепривязки старых черновиков.