### PR TITLE
fix(mgr): пустая карточка товара без resourcegroup_resource_list (#652)

### DIFF
--- a/assets/components/minishop3/js/mgr/product/update.js
+++ b/assets/components/minishop3/js/mgr/product/update.js
@@ -133,8 +133,9 @@ Ext.extend(ms3.panel.UpdateProduct, ms3.panel.Product, {
             // Gallery tab is now inside Vue ProductTabs component
             // No need to add it separately here
 
-            tabs.push(pageSettingsTab);
-            tabs.push(accessPermissionsTab);
+            // Optional tabs: MODX omits access permissions without resourcegroup_resource_list (#652)
+            pageSettingsTab && tabs.push(pageSettingsTab);
+            accessPermissionsTab && tabs.push(accessPermissionsTab);
 
             item.items = tabs;
             fields.push(item);

--- a/core/components/minishop3/tests/ProductUpdateAccessTabGuardTest.php
+++ b/core/components/minishop3/tests/ProductUpdateAccessTabGuardTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Smoke #652: product update must not push undefined access/settings tabs into Ext items.
+ *
+ * Run: php tests/ProductUpdateAccessTabGuardTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL ProductUpdateAccessTabGuardTest: {$message}\n");
+    exit(1);
+};
+
+$repoRoot = dirname(__DIR__, 4);
+$productUpdate = $repoRoot . '/assets/components/minishop3/js/mgr/product/update.js';
+$categoryUpdate = $repoRoot . '/assets/components/minishop3/js/mgr/category/update.js';
+
+foreach ([$productUpdate, $categoryUpdate] as $path) {
+    if (!is_readable($path)) {
+        $fail('not readable: ' . $path);
+    }
+}
+
+$productSrc = file_get_contents($productUpdate);
+if ($productSrc === false) {
+    $fail('cannot read product/update.js');
+}
+
+// Unguarded pushes regress #652 (undefined tab → blank form for managers without resourcegroup_resource_list).
+if (preg_match('/^\s*tabs\.push\(pageSettingsTab\);\s*$/m', $productSrc) === 1) {
+    $fail('product/update.js must guard pageSettingsTab before tabs.push (#652)');
+}
+if (preg_match('/^\s*tabs\.push\(accessPermissionsTab\);\s*$/m', $productSrc) === 1) {
+    $fail('product/update.js must guard accessPermissionsTab before tabs.push (#652)');
+}
+
+if (!str_contains($productSrc, 'pageSettingsTab && tabs.push(pageSettingsTab)')) {
+    $fail('product/update.js missing pageSettingsTab && tabs.push guard');
+}
+if (!str_contains($productSrc, 'accessPermissionsTab && tabs.push(accessPermissionsTab)')) {
+    $fail('product/update.js missing accessPermissionsTab && tabs.push guard');
+}
+
+$categorySrc = file_get_contents($categoryUpdate);
+if ($categorySrc === false) {
+    $fail('cannot read category/update.js');
+}
+if (!str_contains($categorySrc, 'accessPermissionsTab && tabs.push(accessPermissionsTab)')) {
+    $fail('category/update.js lost accessPermissionsTab guard (parity reference)');
+}
+
+fwrite(STDOUT, "OK ProductUpdateAccessTabGuardTest\n");
+exit(0);


### PR DESCRIPTION
## Описание

Без права `resourcegroup_resource_list` ядро MODX не добавляет вкладку «Права доступа». `ms3.panel.UpdateProduct.getFields()` всё равно делал `tabs.push(accessPermissionsTab)` с `undefined`, из‑за чего `addChangeEvent` падал и форма товара оставалась пустой.

Правка как в `category/update.js`: пушим вкладки settings/access только если они есть.

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #652

## Как это было протестировано?

```bash
# red (unguarded push) → exit 1
# green (with guards) → exit 0
cd core/components/minishop3
php tests/ProductUpdateAccessTabGuardTest.php
# EXIT:0
```

- [x] Автоматические тесты (smoke `ProductUpdateAccessTabGuardTest`, red-green)
- [ ] Ручное тестирование менеджером без `resourcegroup_resource_list` (нужна отдельная политика на стенде)

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-652-product-update-access-tab`
- PHP: 8.4 (smoke)

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Изменения не ломают существующую функциональность
- [ ] Обновлён CHANGELOG.md — не в этом PR (релизный процесс)

## Дополнительные заметки

Права ACL не менялись: только защита от `undefined` в Ext `items`. Обходной путь из issue (выдать `resourcegroup_resource_list`) больше не нужен для открытия карточки.