### PR TITLE
fix: права Sort/Multiple в галерее и лексиконы ошибок

### DIFF
--- a/core/components/minishop3/lexicon/en/default.inc.php
+++ b/core/components/minishop3/lexicon/en/default.inc.php
@@ -214,6 +214,8 @@ $_lang['ms3_err_gallery_thumb'] = 'Failed to generate thumbnails. See system log
 $_lang['ms3_err_gallery_upload'] = 'Cannot upload file.';
 $_lang['ms3_err_wrong_image'] = 'File is not a valid image.';
 $_lang['ms3_err_gallery_is_not_msproduct'] = '[msGallery] Resource with id = [[+id]] is not a product.';
+$_lang['ms3_gallery_err_ns'] = 'Required parameter is missing.';
+$_lang['ms3_gallery_err_no_product'] = 'Product not found.';
 $_lang['ms3_err_options_is_not_msproduct'] = '[msOptions] Resource with id = [[+id]] is not a product.';
 $_lang['ms3_err_processor_combo_required'] = 'This processor requires combo: true.';
 

--- a/core/components/minishop3/lexicon/ru/default.inc.php
+++ b/core/components/minishop3/lexicon/ru/default.inc.php
@@ -214,6 +214,8 @@ $_lang['ms3_err_gallery_thumb'] = 'Не получилось сгенериро�
 $_lang['ms3_err_gallery_upload'] = 'Не могу загрузить файл.';
 $_lang['ms3_err_wrong_image'] = 'Файл не является корректным изображением.';
 $_lang['ms3_err_gallery_is_not_msproduct'] = '[msGallery] Ресурс с id = [[+id]] не является товаром.';
+$_lang['ms3_gallery_err_ns'] = 'Не указан обязательный параметр.';
+$_lang['ms3_gallery_err_no_product'] = 'Товар не найден.';
 $_lang['ms3_err_options_is_not_msproduct'] = '[msOptions] Ресурс с id = [[+id]] не является товаром.';
 $_lang['ms3_err_processor_combo_required'] = 'Этот процессор требует combo: true.';
 

--- a/core/components/minishop3/src/Processors/Gallery/Multiple.php
+++ b/core/components/minishop3/src/Processors/Gallery/Multiple.php
@@ -6,6 +6,9 @@ use MODX\Revolution\Processors\ModelProcessor;
 
 class Multiple extends ModelProcessor
 {
+    public $languageTopics = ['minishop3:default'];
+    public $permission = 'msproductfile_save';
+
     /**
      * @return array|string
      */

--- a/core/components/minishop3/src/Processors/Gallery/Sort.php
+++ b/core/components/minishop3/src/Processors/Gallery/Sort.php
@@ -8,9 +8,11 @@ use MODX\Revolution\Processors\ModelProcessor;
 
 class Sort extends ModelProcessor
 {
+    public $classKey = msProductFile::class;
+    public $languageTopics = ['minishop3:default'];
+    public $permission = 'msproductfile_save';
+
     /**
-     *
-     *
      * @return array|string
      */
     public function process()

--- a/core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
+++ b/core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Smoke: gallery processors declare $permission (#660).
+ *
+ * Empty $permission makes ModelProcessor::checkPermissions() return true for any
+ * authenticated manager. Sort/Multiple must require msproductfile_save.
+ *
+ * Denial uses the same formula as MODX ModelProcessor::checkPermissions() with
+ * ModxStub::hasPermission — property values come from the Gallery sources under test.
+ *
+ * Run: php tests/ProcessorPermissionsSmokeTest.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/stubs/ModxStub.php';
+
+use MODX\Revolution\modX;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+};
+
+$assertSame = static function ($expected, $actual, string $label) use ($fail): void {
+    if ($actual !== $expected) {
+        $fail(sprintf(
+            "%s:\nexpected: %s\nactual:   %s",
+            $label,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+};
+
+$assertTrue = static function (bool $actual, string $label) use ($assertSame): void {
+    $assertSame(true, $actual, $label);
+};
+
+$assertFalse = static function (bool $actual, string $label) use ($assertSame): void {
+    $assertSame(false, $actual, $label);
+};
+
+$galleryRoot = dirname(__DIR__) . '/src/Processors/Gallery';
+if (!is_dir($galleryRoot)) {
+    $fail("Gallery processors directory not found: {$galleryRoot}");
+}
+
+$permissionPattern = '/public\s+\$permission\s*=\s*[\'"]([^\'"]*)[\'"]/';
+$declared = [];
+
+foreach (glob($galleryRoot . '/*.php') ?: [] as $absolute) {
+    $relative = 'Gallery/' . basename($absolute);
+    $source = file_get_contents($absolute);
+    if ($source === false) {
+        $fail("Cannot read {$relative}");
+    }
+    if (!preg_match('/\bclass\s+\w+/', $source)) {
+        continue;
+    }
+    if (!preg_match($permissionPattern, $source, $matches) || $matches[1] === '') {
+        $fail("{$relative}: missing non-empty public \$permission");
+    }
+    $declared[basename($absolute)] = $matches[1];
+}
+
+$assertSame('msproductfile_save', $declared['Sort.php'] ?? null, 'Gallery/Sort.php $permission');
+$assertSame('msproductfile_save', $declared['Multiple.php'] ?? null, 'Gallery/Multiple.php $permission');
+
+/**
+ * Mirrors MODX\Revolution\Processors\ModelProcessor::checkPermissions()
+ * (see .phpstan-deps/.../ModelProcessor.php). Wired to ModxStub so AC #2 is
+ * exercised with the permission strings declared on Sort/Multiple.
+ */
+$checkPermissions = static function (object $modx, string $permission): bool {
+    return $permission !== '' ? $modx->hasPermission($permission) : true;
+};
+
+$modxDenied = new modX();
+$modxDenied->setPermissions([]);
+$assertFalse(
+    $checkPermissions($modxDenied, $declared['Sort.php']),
+    'Sort: manager without msproductfile_save is denied'
+);
+$assertFalse(
+    $checkPermissions($modxDenied, $declared['Multiple.php']),
+    'Multiple: manager without msproductfile_save is denied'
+);
+
+$modxAllowed = new modX();
+$modxAllowed->setPermissions(['msproductfile_save']);
+$assertTrue(
+    $checkPermissions($modxAllowed, $declared['Sort.php']),
+    'Sort: manager with msproductfile_save is allowed'
+);
+$assertTrue(
+    $checkPermissions($modxAllowed, $declared['Multiple.php']),
+    'Multiple: manager with msproductfile_save is allowed'
+);
+
+$lexiconKeys = ['ms3_gallery_err_ns', 'ms3_gallery_err_no_product'];
+foreach (['en', 'ru'] as $lang) {
+    $lexiconPath = dirname(__DIR__) . "/lexicon/{$lang}/default.inc.php";
+    $lexicon = file_get_contents($lexiconPath);
+    if ($lexicon === false) {
+        $fail("Cannot read lexicon {$lang}/default.inc.php");
+    }
+    foreach ($lexiconKeys as $key) {
+        if (!str_contains($lexicon, "\$_lang['{$key}']")) {
+            $fail("Missing lexicon key {$key} in {$lang}/default.inc.php");
+        }
+    }
+}
+
+fwrite(STDOUT, 'OK ProcessorPermissionsSmokeTest (' . count($declared) . " Gallery processors)\n");
+exit(0);


### PR DESCRIPTION
## Описание

`Gallery/Sort` и `Gallery/Multiple` не задавали `$permission`, поэтому `ModelProcessor::checkPermissions()` пропускал любого аутентифицированного менеджера. На оба процессора поставлено `msproductfile_save` (как у Upload/Remove/Update). Добавлены отсутствующие ключи `ms3_gallery_err_ns` и `ms3_gallery_err_no_product` (ru/en). Smoke-тест проверяет, что все процессоры в `Gallery/` объявляют непустое `$permission`, а Sort/Multiple именно `msproductfile_save`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #660

## Как это было протестировано?

```bash
php -l core/components/minishop3/src/Processors/Gallery/Sort.php
php -l core/components/minishop3/src/Processors/Gallery/Multiple.php
php -l core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
# exit 0

php core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
# OK ProcessorPermissionsSmokeTest (10 Gallery processors), exit 0

cd core/components/minishop3 && composer ci:php
# OK smoke tests (99); PHPUnit 304 tests, exit 0
```

Vue/ESLint не затрагивались.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-660-gallery-processor-permissions`
- MODX: n/a (smoke без полной установки)
- PHP: 8.4.23

## Скриншоты (если применимо)

не применимо

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- `Multiple` остаётся входным gate на `msproductfile_save`. Дочерние `Generate`/`Remove` по-прежнему проверяют свои права через `runProcessor`.
- Smoke намеренно ограничен каталогом `Gallery/`, а не всем `src/Processors/`: глобальный allowlist давал ложные «дыры» у наследников Update (Hide/Enable и т.п.). Ратчет по остальным Multiple/Sort без `$permission` — отдельный follow-up.
- CHANGELOG не трогали (релизный процесс).