### PR TITLE
Единая трактовка незаданного sort_order в groupProductDataSections

### DIFF
--- a/vueManager/src/utils/groupProductDataSections.js
+++ b/vueManager/src/utils/groupProductDataSections.js
@@ -36,8 +36,8 @@ export function groupProductDataSections(fields, sectionsById = {}) {
   const sections = Array.from(grouped.values())
 
   sections.sort((a, b) => {
-    const sortA = Number.isFinite(Number(a.sort_order)) ? Number(a.sort_order) : Number.MAX_SAFE_INTEGER
-    const sortB = Number.isFinite(Number(b.sort_order)) ? Number(b.sort_order) : Number.MAX_SAFE_INTEGER
+    const sortA = toSortOrder(a.sort_order)
+    const sortB = toSortOrder(b.sort_order)
     if (sortA !== sortB) {
       return sortA - sortB
     }
@@ -52,4 +52,20 @@ export function groupProductDataSections(fields, sectionsById = {}) {
   })
 
   return sections
+}
+
+/**
+ * Normalize section sort_order. null / '' / undefined / non-finite → end of list.
+ * Preserves 0 as a valid leading position (#656).
+ *
+ * @param {unknown} value
+ * @returns {number}
+ */
+function toSortOrder(value) {
+  if (value === null || value === '' || value === undefined) {
+    return Number.MAX_SAFE_INTEGER
+  }
+
+  const n = Number(value)
+  return Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER
 }

--- a/vueManager/src/utils/groupProductDataSections.test.js
+++ b/vueManager/src/utils/groupProductDataSections.test.js
@@ -56,4 +56,67 @@ describe('groupProductDataSections', () => {
     expect(result[0].key).toBe('default')
     expect(result[0].fields[0].name).toBe('orphan')
   })
+
+  it('treats null, empty string, and missing sort_order the same (end of list)', () => {
+    const sectionsById = {
+      1: { id: 1, key: 'nullish', sort_order: null },
+      2: { id: 2, key: 'empty', sort_order: '' },
+      3: { id: 3, key: 'missing' },
+      4: { id: 4, key: 'first', sort_order: 10 },
+    }
+    const fields = [
+      { name: 'a', section: 1 },
+      { name: 'b', section: 2 },
+      { name: 'c', section: 3 },
+      { name: 'd', section: 4 },
+    ]
+
+    const result = groupProductDataSections(fields, sectionsById)
+
+    expect(result.map(s => s.key)).toEqual(['first', 'nullish', 'empty', 'missing'])
+  })
+
+  it('keeps sort_order 0 as a valid leading position', () => {
+    const sectionsById = {
+      1: { id: 1, key: 'zero', sort_order: 0 },
+      2: { id: 2, key: 'ten', sort_order: 10 },
+      3: { id: 3, key: 'unset', sort_order: null },
+    }
+    const fields = [
+      { name: 'a', section: 1 },
+      { name: 'b', section: 2 },
+      { name: 'c', section: 3 },
+    ]
+
+    expect(groupProductDataSections(fields, sectionsById).map(s => s.key)).toEqual([
+      'zero',
+      'ten',
+      'unset',
+    ])
+  })
+
+  it('breaks ties by numeric id then by string key', () => {
+    const sectionsById = {
+      5: { id: 5, key: 'b', sort_order: 10 },
+      2: { id: 2, key: 'a', sort_order: 10 },
+    }
+    const fields = [
+      { name: 'x', section: 5 },
+      { name: 'y', section: 2 },
+    ]
+
+    expect(groupProductDataSections(fields, sectionsById).map(s => s.id)).toEqual([2, 5])
+
+    const stringTied = groupProductDataSections(
+      [
+        { name: 'p', section: 'beta' },
+        { name: 'q', section: 'alpha' },
+      ],
+      {
+        beta: { key: 'beta', sort_order: 1 },
+        alpha: { key: 'alpha', sort_order: 1 },
+      }
+    )
+    expect(stringTied.map(s => s.key)).toEqual(['alpha', 'beta'])
+  })
 })


### PR DESCRIPTION
## Описание

В `groupProductDataSections` значения `null` и `''` для `sort_order` через `Number()` становились `0` и уезжали в начало списка, а отсутствующий ключ — в конец. Добавлен `toSortOrder`: `null` / `''` / `undefined` / non-finite → конец списка. `sort_order: 0` по-прежнему валиден.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #656

## Как это было протестировано?

```bash
cd vueManager
npx vitest run src/utils/groupProductDataSections.test.js
npx eslint src/utils/groupProductDataSections.js src/utils/groupProductDataSections.test.js
```

Результаты: Vitest PASS (7 tests), ESLint OK, exit 0.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-656-sort-order-unset`
- MODX: n/a
- PHP: n/a (Vue util)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [x] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

На текущих данных из API/БД баг не проявляется (`sort_order` всегда int). Правка закрывает спящий риск для переиспользуемого util.