### PR TITLE
Единая валидация context в публичном каталоге

### DIFF
--- a/core/components/minishop3/lexicon/en/default.inc.php
+++ b/core/components/minishop3/lexicon/en/default.inc.php
@@ -230,6 +230,7 @@ $_lang['ms3_err_category_products_no_updates'] = 'No products were updated';
 $_lang['ms3_err_product_id_required'] = 'Product ID is required';
 $_lang['ms3_err_product_nf'] = 'Product not found';
 $_lang['ms3_err_product_update_failed'] = 'Failed to update product';
+$_lang['ms3_err_catalog_context_invalid'] = 'Invalid context parameter';
 $_lang['ms3_err_catalog_parents_invalid'] = 'Invalid parents filter';
 $_lang['ms3_err_catalog_parents_limit'] = 'Too many parent category IDs';
 $_lang['ms3_err_catalog_price_invalid'] = 'Invalid price filter';

--- a/core/components/minishop3/lexicon/ru/default.inc.php
+++ b/core/components/minishop3/lexicon/ru/default.inc.php
@@ -230,6 +230,7 @@ $_lang['ms3_err_category_products_no_updates'] = 'Ни один товар не 
 $_lang['ms3_err_product_id_required'] = 'Не указан ID товара';
 $_lang['ms3_err_product_nf'] = 'Товар не найден';
 $_lang['ms3_err_product_update_failed'] = 'Не удалось обновить товар';
+$_lang['ms3_err_catalog_context_invalid'] = 'Некорректный параметр context';
 $_lang['ms3_err_catalog_parents_invalid'] = 'Некорректный фильтр parents';
 $_lang['ms3_err_catalog_parents_limit'] = 'Слишком много ID категорий в parents';
 $_lang['ms3_err_catalog_price_invalid'] = 'Некорректный фильтр цены';

--- a/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
@@ -6,6 +6,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Catalog\CatalogContextException;
 use MiniShop3\Services\Category\CategoryCatalogService;
 use MODX\Revolution\modX;
 
@@ -40,7 +41,11 @@ class CategoryController
             );
         }
 
-        $category = $this->catalog()->getById($categoryId, $params);
+        try {
+            $category = $this->catalog()->getById($categoryId, $params);
+        } catch (CatalogContextException $e) {
+            return $this->catalogContextBadRequest($e);
+        }
 
         if ($category === null) {
             return Response::error(
@@ -62,7 +67,13 @@ class CategoryController
      */
     public function getList(array $params = []): Response
     {
-        return Response::success($this->catalog()->getList($params));
+        try {
+            $result = $this->catalog()->getList($params);
+        } catch (CatalogContextException $e) {
+            return $this->catalogContextBadRequest($e);
+        }
+
+        return Response::success($result);
     }
 
     /**
@@ -74,7 +85,21 @@ class CategoryController
      */
     public function getTree(array $params = []): Response
     {
-        return Response::success($this->catalog()->getTree($params));
+        try {
+            $result = $this->catalog()->getTree($params);
+        } catch (CatalogContextException $e) {
+            return $this->catalogContextBadRequest($e);
+        }
+
+        return Response::success($result);
+    }
+
+    private function catalogContextBadRequest(CatalogContextException $e): Response
+    {
+        return Response::error(
+            $this->modx->lexicon($e->getLexiconKey()),
+            HttpStatus::BAD_REQUEST
+        );
     }
 
     private function catalog(): CategoryCatalogService

--- a/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
@@ -6,6 +6,7 @@ namespace MiniShop3\Controllers\Api\Web;
 
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
+use MiniShop3\Services\Catalog\CatalogContextException;
 use MiniShop3\Services\Product\ProductCatalogFilterException;
 use MiniShop3\Services\Product\ProductCatalogService;
 use MiniShop3\Services\Product\ProductFacetService;
@@ -44,7 +45,11 @@ class ProductController
             );
         }
 
-        $product = $this->catalog()->getById($productId, $params);
+        try {
+            $product = $this->catalog()->getById($productId, $params);
+        } catch (CatalogContextException $e) {
+            return $this->catalogParamBadRequest($e);
+        }
 
         if ($product === null) {
             return Response::error(
@@ -70,11 +75,8 @@ class ProductController
     {
         try {
             $result = $this->catalog()->getList($params);
-        } catch (ProductCatalogFilterException $e) {
-            return Response::error(
-                $this->modx->lexicon($e->getLexiconKey()),
-                HttpStatus::BAD_REQUEST
-            );
+        } catch (ProductCatalogFilterException|CatalogContextException $e) {
+            return $this->catalogParamBadRequest($e);
         }
 
         return Response::success($result);
@@ -92,11 +94,8 @@ class ProductController
     {
         try {
             $result = $this->facets()->getFilters($params);
-        } catch (ProductCatalogFilterException $e) {
-            return Response::error(
-                $this->modx->lexicon($e->getLexiconKey()),
-                HttpStatus::BAD_REQUEST
-            );
+        } catch (ProductCatalogFilterException|CatalogContextException $e) {
+            return $this->catalogParamBadRequest($e);
         }
 
         return Response::success($result);
@@ -120,7 +119,11 @@ class ProductController
             );
         }
 
-        $result = $this->catalog()->getPublicImages($productId, $params);
+        try {
+            $result = $this->catalog()->getPublicImages($productId, $params);
+        } catch (CatalogContextException $e) {
+            return $this->catalogParamBadRequest($e);
+        }
 
         if ($result === null) {
             return Response::error(
@@ -130,6 +133,14 @@ class ProductController
         }
 
         return Response::success($result);
+    }
+
+    private function catalogParamBadRequest(ProductCatalogFilterException|CatalogContextException $e): Response
+    {
+        return Response::error(
+            $this->modx->lexicon($e->getLexiconKey()),
+            HttpStatus::BAD_REQUEST
+        );
     }
 
     private function catalog(): ProductCatalogService

--- a/core/components/minishop3/src/Services/Catalog/CatalogContextException.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogContextException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Services\Catalog;
+
+/**
+ * Invalid public catalog context param (maps to HTTP 400 + lexicon).
+ */
+final class CatalogContextException extends \InvalidArgumentException
+{
+    public const LEXICON_INVALID = 'ms3_err_catalog_context_invalid';
+
+    public function __construct(
+        private readonly string $lexiconKey = self::LEXICON_INVALID,
+    ) {
+        parent::__construct($lexiconKey);
+    }
+
+    public static function invalid(): self
+    {
+        return new self(self::LEXICON_INVALID);
+    }
+
+    public function getLexiconKey(): string
+    {
+        return $this->lexiconKey;
+    }
+}

--- a/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogQuery.php
@@ -13,6 +13,7 @@ final class CatalogQuery
     public const MAX_LIMIT = 100;
     public const DEFAULT_DEPTH = 5;
     public const MAX_DEPTH = 10;
+    public const MAX_CONTEXT_LENGTH = 100;
 
     /**
      * @param array<string, mixed> $params
@@ -76,20 +77,91 @@ final class CatalogQuery
     }
 
     /**
-     * Empty / whitespace context falls back (avoids unscoped cross-context reads).
+     * Sanitize a MODX context key for catalog queries.
+     *
+     * Empty / whitespace input is treated as absent (returns null).
+     * Non-empty invalid input throws CatalogContextException.
+     *
+     * @throws CatalogContextException
+     */
+    public static function sanitizeContext(?string $key): ?string
+    {
+        if ($key === null) {
+            return null;
+        }
+
+        $key = trim($key);
+        if ($key === '') {
+            return null;
+        }
+
+        if (!self::isValidContextKey($key)) {
+            throw CatalogContextException::invalid();
+        }
+
+        return $key;
+    }
+
+    /**
+     * Empty / whitespace / absent context falls back (avoids unscoped cross-context reads).
+     * Explicit non-empty invalid values throw CatalogContextException (HTTP 400).
      *
      * @param array<string, mixed> $params
+     *
+     * @throws CatalogContextException
      */
     public static function resolveContext(array $params, string $fallback = 'web'): string
     {
-        $context = trim((string) ($params['context'] ?? ''));
-        if ($context !== '') {
-            return $context;
+        if (!array_key_exists('context', $params)) {
+            return self::resolveContextFallback($fallback);
         }
 
-        $fallback = trim($fallback);
+        $sanitized = self::sanitizeContextParam($params['context']);
 
-        return $fallback !== '' ? $fallback : 'web';
+        return $sanitized ?? self::resolveContextFallback($fallback);
+    }
+
+    /**
+     * @throws CatalogContextException
+     */
+    private static function sanitizeContextParam(mixed $raw): ?string
+    {
+        if ($raw === null) {
+            return null;
+        }
+
+        if (is_array($raw) || is_object($raw) || is_bool($raw)) {
+            throw CatalogContextException::invalid();
+        }
+
+        if (!is_string($raw) && !is_int($raw) && !is_float($raw)) {
+            throw CatalogContextException::invalid();
+        }
+
+        return self::sanitizeContext((string) $raw);
+    }
+
+    private static function isValidContextKey(string $key): bool
+    {
+        if (strlen($key) > self::MAX_CONTEXT_LENGTH) {
+            return false;
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $key)) {
+            return false;
+        }
+
+        return !str_starts_with(strtolower($key), 'mgr');
+    }
+
+    private static function resolveContextFallback(string $fallback): string
+    {
+        $fallback = trim($fallback);
+        if ($fallback !== '' && self::isValidContextKey($fallback)) {
+            return $fallback;
+        }
+
+        return 'web';
     }
 
     public static function toBool(mixed $value): bool

--- a/core/components/minishop3/src/Services/Product/ProductFacetService.php
+++ b/core/components/minishop3/src/Services/Product/ProductFacetService.php
@@ -8,6 +8,8 @@ use MiniShop3\Model\msCategoryOption;
 use MiniShop3\Model\msOption;
 use MiniShop3\Model\msProductOption;
 use MiniShop3\Model\msVendor;
+use MiniShop3\Services\Catalog\CatalogContextException;
+use MiniShop3\Services\Catalog\CatalogQuery;
 use MiniShop3\Services\Category\CategoryProductScopeService;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOQuery;
@@ -45,9 +47,16 @@ final class ProductFacetService
      * }
      *
      * @throws ProductCatalogFilterException
+     * @throws CatalogContextException
      */
     public function getFilters(array $params): array
     {
+        // Validate context before cache lookup so invalid keys never hit facet cache (#658).
+        $params['context'] = CatalogQuery::resolveContext(
+            $params,
+            (string) ($this->modx->context->key ?? 'web'),
+        );
+
         $filters = ProductCatalogFilterParser::parse($params);
         $includePrice = ProductCatalogService::toBool($params['include_price'] ?? true);
         $includeVendors = ProductCatalogService::toBool($params['include_vendors'] ?? false);

--- a/core/components/minishop3/tests/CatalogQueryTest.php
+++ b/core/components/minishop3/tests/CatalogQueryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use MiniShop3\Services\Catalog\CatalogContextException;
 use MiniShop3\Services\Catalog\CatalogQuery;
 
 $fail = static function (string $message): never {
@@ -23,6 +24,17 @@ $assertSame = static function ($expected, $actual, string $case) use ($fail): vo
     }
 };
 
+$expectContextException = static function (callable $fn, string $case) use ($fail): void {
+    try {
+        $fn();
+        $fail($case . ': expected CatalogContextException');
+    } catch (CatalogContextException $e) {
+        if ($e->getLexiconKey() !== CatalogContextException::LEXICON_INVALID) {
+            $fail($case . ': unexpected lexicon key ' . $e->getLexiconKey());
+        }
+    }
+};
+
 $assertSame(20, CatalogQuery::resolveLimit([]), 'default limit');
 $assertSame(100, CatalogQuery::resolveLimit(['limit' => 500]), 'limit cap');
 $assertSame(40, CatalogQuery::resolveOffset(['page' => 3], 20), 'page offset');
@@ -33,6 +45,48 @@ $assertSame('shop', CatalogQuery::resolveContext(['context' => ' shop '], 'web')
 $assertSame('web', CatalogQuery::resolveContext(['context' => ''], 'web'), 'empty context → fallback');
 $assertSame('web', CatalogQuery::resolveContext(['context' => '   '], 'web'), 'whitespace context → fallback');
 $assertSame('web', CatalogQuery::resolveContext([], ''), 'empty fallback → web');
+$assertSame('web', CatalogQuery::resolveContext([], 'mgr'), 'invalid fallback mgr → web');
+$assertSame('shop', CatalogQuery::resolveContext(['context' => 'shop'], 'web'), 'valid explicit context');
+$assertSame('shop-v2', CatalogQuery::resolveContext(['context' => 'shop-v2'], 'web'), 'valid charset with dash/underscore');
+
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => 'bad chars!'], 'web'),
+    'invalid charset'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => str_repeat('a', 101)], 'web'),
+    'length > 100'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => 'mgr'], 'web'),
+    'mgr prefix lowercase'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => 'Mgr'], 'web'),
+    'mgr prefix mixed case'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => 'mgrCustom'], 'web'),
+    'mgr prefix prefix'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => ['web']], 'web'),
+    'array context'
+);
+$expectContextException(
+    static fn () => CatalogQuery::resolveContext(['context' => true], 'web'),
+    'bool context'
+);
+
+$assertSame(null, CatalogQuery::sanitizeContext(null), 'sanitize null → absent');
+$assertSame(null, CatalogQuery::sanitizeContext(''), 'sanitize empty → absent');
+$assertSame(null, CatalogQuery::sanitizeContext('   '), 'sanitize whitespace → absent');
+$assertSame('web', CatalogQuery::sanitizeContext(' web '), 'sanitize valid trim');
+
+$expectContextException(
+    static fn () => CatalogQuery::sanitizeContext('mgr'),
+    'sanitize throws on mgr'
+);
 
 $map = [
     'id' => 't.id',


### PR DESCRIPTION
## Описание

Публичные каталожные эндпоинты принимали `context` только через `trim()`. Правила выровнены с `CatalogResolve::sanitizeContext` из #644 (на beta ещё нет): charset `[a-zA-Z0-9_-]+`, длина ≤ 100, запрет префикса `mgr`.

Явный невалидный `context` → HTTP 400 (`ms3_err_catalog_context_invalid`). Пустой / отсутствующий параметр → прежний fallback. Fallback-ключ тоже проходит тот же валидатор (иначе `web`). В `product/filters` контекст проверяется до чтения facet-кэша.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [x] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

Клиенты, которые слали `context=mgr` или мусор и получали пустой список / «как получится», теперь получают 400.

## Связанные Issues

Closes #658

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Catalog/CatalogQuery.php
php -l src/Services/Catalog/CatalogContextException.php
php -l src/Services/Product/ProductFacetService.php
php -l src/Controllers/Api/Web/ProductController.php
php -l src/Controllers/Api/Web/CategoryController.php
php tests/CatalogQueryTest.php
```

Результаты: `php -l` OK, `CatalogQueryTest` OK, exit 0.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-658-catalog-context-validation` от `beta`
- MODX: n/a (smoke unit)
- PHP: локальный CLI 8.x

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [x] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

`CatalogResolve` на beta ещё нет: `CatalogQuery::sanitizeContext()` готов к делегированию после merge #644. Объединение `CatalogContextException` с `ProductCatalogFilterException` в один base-тип отложено.