### PR TITLE
fix: права Product/Sort и Multiple + ratchet по Processors

### DIFF
--- a/core/components/minishop3/src/Processors/Product/Multiple.php
+++ b/core/components/minishop3/src/Processors/Product/Multiple.php
@@ -8,6 +8,7 @@ use MODX\Revolution\Processors\ModelProcessor;
 class Multiple extends ModelProcessor
 {
     public $classKey = msProduct::class;
+    public $permission = 'msproduct_save';
     /**
      * @return array|string
      */

--- a/core/components/minishop3/src/Processors/Product/Sort.php
+++ b/core/components/minishop3/src/Processors/Product/Sort.php
@@ -8,8 +8,8 @@ use MODX\Revolution\Processors\ModelProcessor;
 class Sort extends ModelProcessor
 {
     public $classKey = msProduct::class;
+    public $permission = 'msproduct_save';
     private $parent;
-
 
     /**
      * @return array|string

--- a/core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
+++ b/core/components/minishop3/tests/ProcessorPermissionsSmokeTest.php
@@ -1,20 +1,20 @@
 <?php
 
 /**
- * Smoke: gallery processors declare $permission (#660).
+ * Smoke: every src/Processors class resolves a non-empty $permission
+ * unless allowlisted (#660 Gallery, #672 Product + full-tree ratchet).
  *
- * Empty $permission makes ModelProcessor::checkPermissions() return true for any
- * authenticated manager. Sort/Multiple must require msproductfile_save.
- *
- * Denial uses the same formula as MODX ModelProcessor::checkPermissions() with
- * ModxStub::hasPermission — property values come from the Gallery sources under test.
+ * Resolution uses ReflectionClass (inheritance-aware). Regex on source
+ * is not used for the permission value.
  *
  * Run: php tests/ProcessorPermissionsSmokeTest.php
  */
 
 declare(strict_types=1);
 
+require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/stubs/ModxStub.php';
+require __DIR__ . '/stubs/ModxProcessorBasesStub.php';
 
 use MODX\Revolution\modX;
 
@@ -42,16 +42,92 @@ $assertFalse = static function (bool $actual, string $label) use ($assertSame): 
     $assertSame(false, $actual, $label);
 };
 
-$galleryRoot = dirname(__DIR__) . '/src/Processors/Gallery';
-if (!is_dir($galleryRoot)) {
-    $fail("Gallery processors directory not found: {$galleryRoot}");
+/**
+ * Intentional empty $permission (or connector entrypoints that gate elsewhere).
+ * Do not add mutating Sort/Multiple here — they must fail the ratchet.
+ *
+ * @var array<string, string> relative path => reason
+ */
+$allowEmptyPermission = [
+    // Product reads — no msproduct_list in policy; Vue uses Manager REST (#672)
+    'Product/Get.php' => 'read: legacy combo/get; no msproduct_list in policy',
+    'Product/GetList.php' => 'read: legacy combo list; no msproduct_list in policy',
+    'Product/GetOptions.php' => 'read: option helper; no msproduct_list in policy',
+    'Product/Autocomplete.php' => 'read: autocomplete; Manager REST has own route',
+
+    // Category tree helpers (resource UI)
+    'Category/GetCats.php' => 'read: category picker list',
+    'Category/GetNodes.php' => 'read: resource tree nodes',
+
+    // System element combos
+    'System/Element/Context/GetList.php' => 'read: MODX context combo',
+    'System/Element/Chunk/GetList.php' => 'read: chunk combo',
+    'System/Element/Resource/GetList.php' => 'read: resource combo',
+    'System/User/GetList.php' => 'read: user combo',
+
+    // Customer combobox + legacy Multiple dispatchers (out of #672 scope)
+    'Customer/GetListCombobox.php' => 'read: customer combo',
+    'Customer/Multiple.php' => 'deferred: Settings/Customer Multiple gate — follow-up',
+    'Customer/Address/Multiple.php' => 'deferred: address Multiple gate — follow-up',
+
+    // Settings Multiple dispatchers (same pattern as Gallery pre-#661; out of #672)
+    'Settings/Delivery/Multiple.php' => 'deferred: settings Multiple — follow-up',
+    'Settings/Payment/Multiple.php' => 'deferred: settings Multiple — follow-up',
+    'Settings/Status/Multiple.php' => 'deferred: settings Multiple — follow-up',
+    'Settings/Link/Multiple.php' => 'deferred: settings Multiple — follow-up',
+    'Settings/Vendor/Multiple.php' => 'deferred: settings Multiple — follow-up',
+    'Settings/GetClass.php' => 'read: class-name helper for settings UI',
+
+    // Api connector: Index intentionally empty + checkPermissions true; Customer auth is public API
+    'Api/Index.php' => 'connector entry: checkPermissions() always true by design',
+    'Api/Router.php' => 'connector router; auth on route handlers',
+    'Api/Customer/Login.php' => 'public customer auth processor',
+    'Api/Customer/Register.php' => 'public customer auth processor',
+    'Api/Customer/Logout.php' => 'public customer auth processor',
+    'Api/Customer/ForgotPassword.php' => 'public customer auth processor',
+    'Api/Customer/ResetPassword.php' => 'public customer auth processor',
+    'Api/Customer/ResendVerification.php' => 'public customer auth processor',
+    'Api/Customer/VerifyEmail.php' => 'public customer auth processor',
+];
+
+$processorsRoot = dirname(__DIR__) . '/src/Processors';
+if (!is_dir($processorsRoot)) {
+    $fail("Processors directory not found: {$processorsRoot}");
 }
 
-$permissionPattern = '/public\s+\$permission\s*=\s*[\'"]([^\'"]*)[\'"]/';
-$declared = [];
+$resolvePermission = static function (string $class): string {
+    if (!class_exists($class)) {
+        return '';
+    }
+    $ref = new ReflectionClass($class);
+    if (!$ref->hasProperty('permission')) {
+        return '';
+    }
+    $value = $ref->getProperty('permission')->getDefaultValue();
 
-foreach (glob($galleryRoot . '/*.php') ?: [] as $absolute) {
-    $relative = 'Gallery/' . basename($absolute);
+    return is_string($value) ? $value : '';
+};
+
+$relativeToClass = static function (string $relative): string {
+    $path = preg_replace('/\.php$/', '', str_replace('\\', '/', $relative));
+
+    return 'MiniShop3\\Processors\\' . str_replace('/', '\\', $path);
+};
+
+$declared = [];
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($processorsRoot, FilesystemIterator::SKIP_DOTS)
+);
+
+/** @var SplFileInfo $file */
+foreach ($iterator as $file) {
+    if (!$file->isFile() || $file->getExtension() !== 'php') {
+        continue;
+    }
+    $absolute = $file->getPathname();
+    $relative = substr($absolute, strlen($processorsRoot) + 1);
+    $relative = str_replace('\\', '/', $relative);
+
     $source = file_get_contents($absolute);
     if ($source === false) {
         $fail("Cannot read {$relative}");
@@ -59,19 +135,49 @@ foreach (glob($galleryRoot . '/*.php') ?: [] as $absolute) {
     if (!preg_match('/\bclass\s+\w+/', $source)) {
         continue;
     }
-    if (!preg_match($permissionPattern, $source, $matches) || $matches[1] === '') {
-        $fail("{$relative}: missing non-empty public \$permission");
+
+    $class = $relativeToClass($relative);
+    if (!class_exists($class)) {
+        $fail("{$relative}: class {$class} failed to autoload");
     }
-    $declared[basename($absolute)] = $matches[1];
+
+    $permission = $resolvePermission($class);
+    $declared[$relative] = $permission;
+
+    if ($permission !== '') {
+        continue;
+    }
+
+    if (!isset($allowEmptyPermission[$relative])) {
+        $fail("{$relative}: empty \$permission (resolved via reflection) — add gate or allowlist with reason");
+    }
 }
 
-$assertSame('msproductfile_save', $declared['Sort.php'] ?? null, 'Gallery/Sort.php $permission');
-$assertSame('msproductfile_save', $declared['Multiple.php'] ?? null, 'Gallery/Multiple.php $permission');
+// Stale allowlist entries must not hide removals forever
+foreach (array_keys($allowEmptyPermission) as $path) {
+    if (!isset($declared[$path])) {
+        $fail("Allowlist entry missing on disk: {$path}");
+    }
+    if ($declared[$path] !== '') {
+        $fail("Allowlist entry {$path} now has permission {$declared[$path]} — remove from allowlist");
+    }
+}
+
+$expectedPermissions = [
+    'Gallery/Sort.php' => 'msproductfile_save',
+    'Gallery/Multiple.php' => 'msproductfile_save',
+    'Product/Sort.php' => 'msproduct_save',
+    'Product/Multiple.php' => 'msproduct_save',
+    'Product/Hide.php' => 'msproduct_save',
+    'Product/Show.php' => 'msproduct_save',
+    'Product/UpdateFromGrid.php' => 'msproduct_save',
+];
+foreach ($expectedPermissions as $path => $expected) {
+    $assertSame($expected, $declared[$path] ?? null, "{$path} \$permission");
+}
 
 /**
- * Mirrors MODX\Revolution\Processors\ModelProcessor::checkPermissions()
- * (see .phpstan-deps/.../ModelProcessor.php). Wired to ModxStub so AC #2 is
- * exercised with the permission strings declared on Sort/Multiple.
+ * Mirrors MODX ModelProcessor::checkPermissions().
  */
 $checkPermissions = static function (object $modx, string $permission): bool {
     return $permission !== '' ? $modx->hasPermission($permission) : true;
@@ -79,25 +185,29 @@ $checkPermissions = static function (object $modx, string $permission): bool {
 
 $modxDenied = new modX();
 $modxDenied->setPermissions([]);
-$assertFalse(
-    $checkPermissions($modxDenied, $declared['Sort.php']),
-    'Sort: manager without msproductfile_save is denied'
-);
-$assertFalse(
-    $checkPermissions($modxDenied, $declared['Multiple.php']),
-    'Multiple: manager without msproductfile_save is denied'
-);
+foreach ([
+    'Product/Sort.php' => 'msproduct_save',
+    'Product/Multiple.php' => 'msproduct_save',
+    'Gallery/Sort.php' => 'msproductfile_save',
+] as $path => $permission) {
+    $assertFalse(
+        $checkPermissions($modxDenied, $declared[$path]),
+        "{$path}: manager without {$permission} is denied"
+    );
+}
 
-$modxAllowed = new modX();
-$modxAllowed->setPermissions(['msproductfile_save']);
-$assertTrue(
-    $checkPermissions($modxAllowed, $declared['Sort.php']),
-    'Sort: manager with msproductfile_save is allowed'
-);
-$assertTrue(
-    $checkPermissions($modxAllowed, $declared['Multiple.php']),
-    'Multiple: manager with msproductfile_save is allowed'
-);
+foreach ([
+    'Product/Sort.php' => ['msproduct_save'],
+    'Product/Multiple.php' => ['msproduct_save'],
+    'Gallery/Sort.php' => ['msproductfile_save'],
+] as $path => $permissions) {
+    $modx = new modX();
+    $modx->setPermissions($permissions);
+    $assertTrue(
+        $checkPermissions($modx, $declared[$path]),
+        "{$path}: manager with {$permissions[0]} is allowed"
+    );
+}
 
 $lexiconKeys = ['ms3_gallery_err_ns', 'ms3_gallery_err_no_product'];
 foreach (['en', 'ru'] as $lang) {
@@ -113,5 +223,9 @@ foreach (['en', 'ru'] as $lang) {
     }
 }
 
-fwrite(STDOUT, 'OK ProcessorPermissionsSmokeTest (' . count($declared) . " Gallery processors)\n");
+fwrite(
+    STDOUT,
+    'OK ProcessorPermissionsSmokeTest (' . count($declared) . ' processors, '
+    . count($allowEmptyPermission) . " allowlisted empty)\n"
+);
 exit(0);

--- a/core/components/minishop3/tests/stubs/ModxProcessorBasesStub.php
+++ b/core/components/minishop3/tests/stubs/ModxProcessorBasesStub.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Minimal MODX processor bases for permission reflection smoke (#672).
+ * Empty $permission mirrors ModelProcessor::checkPermissions() passthrough.
+ */
+
+declare(strict_types=1);
+
+namespace MODX\Revolution\Processors {
+    if (!class_exists(Processor::class, false)) {
+        class Processor
+        {
+            public $permission = '';
+        }
+    }
+
+    if (!class_exists(ModelProcessor::class, false)) {
+        class ModelProcessor extends Processor
+        {
+        }
+    }
+
+    if (!class_exists(GetProcessor::class, false)) {
+        class GetProcessor extends ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(GetListProcessor::class, false)) {
+        class GetListProcessor extends ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(CreateProcessor::class, false)) {
+        class CreateProcessor extends ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(UpdateProcessor::class, false)) {
+        class UpdateProcessor extends ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(DeleteProcessor::class, false)) {
+        class DeleteProcessor extends ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(ProcessorResponse::class, false)) {
+        class ProcessorResponse
+        {
+        }
+    }
+}
+
+namespace MODX\Revolution\Processors\Model {
+    if (!class_exists(GetProcessor::class, false)) {
+        class GetProcessor extends \MODX\Revolution\Processors\GetProcessor
+        {
+        }
+    }
+
+    if (!class_exists(GetListProcessor::class, false)) {
+        class GetListProcessor extends \MODX\Revolution\Processors\GetListProcessor
+        {
+        }
+    }
+
+    if (!class_exists(CreateProcessor::class, false)) {
+        class CreateProcessor extends \MODX\Revolution\Processors\CreateProcessor
+        {
+        }
+    }
+
+    if (!class_exists(UpdateProcessor::class, false)) {
+        class UpdateProcessor extends \MODX\Revolution\Processors\UpdateProcessor
+        {
+        }
+    }
+
+    if (!class_exists(DeleteProcessor::class, false)) {
+        class DeleteProcessor extends \MODX\Revolution\Processors\DeleteProcessor
+        {
+        }
+    }
+
+    if (!class_exists(RemoveProcessor::class, false)) {
+        class RemoveProcessor extends \MODX\Revolution\Processors\ModelProcessor
+        {
+        }
+    }
+}
+
+namespace MODX\Revolution\Processors\Resource {
+    if (!class_exists(Create::class, false)) {
+        class Create extends \MODX\Revolution\Processors\CreateProcessor
+        {
+        }
+    }
+
+    if (!class_exists(Update::class, false)) {
+        class Update extends \MODX\Revolution\Processors\UpdateProcessor
+        {
+        }
+    }
+
+    if (!class_exists(Delete::class, false)) {
+        class Delete extends \MODX\Revolution\Processors\DeleteProcessor
+        {
+        }
+    }
+
+    if (!class_exists(Publish::class, false)) {
+        class Publish extends \MODX\Revolution\Processors\ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(Unpublish::class, false)) {
+        class Unpublish extends \MODX\Revolution\Processors\ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(Undelete::class, false)) {
+        class Undelete extends \MODX\Revolution\Processors\ModelProcessor
+        {
+        }
+    }
+
+    if (!class_exists(GetNodes::class, false)) {
+        class GetNodes extends \MODX\Revolution\Processors\ModelProcessor
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Описание

`Product/Sort.php` и `Product/Multiple.php` задают `$permission = 'msproduct_save'` (как Gallery в #661). Без права менеджер больше не проходит `ModelProcessor::checkPermissions()` до записи `menuindex` / bulk-диспетчера.

Smoke `ProcessorPermissionsSmokeTest` обходит весь `src/Processors/` и резолвит `$permission` через `ReflectionClass` (наследование Hide/Show/UpdateFromGrid). Читающие Product-процессоры и прочие отложенные Multiple — в allowlist с причиной (в политике нет `msproduct_list`; Settings/Customer Multiple — follow-up).

## Тип изменений

- [x] Исправление бага (non-breaking change)

## Связанные Issues

Closes #672

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Processors/Product/Sort.php
php -l src/Processors/Product/Multiple.php
php tests/ProcessorPermissionsSmokeTest.php
# OK ProcessorPermissionsSmokeTest (104 processors, 28 allowlisted empty)
```

- [x] Автоматические тесты (smoke)
- [ ] Ручное тестирование connector без `msproduct_save`

**Конфигурация тестирования:**
- MiniShop3: `fix/issue-672-product-processor-permissions` от `beta`
- PHP: локальный CLI

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Лексиконы не требуются (ошибка доступа — стандарт MODX)
- [ ] CHANGELOG — при релизе

## Дополнительные заметки

Решение по read-процессорам: без нового права, allowlist. Deferred: Settings/Customer `*/Multiple.php` без `$permission` (отдельный issue по образцу #661/#672).