### PR TITLE
fix(api): не отдавать пустое тело менеджерского API при битом UTF-8

### DIFF
--- a/core/components/minishop3/src/Processors/Api/ProcessesManagerConnectorRouteTrait.php
+++ b/core/components/minishop3/src/Processors/Api/ProcessesManagerConnectorRouteTrait.php
@@ -2,6 +2,7 @@
 
 namespace MiniShop3\Processors\Api;
 
+use MiniShop3\Router\Response;
 use MiniShop3\Router\Router as ApiRouter;
 
 /**
@@ -65,14 +66,9 @@ trait ProcessesManagerConnectorRouteTrait
 
             http_response_code($statusCode);
 
-            if ($statusCode >= 200 && $statusCode < 300) {
-                return $this->success('', $responseData['data'] ?? $responseData);
-            }
-
-            return $this->failure(
-                $responseData['message'] ?? 'API request failed',
-                $responseData
-            );
+            // Sanitize before Processor success()/failure() → modConnectorResponse → xPDO::toJSON()
+            // which has no UTF-8 fallback (#671 / #654).
+            return $this->respondFromRouter($responseData, $statusCode);
         } catch (\Throwable $e) {
             // TypeError/Error must stay JSON — display_errors HTML breaks Vue request.json() (#531/#532).
             $this->modx->log(\MODX\Revolution\modX::LOG_LEVEL_ERROR, '[MiniShop3 API] ' . $e->getMessage());
@@ -85,5 +81,35 @@ trait ProcessesManagerConnectorRouteTrait
                 ['code' => 500]
             );
         }
+    }
+
+    /**
+     * Map router Response payload to MODX Processor success()/failure() after UTF-8 sanitize (#671).
+     *
+     * @param mixed $responseData Router Response::getData()
+     * @internal Exposed for unit tests of the manager connector reshape path.
+     */
+    protected function respondFromRouter(mixed $responseData, int $statusCode): mixed
+    {
+        $payload = is_array($responseData) ? $responseData : ['code' => $statusCode];
+        $clean = Response::sanitizeUtf8ForJson($payload, $this->modx);
+        if (!is_array($clean)) {
+            return $this->connectorJsonEncodeFailure();
+        }
+
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return $this->success('', $clean['data'] ?? $clean);
+        }
+
+        $message = (string) ($clean['message'] ?? 'API request failed');
+
+        return $this->failure($message !== '' ? $message : 'API request failed', $clean);
+    }
+
+    private function connectorJsonEncodeFailure(): mixed
+    {
+        http_response_code(500);
+
+        return $this->failure('Internal server error', ['code' => 500]);
     }
 }

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -24,6 +24,8 @@ class Response
     /** @var string|null HTTP redirect target (Location) */
     protected ?string $redirectUrl = null;
 
+    private const JSON_ENCODE_FLAGS = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
     public function __construct($data, int $statusCode = HttpStatus::OK, array $headers = [])
     {
         $this->data = $data;
@@ -304,20 +306,11 @@ class Response
      */
     public function encodeJsonBody(?object $modx = null): string
     {
-        $flags = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
-        $json = json_encode($this->data, $flags);
-        if ($json !== false) {
+        $json = self::encodeJsonUtf8Safe($this->data, $modx);
+        if ($json !== null) {
             return $json;
         }
 
-        self::logJsonEncodeFailure($modx, json_last_error_msg(), $this->data);
-
-        $json = json_encode($this->data, $flags | JSON_INVALID_UTF8_SUBSTITUTE);
-        if ($json !== false) {
-            return $json;
-        }
-
-        self::logJsonEncodeFailure($modx, json_last_error_msg(), $this->data, true);
         $this->statusCode = HttpStatus::INTERNAL_SERVER_ERROR;
         $this->data = [
             'success' => false,
@@ -327,8 +320,63 @@ class Response
             'error_code' => ApiErrorCode::INTERNAL_ERROR,
         ];
 
-        $fallback = json_encode($this->data, $flags);
+        $fallback = json_encode($this->data, self::JSON_ENCODE_FLAGS);
         return $fallback !== false ? $fallback : '{"success":false,"message":"Internal server error","code":500,"errors":null,"error_code":"internal_error"}';
+    }
+
+    /**
+     * Return a JSON-encodable copy of $data for MODX connector toJSON() (#671).
+     *
+     * Same UTF-8 handling as {@see encodeJsonBody()}: log invalid paths (hex snippets only),
+     * then substitute invalid sequences. Returns $data unchanged when already encodable.
+     * When encoding still fails (e.g. NAN), returns null so the caller can fail closed.
+     */
+    public static function sanitizeUtf8ForJson(mixed $data, ?object $modx = null): mixed
+    {
+        if (json_encode($data, self::JSON_ENCODE_FLAGS) !== false) {
+            return $data;
+        }
+
+        $json = self::encodeJsonSubstitutingUtf8($data, $modx);
+        if ($json === null) {
+            return null;
+        }
+
+        $decoded = json_decode($json, true);
+
+        return json_last_error() === JSON_ERROR_NONE ? $decoded : null;
+    }
+
+    /**
+     * json_encode with UTF-8 substitute fallback and MODX logging (#654 / #671).
+     *
+     * @return string|null JSON string, or null when unencodable even after substitute.
+     */
+    private static function encodeJsonUtf8Safe(mixed $data, ?object $modx): ?string
+    {
+        $json = json_encode($data, self::JSON_ENCODE_FLAGS);
+        if ($json !== false) {
+            return $json;
+        }
+
+        return self::encodeJsonSubstitutingUtf8($data, $modx);
+    }
+
+    /**
+     * Log + re-encode with JSON_INVALID_UTF8_SUBSTITUTE after a failed first encode.
+     */
+    private static function encodeJsonSubstitutingUtf8(mixed $data, ?object $modx): ?string
+    {
+        self::logJsonEncodeFailure($modx, json_last_error_msg(), $data);
+
+        $json = json_encode($data, self::JSON_ENCODE_FLAGS | JSON_INVALID_UTF8_SUBSTITUTE);
+        if ($json === false) {
+            self::logJsonEncodeFailure($modx, json_last_error_msg(), $data, true);
+
+            return null;
+        }
+
+        return $json;
     }
 
     /**

--- a/core/components/minishop3/tests/RouterRoutePlansTest.php
+++ b/core/components/minishop3/tests/RouterRoutePlansTest.php
@@ -112,6 +112,9 @@ if (!str_contains($traitSrc, 'http_response_code(404)')) {
 if (!str_contains($traitSrc, 'catch (\\Throwable')) {
     $fail('trait must catch \\Throwable so TypeError stays JSON (#531/#532)');
 }
+if (!str_contains($traitSrc, 'respondFromRouter') || !str_contains($traitSrc, 'sanitizeUtf8ForJson')) {
+    $fail('trait must sanitize UTF-8 via respondFromRouter before success()/failure() (#671)');
+}
 if (str_contains($traitSrc, 'loadWebRoutes') || str_contains($traitSrc, 'ManagerConnectorRouteLoader')) {
     $fail('trait must not load web routes or use deleted ManagerConnectorRouteLoader');
 }

--- a/core/components/minishop3/tests/Unit/Router/ResponseJsonEncodeTest.php
+++ b/core/components/minishop3/tests/Unit/Router/ResponseJsonEncodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Unit\Router;
 
+use MiniShop3\Processors\Api\ProcessesManagerConnectorRouteTrait;
 use MiniShop3\Router\ApiErrorCode;
 use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
@@ -55,6 +56,73 @@ final class ResponseJsonEncodeTest extends TestCase
         );
     }
 
+    public function testSanitizeUtf8ForJsonSubstitutesInvalidBytes(): void
+    {
+        $modx = $this->makeLogger();
+        $clean = Response::sanitizeUtf8ForJson(['label' => "ab\xC3\x28cd"], $modx);
+
+        self::assertIsArray($clean);
+        self::assertIsString($clean['label']);
+        self::assertStringContainsString("\u{FFFD}", $clean['label']);
+        self::assertNotFalse(json_encode($clean));
+        self::assertNotEmpty($modx->logs);
+        self::assertStringContainsString('label', $modx->logs[0]);
+        self::assertStringContainsString('hex=', $modx->logs[0]);
+    }
+
+    public function testSanitizeUtf8ForJsonLeavesValidDataUnchanged(): void
+    {
+        $payload = ['title' => 'Товар', 'n' => 1];
+        self::assertSame($payload, Response::sanitizeUtf8ForJson($payload));
+    }
+
+    public function testSanitizeUtf8ForJsonReturnsNullWhenUnencodable(): void
+    {
+        $modx = $this->makeLogger();
+        self::assertNull(Response::sanitizeUtf8ForJson(['value' => NAN], $modx));
+        self::assertNotEmpty($modx->logs);
+    }
+
+    /**
+     * Manager connector path: trait respondFromRouter → Processor success → xPDO-style json_encode (#671).
+     */
+    public function testManagerConnectorRespondFromRouterSurvivesBareJsonEncode(): void
+    {
+        $modx = $this->makeLogger();
+        $harness = $this->makeConnectorHarness($modx);
+        $apiData = [
+            'success' => true,
+            'message' => null,
+            'data' => ['fields' => [['label' => "bad\xC3\x28"]]],
+        ];
+
+        $result = $harness->exposeRespond($apiData, 200);
+
+        self::assertTrue($result['success']);
+        self::assertArrayHasKey('object', $result);
+        // Mirrors xPDO::toJSON / modConnectorResponse (no flags, no false check).
+        $encoded = json_encode($result);
+        self::assertNotFalse($encoded);
+        self::assertNotSame('', $encoded);
+        $decoded = json_decode($encoded, true);
+        self::assertStringContainsString("\u{FFFD}", $decoded['object']['fields'][0]['label']);
+        self::assertNotEmpty($modx->logs);
+    }
+
+    public function testManagerConnectorRespondFromRouterFailsClosedOnNan(): void
+    {
+        $modx = $this->makeLogger();
+        $harness = $this->makeConnectorHarness($modx);
+        $result = $harness->exposeRespond(['success' => false, 'message' => 'x', 'value' => NAN], 400);
+
+        self::assertFalse($result['success']);
+        self::assertSame('Internal server error', $result['message']);
+        self::assertSame(['code' => 500], $result['object']);
+        $encoded = json_encode($result);
+        self::assertNotFalse($encoded);
+        self::assertNotSame('', $encoded);
+    }
+
     public function testNonUtf8EncodeFailureFallsBackTo500Envelope(): void
     {
         $modx = $this->makeLogger();
@@ -79,6 +147,51 @@ final class ResponseJsonEncodeTest extends TestCase
             public function log($level, $message): void
             {
                 $this->logs[] = (string) $message;
+            }
+        };
+    }
+
+    /**
+     * Minimal Processor stand-in that exercises trait respondFromRouter (#671).
+     */
+    private function makeConnectorHarness(object $modx): object
+    {
+        return new class ($modx) {
+            use ProcessesManagerConnectorRouteTrait;
+
+            public object $modx;
+
+            public function __construct(object $modx)
+            {
+                $this->modx = $modx;
+            }
+
+            public function exposeRespond(mixed $responseData, int $statusCode): mixed
+            {
+                return $this->respondFromRouter($responseData, $statusCode);
+            }
+
+            public function success($message = '', $object = null): array
+            {
+                return [
+                    'success' => true,
+                    'message' => $message,
+                    'object' => $object,
+                ];
+            }
+
+            public function failure($message = '', $object = null): array
+            {
+                return [
+                    'success' => false,
+                    'message' => $message,
+                    'object' => $object,
+                ];
+            }
+
+            public function getProperty($key, $default = null): mixed
+            {
+                return $default;
             }
         };
     }


### PR DESCRIPTION
## Описание

Менеджерский connector путь (`ProcessesManagerConnectorRouteTrait` → `success()`/`failure()` → `xPDO::toJSON`) при невалидном UTF-8 отдавал пустое тело: `json_encode` без флагов возвращал `false`, `die(false)` печатал пустую строку.

До передачи в процессор данные проходят через `Response::sanitizeUtf8ForJson()` (тот же log + `JSON_INVALID_UTF8_SUBSTITUTE`, что у витринного `#662`). При невозможности кодирования (например NAN) — fail-closed 500 с непустым JSON.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #671

Связано: #654, #662, #618, #619

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Router/Response.php
php -l src/Processors/Api/ProcessesManagerConnectorRouteTrait.php
# exit 0

./vendor/bin/phpunit tests/Unit/Router/ResponseJsonEncodeTest.php
# OK (9 tests, 41 assertions), exit 0

php tests/RouterRoutePlansTest.php
# OK: RouterRoutePlansTest, exit 0
```

Покрыто: substitute битого UTF-8, identity для валидных данных, null на NAN, путь `respondFromRouter` → bare `json_encode` как у `xPDO::toJSON`, fail-closed 500.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-671-manager-utf8-json`
- MODX: n/a (unit)
- PHP: 8.4.23

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Лексиконы и Vue не затронуты. CHANGELOG оставляем на релиз. Витринный путь (`encodeJsonBody` / `api.php`) без изменений контракта, общая логика вынесена в `encodeJsonSubstitutingUtf8`.