### PR TITLE
Quote customer-grid relation SQL identifiers

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
+++ b/core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
@@ -8,6 +8,7 @@ use MiniShop3\Router\HttpStatus;
 use MiniShop3\Router\Response;
 use MiniShop3\Services\Customer\AuthManager;
 use MiniShop3\Services\Grid\ManagerListFilterPolicy;
+use MiniShop3\Services\Grid\RelationSqlFragments;
 use MODX\Revolution\modX;
 
 /**
@@ -421,7 +422,7 @@ class CustomersController
             }
         }
 
-        $customersTable = $this->modx->getTableName(msCustomer::class);
+        $customersTable = (string) $this->modx->getTableName(msCustomer::class);
 
         foreach ($relationFields as $fieldName => $config) {
             $relationTable = $config['resolvedTableName'] ?? $config['table'] ?? null;
@@ -433,31 +434,26 @@ class CustomersController
                 continue;
             }
 
+            $relationTable = RelationSqlFragments::stripIdentQuotes((string) $relationTable);
+
             // Fallback for configs saved before table prefix fix — can be removed
             // after all existing relation configs are re-saved via utility page
             $tablePrefix = $this->modx->config['table_prefix'] ?? '';
-            if ($tablePrefix !== ''
-                && !str_starts_with($relationTable, $tablePrefix)
-                && !str_starts_with($relationTable, '`')
-            ) {
+            if ($tablePrefix !== '' && !str_starts_with($relationTable, $tablePrefix)) {
                 $relationTable = $tablePrefix . $relationTable;
             }
 
-            if ($aggregation) {
-                $selectExpr = "{$aggregation}({$relationTable}.{$displayField})";
-            } else {
-                $selectExpr = "{$relationTable}.{$displayField}";
+            $sql = RelationSqlFragments::customerRelationAggregateSql(
+                $customersTable,
+                $relationTable,
+                (string) $foreignKey,
+                (string) $displayField,
+                is_string($aggregation) && $aggregation !== '' ? $aggregation : null,
+                $customerIds,
+            );
+            if ($sql === null) {
+                continue;
             }
-
-            $sql = "
-                SELECT
-                    {$customersTable}.id as customer_id,
-                    {$selectExpr} as field_value
-                FROM {$customersTable}
-                LEFT JOIN {$relationTable} ON {$relationTable}.{$foreignKey} = {$customersTable}.id
-                WHERE {$customersTable}.id IN (" . implode(',', $customerIds) . ")
-                GROUP BY {$customersTable}.id
-            ";
 
             $stmt = $this->modx->prepare($sql);
             $stmt->execute();
@@ -467,9 +463,10 @@ class CustomersController
                 $customerId = (int)$row['customer_id'];
                 $value = $row['field_value'];
 
-                if ($aggregation === 'COUNT') {
+                $aggUpper = is_string($aggregation) ? strtoupper($aggregation) : null;
+                if ($aggUpper === 'COUNT') {
                     $value = (int)$value;
-                } elseif (in_array($aggregation, ['SUM', 'AVG'])) {
+                } elseif (in_array($aggUpper, ['SUM', 'AVG'], true)) {
                     $value = (float)$value;
                 }
 

--- a/core/components/minishop3/src/Services/Grid/RelationSqlFragments.php
+++ b/core/components/minishop3/src/Services/Grid/RelationSqlFragments.php
@@ -15,7 +15,17 @@ final class RelationSqlFragments
 
     public static function quoteIdent(string $name): string
     {
-        return '`' . str_replace('`', '``', $name) . '`';
+        // Names may arrive already quoted (e.g. xPDO getTableName). Strip then wrap.
+        // Charset-validated identifiers never contain backticks, so no `` escape needed.
+        return '`' . self::stripIdentQuotes($name) . '`';
+    }
+
+    /**
+     * Remove MySQL identifier quotes before re-quoting or prefix checks.
+     */
+    public static function stripIdentQuotes(string $name): string
+    {
+        return str_replace('`', '', $name);
     }
 
     public static function joinEqualsId(string $alias, string $localAlias, string $foreignKey): string
@@ -33,5 +43,57 @@ final class RelationSqlFragments
     public static function columnRef(string $alias, string $column): string
     {
         return self::quoteIdent($alias) . '.' . self::quoteIdent($column);
+    }
+
+    /**
+     * Aggregate SELECT for customer-grid relation columns (JOIN direction: relation.fk = customers.id).
+     *
+     * Uses charset-only identifier checks (grandfather reserved words) + quoting, same as RelationColumnSpec.
+     *
+     * @param list<int> $customerIds
+     */
+    public static function customerRelationAggregateSql(
+        string $customersTable,
+        string $relationTable,
+        string $foreignKey,
+        string $displayField,
+        ?string $aggregation,
+        array $customerIds,
+    ): ?string {
+        $ids = array_values(array_filter(array_map('intval', $customerIds), static fn (int $id): bool => $id > 0));
+        if ($ids === []) {
+            return null;
+        }
+
+        $customersTable = self::stripIdentQuotes($customersTable);
+        $relationTable = self::stripIdentQuotes($relationTable);
+        $foreignKey = self::stripIdentQuotes($foreignKey);
+        $displayField = self::stripIdentQuotes($displayField);
+
+        foreach ([$customersTable, $relationTable, $foreignKey, $displayField] as $ident) {
+            if (!GridColumnRules::matchesSqlIdentifierPattern($ident)) {
+                return null;
+            }
+        }
+
+        $agg = ($aggregation !== null && $aggregation !== '') ? strtoupper($aggregation) : null;
+        if ($agg !== null && !in_array($agg, ['COUNT', 'SUM', 'AVG', 'MIN', 'MAX'], true)) {
+            return null;
+        }
+
+        $column = self::columnRef($relationTable, $displayField);
+        $selectExpr = $agg !== null ? "{$agg}({$column})" : $column;
+        $customersId = self::columnRef($customersTable, 'id');
+        $joinOn = self::columnRef($relationTable, $foreignKey) . ' = ' . $customersId;
+
+        return "
+                SELECT
+                    {$customersId} as customer_id,
+                    {$selectExpr} as field_value
+                FROM " . self::quoteIdent($customersTable) . "
+                LEFT JOIN " . self::quoteIdent($relationTable) . " ON {$joinOn}
+                WHERE {$customersId} IN (" . implode(',', $ids) . ")
+                GROUP BY {$customersId}
+            ";
     }
 }

--- a/core/components/minishop3/tests/RelationColumnSpecTest.php
+++ b/core/components/minishop3/tests/RelationColumnSpecTest.php
@@ -142,5 +142,61 @@ $assertSame(
     'RelationSqlFragments order join'
 );
 
+$assertSame('modx_ms3_orders', RelationSqlFragments::stripIdentQuotes('`modx_ms3_orders`'), 'stripIdentQuotes');
+
+$customersSql = RelationSqlFragments::customerRelationAggregateSql(
+    '`modx_ms3_customers`',
+    'modx_ms3_orders',
+    'user_id',
+    'rank',
+    'COUNT',
+    [1, 2],
+);
+$assertTrue(
+    is_string($customersSql)
+    && str_contains($customersSql, '`modx_ms3_orders`.`rank`')
+    && str_contains($customersSql, 'COUNT(`modx_ms3_orders`.`rank`)')
+    && str_contains($customersSql, 'LEFT JOIN `modx_ms3_orders` ON `modx_ms3_orders`.`user_id` = `modx_ms3_customers`.`id`')
+    && str_contains($customersSql, 'IN (1,2)'),
+    'customerRelationAggregateSql quotes reserved displayField and tables'
+);
+
+$fkSql = RelationSqlFragments::customerRelationAggregateSql(
+    'modx_ms3_customers',
+    'modx_ms3_orders',
+    'order',
+    'cost',
+    'SUM',
+    [5],
+);
+$assertTrue(
+    is_string($fkSql) && str_contains($fkSql, '`modx_ms3_orders`.`order`'),
+    'customerRelationAggregateSql quotes reserved foreignKey'
+);
+
+$assertTrue(
+    RelationSqlFragments::customerRelationAggregateSql(
+        'c',
+        'r',
+        'fk',
+        'col',
+        'DROP',
+        [1],
+    ) === null,
+    'customerRelationAggregateSql rejects unknown aggregation'
+);
+
+$assertTrue(
+    RelationSqlFragments::customerRelationAggregateSql(
+        'modx_ms3_customers',
+        'modx_ms3_orders',
+        'user_id',
+        'address; DROP TABLE',
+        'COUNT',
+        [1],
+    ) === null,
+    'customerRelationAggregateSql rejects invalid identifier charset'
+);
+
 fwrite(STDOUT, "OK RelationColumnSpecTest\n");
 exit(0);


### PR DESCRIPTION
## Описание

В гриде покупателей relation-агрегация собирала SQL без квотирования идентификаторов. Зарезервированные имена MySQL 8 (`rank`, `order` и т.п.) ломали запрос. Теперь фрагменты идут через `RelationSqlFragments` (как в пути заказов из #663): квотирование, charset-check, allowlist агрегаций.

Depends on #663 (`RelationSqlFragments`). После merge #663 retarget на `beta`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #673

## Как это было протестировано?

```bash
php -l core/components/minishop3/src/Services/Grid/RelationSqlFragments.php
# exit 0
php -l core/components/minishop3/src/Controllers/Api/Manager/CustomersController.php
# exit 0
php core/components/minishop3/tests/RelationColumnSpecTest.php
# EXIT:0 — OK RelationColumnSpecTest
```

Vue / полный `composer ci:php` не гонялись: PHP-only, без vueManager.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка PR (поверх #663)
- MODX: n/a (smoke без bootstrap)
- PHP: локальный CLI

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Скан `src` по сырой подстановке `$displayField` / `$foreignKey` в SQL: после #663 оставался только `CustomersController`. Заказы и category-products уже на `RelationSqlFragments`.