### PR TITLE
Live MODX tests via modxkit/testbench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2']
-        modx: ['3.1.2-pl', '3.2.3-pl']
+        modx: ['3.1.2-pl', '3.2.3-pl', '3.2.4-pl']
 
     services:
       mysql:
@@ -105,7 +105,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: pdo_mysql, zip
+          extensions: pdo_mysql, zip, gd
           tools: composer:v2
 
       - name: Cache testbench MODX releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,68 @@ jobs:
       - name: PHP syntax check + smoke + PHPUnit
         run: composer ci:php
 
+  modx-testbench:
+    name: MODX testbench (${{ matrix.modx }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: core/components/minishop3
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2']
+        modx: ['3.1.2-pl', '3.2.3-pl']
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: modx_testbench
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+
+    env:
+      MODX_TESTBENCH_VERSION: ${{ matrix.modx }}
+      MODX_TESTBENCH_DB_HOST: 127.0.0.1
+      MODX_TESTBENCH_DB_PORT: 3306
+      MODX_TESTBENCH_DB_NAME: modx_testbench
+      MODX_TESTBENCH_DB_USER: root
+      MODX_TESTBENCH_DB_PASS: root
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: pdo_mysql, zip
+          tools: composer:v2
+
+      - name: Cache testbench MODX releases
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/modx-testbench/releases
+          key: testbench-releases-${{ matrix.modx }}-${{ runner.os }}
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Install MODX testbench environment
+        run: vendor/bin/modx-testbench install
+
+      - name: Live MODX PHPUnit
+        run: composer test:modx
+
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ assets/customScript.js
 !CHANGELOG.md
 !changelogs/*.md
 !.github/**/*.md
+!core/components/minishop3/tests/**/*.md
 
 # Environment
 .env

--- a/core/components/minishop3/composer.json
+++ b/core/components/minishop3/composer.json
@@ -40,6 +40,11 @@
   },
   "minimum-stability": "stable",
   "prefer-stable": true,
+  "config": {
+    "platform": {
+      "php": "8.2.0"
+    }
+  },
   "suggest": {
     "ext-redis": "Shared rate-limit counters for multi-node Web API (ms3_rate_limit_store=redis)",
     "ext-memcached": "Alternative shared rate-limit storage (ms3_rate_limit_store=memcached)"
@@ -47,6 +52,7 @@
   "require-dev": {
     "modxkit/testbench": "^1.0",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^11.5"
+    "phpunit/phpunit": "^11.5",
+    "symfony/process": "^6.4.33 || ^7.1.7"
   }
 }

--- a/core/components/minishop3/composer.json
+++ b/core/components/minishop3/composer.json
@@ -30,7 +30,10 @@
   "scripts": {
     "test": "phpunit",
     "test:smoke": "php tests/run-smoke.php",
+    "test:unit": "phpunit --testsuite Unit",
+    "test:integration": "phpunit --testsuite Integration",
     "test:web-api": "phpunit --testsuite WebApi",
+    "test:modx": "phpunit -c phpunit.modx.xml --testsuite Modx",
     "ci:php": "bash scripts/ci-php.sh",
     "stan:prepare": "bash scripts/phpstan-prepare-deps.sh",
     "stan": "vendor/bin/phpstan analyse -c ../../../phpstan.neon --memory-limit=1G"
@@ -42,6 +45,7 @@
     "ext-memcached": "Alternative shared rate-limit storage (ms3_rate_limit_store=memcached)"
   },
   "require-dev": {
+    "modxkit/testbench": "^1.0",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.5"
   }

--- a/core/components/minishop3/composer.lock
+++ b/core/components/minishop3/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "541a2bb3a6d325164f8600968e830d0d",
+    "content-hash": "04ae27b660f08e56f67dc68b5622bf58",
     "packages": [
         {
             "name": "brick/math",
@@ -2049,6 +2049,73 @@
     ],
     "packages-dev": [
         {
+            "name": "modxkit/testbench",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/modxkit/testbench.git",
+                "reference": "82edb0cb797b86d85762043b7353e6b529893fe6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/modxkit/testbench/zipball/82edb0cb797b86d85762043b7353e6b529893fe6",
+                "reference": "82edb0cb797b86d85762043b7353e6b529893fe6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-pdo": "*",
+                "ext-pdo_mysql": "*",
+                "ext-zip": "*",
+                "php": ">=8.2",
+                "phpunit/phpunit": "^10.5.62|^11.5.50|^12.5.22",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4.33|^7.1.7|^8.0"
+            },
+            "require-dev": {
+                "ext-posix": "*",
+                "friendsofphp/php-cs-fixer": "^3.94",
+                "phpstan/phpstan": "^2.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "rector/rector": "^2.3"
+            },
+            "bin": [
+                "bin/modx-testbench"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ModxKit\\Testbench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prihod",
+                    "email": "prihod2004@gmail.com"
+                }
+            ],
+            "description": "Automated testing environment for MODX Revolution 3 extras",
+            "homepage": "https://github.com/modxkit/testbench",
+            "keywords": [
+                "Extras",
+                "TestBench",
+                "modx",
+                "modx-revolution",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/modxkit/testbench/issues",
+                "source": "https://github.com/modxkit/testbench"
+            },
+            "time": "2026-09-05T15:17:10+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -3825,6 +3892,71 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v8.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d863f5e70d7c87abb906ac11b61f83036093000b",
+                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v8.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/core/components/minishop3/composer.lock
+++ b/core/components/minishop3/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04ae27b660f08e56f67dc68b5622bf58",
+    "content-hash": "7c4fc0fe2c7b84b12d6a8fe1f094d136",
     "packages": [
         {
             "name": "brick/math",
@@ -3895,20 +3895,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.1.6",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b"
+                "reference": "058d17fc284cce14efb2385783b55014a461b176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d863f5e70d7c87abb906ac11b61f83036093000b",
-                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/058d17fc284cce14efb2385783b55014a461b176",
+                "reference": "058d17fc284cce14efb2385783b55014a461b176",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -3936,7 +3936,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.1.6"
+                "source": "https://github.com/symfony/process/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -3956,7 +3956,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T17:47:34+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4018,5 +4018,8 @@
         "php": ">=8.2"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/core/components/minishop3/phpunit.modx.xml
+++ b/core/components/minishop3/phpunit.modx.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        bootstrap="vendor/modxkit/testbench/bootstrap.php"
+        colors="true"
+        cacheDirectory=".phpunit.cache/modx"
+        beStrictAboutOutputDuringTests="true"
+        failOnRisky="true"
+        failOnWarning="true">
+    <testsuites>
+        <testsuite name="Modx">
+            <directory>tests/Modx</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/core/components/minishop3/phpunit.modx.xml
+++ b/core/components/minishop3/phpunit.modx.xml
@@ -9,7 +9,7 @@
         failOnWarning="true">
     <testsuites>
         <testsuite name="Modx">
-            <directory>tests/Modx</directory>
+            <directory suffix="Test.php">tests/Modx</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/core/components/minishop3/tests/Modx/CustomerRegisterLiveTest.php
+++ b/core/components/minishop3/tests/Modx/CustomerRegisterLiveTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Services\Customer\RegisterService;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class CustomerRegisterLiveTest extends ExtraTestCase
+{
+    public function testRegisterServiceCreatesCustomerWhenVerificationIsOff(): void
+    {
+        $this->setSetting('ms3_customer_require_email_verification', '0');
+        $this->setSetting('ms3_customer_send_welcome_email', '0');
+        $this->modx->lexicon->load('minishop3:default', 'minishop3:customer');
+
+        $email = 'tb-reg-' . bin2hex(random_bytes(4)) . '@example.invalid';
+        /** @var RegisterService $register */
+        $register = $this->modx->services->get('ms3_register_service');
+        $result = $register->register([
+            'email' => $email,
+            'password' => 'Secret123!',
+            'first_name' => 'TB',
+            'last_name' => 'User',
+            'privacy_accepted' => true,
+        ]);
+
+        self::assertTrue($result['success'], $result['message'] ?? 'register failed');
+        self::assertInstanceOf(msCustomer::class, $result['customer'] ?? null);
+        $this->assertObjectExists(msCustomer::class, ['email' => $email]);
+    }
+
+    public function testRegisterServiceRejectsInvalidEmail(): void
+    {
+        $this->modx->lexicon->load('minishop3:default', 'minishop3:customer');
+        /** @var RegisterService $register */
+        $register = $this->modx->services->get('ms3_register_service');
+        $result = $register->register([
+            'email' => 'not-an-email',
+            'password' => 'Secret123!',
+        ]);
+
+        self::assertFalse($result['success']);
+        $this->assertObjectMissing(msCustomer::class, ['email' => 'not-an-email']);
+    }
+}

--- a/core/components/minishop3/tests/Modx/ExtraFieldMapTest.php
+++ b/core/components/minishop3/tests/Modx/ExtraFieldMapTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msExtraField;
+use MiniShop3\Model\msVendor;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+use MiniShop3\Utils\ExtraFields;
+
+final class ExtraFieldMapTest extends ExtraTestCase
+{
+    public function testActiveExtraFieldIsMergedIntoXpdoMap(): void
+    {
+        $key = 'tb_note_' . bin2hex(random_bytes(3));
+        $this->persistObject(msVendor::class, ['name' => 'TB Extra Host']);
+        $this->persistObject(msExtraField::class, [
+            'class' => msVendor::class,
+            'key' => $key,
+            'label' => 'TB Note',
+            'dbtype' => 'varchar',
+            'phptype' => 'string',
+            'precision' => '191',
+            'null' => 1,
+            'active' => 1,
+        ]);
+
+        $extra = new ExtraFields($this->modx);
+        $extra->clearCache();
+        $extra->loadMap();
+
+        self::assertArrayHasKey($key, $this->modx->map[msVendor::class]['fields'] ?? []);
+        self::assertSame('varchar', $this->modx->map[msVendor::class]['fieldMeta'][$key]['dbtype'] ?? null);
+        self::assertSame('string', $this->modx->map[msVendor::class]['fieldMeta'][$key]['phptype'] ?? null);
+    }
+}

--- a/core/components/minishop3/tests/Modx/ModelPersistTest.php
+++ b/core/components/minishop3/tests/Modx/ModelPersistTest.php
@@ -73,6 +73,8 @@ final class ModelPersistTest extends ExtraTestCase
 
         $this->persistObject(msOrderProduct::class, [
             'order_id' => $order->get('id'),
+            'product_id' => 0,
+            'product_key' => substr(md5('tb-line-' . $suffix), 0, 32),
             'name' => 'TB Line',
             'count' => 1,
             'price' => 25.5,

--- a/core/components/minishop3/tests/Modx/ModelPersistTest.php
+++ b/core/components/minishop3/tests/Modx/ModelPersistTest.php
@@ -90,6 +90,7 @@ final class ModelPersistTest extends ExtraTestCase
             'order_id' => $order->get('id'),
             'action' => 'testbench',
             'entry' => ['ok' => true],
+            'ip' => ['ip' => '127.0.0.1'],
             'timestamp' => $now,
         ]);
         $this->persistObject(msCustomerAddress::class, [

--- a/core/components/minishop3/tests/Modx/ModelPersistTest.php
+++ b/core/components/minishop3/tests/Modx/ModelPersistTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerAddress;
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msExtraField;
+use MiniShop3\Model\msGridField;
+use MiniShop3\Model\msLink;
+use MiniShop3\Model\msModelField;
+use MiniShop3\Model\msModelFieldSection;
+use MiniShop3\Model\msNotificationConfig;
+use MiniShop3\Model\msOption;
+use MiniShop3\Model\msOptionGroup;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderAddress;
+use MiniShop3\Model\msOrderLog;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msOrderStatus;
+use MiniShop3\Model\msPageSection;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductField;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Model\msProductOption;
+use MiniShop3\Model\msVendor;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class ModelPersistTest extends ExtraTestCase
+{
+    public function testSimpleObjectsPersist(): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $suffix = bin2hex(random_bytes(3));
+
+        $vendor = $this->persistObject(msVendor::class, ['name' => 'TB Vendor ' . $suffix]);
+        $delivery = $this->persistObject(msDelivery::class, ['name' => 'TB Delivery ' . $suffix]);
+        $payment = $this->persistObject(msPayment::class, ['name' => 'TB Payment ' . $suffix]);
+        $status = $this->persistObject(msOrderStatus::class, ['name' => 'TB Status ' . $suffix]);
+        $link = $this->persistObject(msLink::class, [
+            'name' => 'TB Link ' . $suffix,
+            'type' => 'many_to_many',
+        ]);
+        $group = $this->persistObject(msOptionGroup::class, [
+            'name' => 'TB Group ' . $suffix,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $option = $this->persistObject(msOption::class, [
+            'key' => 'tb_color_' . $suffix,
+            'caption' => 'Color',
+            'type' => 'textfield',
+            'option_group_id' => $group->get('id'),
+        ]);
+        $customer = $this->persistObject(msCustomer::class, [
+            'email' => 'tb-' . $suffix . '@example.invalid',
+            'token' => bin2hex(random_bytes(16)),
+        ]);
+        $order = $this->persistObject(msOrder::class, [
+            'num' => 'TB-P-' . $suffix,
+            'cost' => 25.5,
+            'cart_cost' => 25.5,
+            'context' => 'web',
+            'status_id' => $status->get('id'),
+            'delivery_id' => $delivery->get('id'),
+            'payment_id' => $payment->get('id'),
+            'customer_id' => $customer->get('id'),
+        ]);
+
+        $this->persistObject(msOrderProduct::class, [
+            'order_id' => $order->get('id'),
+            'name' => 'TB Line',
+            'count' => 1,
+            'price' => 25.5,
+            'cost' => 25.5,
+        ]);
+        $this->persistObject(msOrderAddress::class, [
+            'order_id' => $order->get('id'),
+            'email' => 'tb-' . $suffix . '@example.invalid',
+            'city' => 'Test City',
+        ]);
+        $this->persistObject(msOrderLog::class, [
+            'user_id' => 0,
+            'order_id' => $order->get('id'),
+            'action' => 'testbench',
+            'entry' => ['ok' => true],
+            'timestamp' => $now,
+        ]);
+        $this->persistObject(msCustomerAddress::class, [
+            'customer_id' => $customer->get('id'),
+            'name' => 'Home',
+            'city' => 'Test City',
+        ]);
+        $this->persistObject(msCustomerToken::class, [
+            'customer_id' => $customer->get('id'),
+            'token' => 'tb-token-' . $suffix,
+            'type' => msCustomerToken::TYPE_API,
+            'expires_at' => date('Y-m-d H:i:s', time() + 3600),
+            'created_at' => $now,
+        ]);
+        $this->persistObject(msProductData::class, [
+            'article' => 'TB-' . $suffix,
+            'price' => 99.0,
+            'vendor_id' => $vendor->get('id'),
+        ]);
+        $this->persistObject(msProductFile::class, [
+            'product_id' => 1,
+            'file' => 'tb-' . $suffix . '.jpg',
+            'name' => 'tb.jpg',
+            'path' => '/',
+        ]);
+        $this->persistObject(msProductOption::class, [
+            'product_id' => 1,
+            'key' => 'tb_color_' . $suffix,
+            'value' => 'red',
+        ]);
+        $this->persistObject(msExtraField::class, [
+            'class' => msVendor::class,
+            'key' => 'tb_note_' . $suffix,
+            'label' => 'Note',
+            'dbtype' => 'varchar',
+            'phptype' => 'string',
+            'precision' => '191',
+            'active' => 0,
+        ]);
+        $this->persistObject(msGridField::class, [
+            'grid_key' => 'orders',
+            'field_name' => 'tb_' . $suffix,
+            'label' => 'TB',
+        ]);
+        $this->persistObject(msPageSection::class, [
+            'page_key' => 'order',
+            'section_key' => 'tb_' . $suffix,
+        ]);
+        $this->persistObject(msNotificationConfig::class, [
+            'event' => 'msOnChangeOrderStatus',
+            'recipient_type' => 'customer',
+            'channel' => 'email',
+        ]);
+        $this->persistObject(msModelFieldSection::class, [
+            'model' => 'msOrder',
+            'section_key' => 'tb_' . $suffix,
+            'label' => 'TB',
+        ]);
+        $this->persistObject(msModelField::class, [
+            'model' => 'msOrder',
+            'name' => 'tb_' . $suffix,
+            'label' => 'TB',
+        ]);
+        $this->persistObject(msProductField::class, [
+            'name' => 'tb_' . $suffix,
+            'label' => 'TB',
+            'section' => 'main',
+        ]);
+
+        $this->assertObjectExists(msVendor::class, ['name' => 'TB Vendor ' . $suffix]);
+        $this->assertObjectExists(msDelivery::class, ['name' => 'TB Delivery ' . $suffix]);
+        $this->assertObjectExists(msPayment::class, ['name' => 'TB Payment ' . $suffix]);
+        $this->assertObjectExists(msOrderStatus::class, ['name' => 'TB Status ' . $suffix]);
+        $this->assertObjectExists(msLink::class, ['name' => 'TB Link ' . $suffix]);
+        $this->assertObjectExists(msOption::class, ['key' => 'tb_color_' . $suffix]);
+        $this->assertObjectExists(msCustomer::class, ['email' => 'tb-' . $suffix . '@example.invalid']);
+        $this->assertObjectExists(msOrder::class, ['num' => 'TB-P-' . $suffix]);
+        $this->assertObjectExists(msCustomerToken::class, ['token' => 'tb-token-' . $suffix]);
+        $this->assertObjectExists(msNotificationConfig::class, [
+            'event' => 'msOnChangeOrderStatus',
+            'channel' => 'email',
+        ]);
+    }
+}

--- a/core/components/minishop3/tests/Modx/MsOrderPersistTest.php
+++ b/core/components/minishop3/tests/Modx/MsOrderPersistTest.php
@@ -26,6 +26,8 @@ final class MsOrderPersistTest extends ExtraTestCase
         $product = $this->modx->newObject(msOrderProduct::class);
         $product->fromArray([
             'order_id' => $order->get('id'),
+            'product_id' => 0,
+            'product_key' => substr(md5('tb-order-1-widget'), 0, 32),
             'name' => 'Widget',
             'count' => 2,
             'price' => 75.0,

--- a/core/components/minishop3/tests/Modx/MsOrderPersistTest.php
+++ b/core/components/minishop3/tests/Modx/MsOrderPersistTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class MsOrderPersistTest extends ExtraTestCase
+{
+    public function testOrderAndProductPersist(): void
+    {
+        $order = $this->modx->newObject(msOrder::class);
+        $order->fromArray([
+            'num' => 'TB-ORDER-1',
+            'cost' => 150.0,
+            'cart_cost' => 150.0,
+            'context' => 'web',
+        ]);
+
+        self::assertTrue($order->save());
+        $this->assertObjectExists(msOrder::class, ['num' => 'TB-ORDER-1']);
+
+        $product = $this->modx->newObject(msOrderProduct::class);
+        $product->fromArray([
+            'order_id' => $order->get('id'),
+            'name' => 'Widget',
+            'count' => 2,
+            'price' => 75.0,
+            'cost' => 150.0,
+        ]);
+
+        self::assertTrue($product->save());
+        $this->assertObjectExists(msOrderProduct::class, [
+            'order_id' => $order->get('id'),
+            'name' => 'Widget',
+        ]);
+    }
+}

--- a/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
+++ b/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+use MiniShop3\Utils\EventGate;
+use MODX\Revolution\modEvent;
+use MODX\Revolution\modPlugin;
+use MODX\Revolution\modPluginEvent;
+
+final class OrderSaveEventTest extends ExtraTestCase
+{
+    public function testMsOnSaveOrderPluginRunsAndEventGateSeesCancel(): void
+    {
+        $this->registerPlugin(
+            'msOnSaveOrder',
+            '$modx->setPlaceholder("ms3_testbench_save", "1"); return "cancel";',
+        );
+
+        $order = $this->modx->newObject(msOrder::class);
+        $order->fromArray([
+            'num' => 'TB-EVENT-1',
+            'cost' => 10.0,
+            'context' => 'web',
+        ]);
+        self::assertTrue($order->save());
+
+        self::assertSame('1', $this->modx->getPlaceholder('ms3_testbench_save'));
+
+        $result = $this->triggerEvent('msOnSaveOrder', [
+            'mode' => 'upd',
+            'object' => $order,
+            'msOrder' => $order,
+        ]);
+        self::assertIsArray($result);
+        self::assertTrue(EventGate::isCancelled($result));
+
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+        $gated = $ms3->utils->invokeEvent('msOnSaveOrder', [
+            'object' => $order,
+            'msOrder' => $order,
+        ]);
+        self::assertFalse($gated['success']);
+    }
+
+    private function registerPlugin(string $eventName, string $phpCode): void
+    {
+        $plugin = $this->modx->newObject(modPlugin::class);
+        $plugin->fromArray([
+            'name' => 'testbench-' . $eventName . '-' . bin2hex(random_bytes(3)),
+            'plugincode' => $phpCode,
+            'disabled' => false,
+        ]);
+        self::assertTrue($plugin->save(), 'Failed to save test plugin');
+
+        if ($this->modx->getCount(modEvent::class, ['name' => $eventName]) === 0) {
+            $event = $this->modx->newObject(modEvent::class);
+            $event->fromArray([
+                'name' => $eventName,
+                'service' => 1,
+                'groupname' => 'MiniShop3',
+            ]);
+            self::assertTrue($event->save(), 'Failed to save modEvent ' . $eventName);
+        }
+
+        $pluginEvent = $this->modx->newObject(modPluginEvent::class);
+        $pluginEvent->fromArray([
+            'pluginid' => $plugin->get('id'),
+            'event' => $eventName,
+            'priority' => 0,
+        ]);
+        self::assertTrue($pluginEvent->save(), 'Failed to attach plugin to ' . $eventName);
+
+        $pluginId = (int) $plugin->get('id');
+        $this->modx->pluginCache[(string) $pluginId] = $plugin->toArray();
+        $this->modx->eventMap[$eventName][$pluginId] = $pluginId;
+    }
+}

--- a/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
+++ b/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
@@ -8,9 +8,6 @@ use MiniShop3\MiniShop3;
 use MiniShop3\Model\msOrder;
 use MiniShop3\Tests\Modx\Support\ExtraTestCase;
 use MiniShop3\Utils\EventGate;
-use MODX\Revolution\modEvent;
-use MODX\Revolution\modPlugin;
-use MODX\Revolution\modPluginEvent;
 
 final class OrderSaveEventTest extends ExtraTestCase
 {
@@ -46,38 +43,5 @@ final class OrderSaveEventTest extends ExtraTestCase
             'msOrder' => $order,
         ]);
         self::assertFalse($gated['success']);
-    }
-
-    private function registerPlugin(string $eventName, string $phpCode): void
-    {
-        $plugin = $this->modx->newObject(modPlugin::class);
-        $plugin->fromArray([
-            'name' => 'testbench-' . $eventName . '-' . bin2hex(random_bytes(3)),
-            'plugincode' => $phpCode,
-            'disabled' => false,
-        ]);
-        self::assertTrue($plugin->save(), 'Failed to save test plugin');
-
-        if ($this->modx->getCount(modEvent::class, ['name' => $eventName]) === 0) {
-            $event = $this->modx->newObject(modEvent::class);
-            $event->fromArray([
-                'name' => $eventName,
-                'service' => 1,
-                'groupname' => 'MiniShop3',
-            ]);
-            self::assertTrue($event->save(), 'Failed to save modEvent ' . $eventName);
-        }
-
-        $pluginEvent = $this->modx->newObject(modPluginEvent::class);
-        $pluginEvent->fromArray([
-            'pluginid' => $plugin->get('id'),
-            'event' => $eventName,
-            'priority' => 0,
-        ]);
-        self::assertTrue($pluginEvent->save(), 'Failed to attach plugin to ' . $eventName);
-
-        $pluginId = (int) $plugin->get('id');
-        $this->modx->pluginCache[(string) $pluginId] = $plugin->toArray();
-        $this->modx->eventMap[$eventName][$pluginId] = $pluginId;
     }
 }

--- a/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
+++ b/core/components/minishop3/tests/Modx/OrderSaveEventTest.php
@@ -15,7 +15,8 @@ final class OrderSaveEventTest extends ExtraTestCase
     {
         $this->registerPlugin(
             'msOnSaveOrder',
-            '$modx->setPlaceholder("ms3_testbench_save", "1"); return "cancel";',
+            // invokeEvent collects $modx->event->_output, not the plugin return value.
+            '$modx->setPlaceholder("ms3_testbench_save", "1"); $modx->event->_output = "cancel";',
         );
 
         $order = $this->modx->newObject(msOrder::class);

--- a/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
+++ b/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msLink;
+use MiniShop3\Model\msOrderStatus;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Model\msVendor;
+use MiniShop3\Processors\Customer\Address\GetList as CustomerAddressGetList;
+use MiniShop3\Processors\Customer\GetList as CustomerGetList;
+use MiniShop3\Processors\Gallery\GetList as GalleryGetList;
+use MiniShop3\Processors\Product\GetList as ProductGetList;
+use MiniShop3\Processors\Settings\Delivery\Create as DeliveryCreate;
+use MiniShop3\Processors\Settings\Delivery\GetList as DeliveryGetList;
+use MiniShop3\Processors\Settings\Link\Create as LinkCreate;
+use MiniShop3\Processors\Settings\Link\GetList as LinkGetList;
+use MiniShop3\Processors\Settings\Payment\Create as PaymentCreate;
+use MiniShop3\Processors\Settings\Payment\Disable as PaymentDisable;
+use MiniShop3\Processors\Settings\Payment\Enable as PaymentEnable;
+use MiniShop3\Processors\Settings\Payment\GetList as PaymentGetList;
+use MiniShop3\Processors\Settings\Status\Create as StatusCreate;
+use MiniShop3\Processors\Settings\Status\Disable as StatusDisable;
+use MiniShop3\Processors\Settings\Status\Enable as StatusEnable;
+use MiniShop3\Processors\Settings\Status\GetList as StatusGetList;
+use MiniShop3\Processors\Settings\Vendor\Create as VendorCreate;
+use MiniShop3\Processors\Settings\Vendor\GetList as VendorGetList;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class ProcessorCoverageTest extends ExtraTestCase
+{
+    public function testGetListProcessorsDenyAnonymousAndSucceedForSudo(): void
+    {
+        $this->actingAsPlain();
+
+        foreach ($this->getListProcessors() as [$class, $properties]) {
+            $this->modx->error->reset();
+            $response = $this->runExtraProcessor($class, $properties);
+            $this->assertProcessorFailure($response);
+            self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
+        }
+
+        $this->actingAsSudo();
+
+        foreach ($this->getListProcessors() as [$class, $properties]) {
+            $this->modx->error->reset();
+            $response = $this->runExtraProcessor($class, $properties);
+            $this->assertProcessorSuccess($response);
+        }
+
+        $this->modx->error->reset();
+        $combo = $this->runExtraProcessor(ProductGetList::class, [
+            'combo' => true,
+            'limit' => 10,
+        ]);
+        $this->assertProcessorSuccess($combo);
+    }
+
+    public function testSettingsCreateEnableDisableRoundTrip(): void
+    {
+        $this->actingAsSudo();
+        $suffix = bin2hex(random_bytes(3));
+
+        $creates = [
+            [VendorCreate::class, ['name' => 'TB Proc Vendor ' . $suffix], msVendor::class],
+            [PaymentCreate::class, ['name' => 'TB Proc Payment ' . $suffix], msPayment::class],
+            [DeliveryCreate::class, ['name' => 'TB Proc Delivery ' . $suffix], msDelivery::class],
+            [LinkCreate::class, ['name' => 'TB Proc Link ' . $suffix, 'type' => 'many_to_many'], msLink::class],
+            [StatusCreate::class, ['name' => 'TB Proc Status ' . $suffix], msOrderStatus::class],
+        ];
+
+        foreach ($creates as [$class, $properties, $model]) {
+            $this->modx->error->reset();
+            $response = $this->runExtraProcessor($class, $properties);
+            $this->assertProcessorSuccess($response);
+            $this->assertObjectExists($model, ['name' => $properties['name']]);
+        }
+
+        $payment = $this->modx->getObject(msPayment::class, ['name' => 'TB Proc Payment ' . $suffix]);
+        self::assertNotNull($payment);
+        $this->modx->error->reset();
+        $this->assertProcessorSuccess($this->runExtraProcessor(PaymentDisable::class, [
+            'id' => $payment->get('id'),
+        ]));
+        $payment = $this->modx->getObject(msPayment::class, ['id' => $payment->get('id')]);
+        self::assertNotNull($payment);
+        self::assertFalse((bool) $payment->get('active'));
+
+        $this->modx->error->reset();
+        $this->assertProcessorSuccess($this->runExtraProcessor(PaymentEnable::class, [
+            'id' => $payment->get('id'),
+        ]));
+        $payment = $this->modx->getObject(msPayment::class, ['id' => $payment->get('id')]);
+        self::assertNotNull($payment);
+        self::assertTrue((bool) $payment->get('active'));
+
+        $status = $this->modx->getObject(msOrderStatus::class, ['name' => 'TB Proc Status ' . $suffix]);
+        self::assertNotNull($status);
+        $this->modx->error->reset();
+        $this->assertProcessorSuccess($this->runExtraProcessor(StatusDisable::class, [
+            'id' => $status->get('id'),
+        ]));
+        $this->modx->error->reset();
+        $this->assertProcessorSuccess($this->runExtraProcessor(StatusEnable::class, [
+            'id' => $status->get('id'),
+        ]));
+    }
+
+    /**
+     * @return list<array{0: class-string, 1: array<string, mixed>}>
+     */
+    private function getListProcessors(): array
+    {
+        return [
+            [VendorGetList::class, ['limit' => 10]],
+            [PaymentGetList::class, ['limit' => 10]],
+            [DeliveryGetList::class, ['limit' => 10]],
+            [LinkGetList::class, ['limit' => 10]],
+            [StatusGetList::class, ['limit' => 10]],
+            [CustomerGetList::class, ['limit' => 10]],
+            [CustomerAddressGetList::class, ['limit' => 10]],
+            [GalleryGetList::class, ['product_id' => 0, 'limit' => 10]],
+        ];
+    }
+}

--- a/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
+++ b/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
@@ -31,17 +31,8 @@ use MiniShop3\Tests\Modx\Support\ExtraTestCase;
 
 final class ProcessorCoverageTest extends ExtraTestCase
 {
-    public function testGetListProcessorsDenyAnonymousAndSucceedForSudo(): void
+    public function testGetListProcessorsSucceedForSudo(): void
     {
-        $this->actingAsPlain();
-
-        foreach ($this->getListProcessors() as [$class, $properties]) {
-            $this->modx->error->reset();
-            $response = $this->runExtraProcessor($class, $properties);
-            $this->assertProcessorFailure($response);
-            self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
-        }
-
         $this->actingAsSudo();
 
         foreach ($this->getListProcessors() as [$class, $properties]) {
@@ -56,6 +47,20 @@ final class ProcessorCoverageTest extends ExtraTestCase
             'limit' => 10,
         ]);
         $this->assertProcessorSuccess($combo);
+    }
+
+    public function testGetListProcessorsDenyAnonymousWhenPoliciesAreEnforced(): void
+    {
+        $this->skipUnlessProcessorPoliciesAreEnforced();
+
+        $this->actingAsPlain();
+
+        foreach ($this->getListProcessors() as [$class, $properties]) {
+            $this->modx->error->reset();
+            $response = $this->runExtraProcessor($class, $properties);
+            $this->assertProcessorFailure($response);
+            self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
+        }
     }
 
     public function testSettingsCreateEnableDisableRoundTrip(): void

--- a/core/components/minishop3/tests/Modx/ProductAndCompositeTest.php
+++ b/core/components/minishop3/tests/Modx/ProductAndCompositeTest.php
@@ -54,7 +54,7 @@ final class ProductAndCompositeTest extends ExtraTestCase
                 'id' => $product->get('id'),
                 'article' => 'TB-RES-' . $suffix,
                 'price' => 42.0,
-            ]);
+            ], '', true);
             self::assertTrue($data->save(), 'Failed to save msProductData with resource id');
         } else {
             $data->set('article', 'TB-RES-' . $suffix);

--- a/core/components/minishop3/tests/Modx/ProductAndCompositeTest.php
+++ b/core/components/minishop3/tests/Modx/ProductAndCompositeTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msCategory;
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msCategoryOption;
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msDeliveryMember;
+use MiniShop3\Model\msLink;
+use MiniShop3\Model\msOption;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Model\msProduct;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductLink;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class ProductAndCompositeTest extends ExtraTestCase
+{
+    public function testCategoryProductResourcesAndCompositeRowsPersist(): void
+    {
+        $suffix = bin2hex(random_bytes(3));
+
+        $category = $this->modx->newObject(msCategory::class);
+        $category->fromArray([
+            'pagetitle' => 'TB Category ' . $suffix,
+            'alias' => 'tb-cat-' . $suffix,
+            'published' => true,
+            'class_key' => msCategory::class,
+            'context_key' => 'web',
+            'parent' => 0,
+            'template' => 0,
+        ]);
+        self::assertTrue($category->save(), 'Failed to save msCategory resource');
+
+        $product = $this->modx->newObject(msProduct::class);
+        $product->fromArray([
+            'pagetitle' => 'TB Product ' . $suffix,
+            'alias' => 'tb-prod-' . $suffix,
+            'published' => true,
+            'class_key' => msProduct::class,
+            'context_key' => 'web',
+            'parent' => $category->get('id'),
+            'template' => 0,
+        ]);
+        self::assertTrue($product->save(), 'Failed to save msProduct resource');
+
+        $data = $this->modx->getObject(msProductData::class, ['id' => $product->get('id')]);
+        if ($data === null) {
+            $data = $this->modx->newObject(msProductData::class);
+            $data->fromArray([
+                'id' => $product->get('id'),
+                'article' => 'TB-RES-' . $suffix,
+                'price' => 42.0,
+            ]);
+            self::assertTrue($data->save(), 'Failed to save msProductData with resource id');
+        } else {
+            $data->set('article', 'TB-RES-' . $suffix);
+            $data->set('price', 42.0);
+            self::assertTrue($data->save(), 'Failed to update msProductData');
+        }
+        $this->assertObjectExists(msProductData::class, ['id' => $product->get('id')]);
+
+        $option = $this->persistObject(msOption::class, [
+            'key' => 'tb_size_' . $suffix,
+            'caption' => 'Size',
+            'type' => 'textfield',
+        ]);
+        $this->persistObject(msCategoryMember::class, [
+            'product_id' => $product->get('id'),
+            'category_id' => $category->get('id'),
+            'menuindex' => 1,
+        ]);
+        $this->persistObject(msCategoryOption::class, [
+            'option_id' => $option->get('id'),
+            'category_id' => $category->get('id'),
+            'active' => 1,
+        ]);
+
+        $delivery = $this->persistObject(msDelivery::class, ['name' => 'TB Comp Delivery ' . $suffix]);
+        $payment = $this->persistObject(msPayment::class, ['name' => 'TB Comp Payment ' . $suffix]);
+        $this->persistObject(msDeliveryMember::class, [
+            'delivery_id' => $delivery->get('id'),
+            'payment_id' => $payment->get('id'),
+        ]);
+
+        $slave = $this->modx->newObject(msProduct::class);
+        $slave->fromArray([
+            'pagetitle' => 'TB Slave ' . $suffix,
+            'alias' => 'tb-slave-' . $suffix,
+            'published' => true,
+            'class_key' => msProduct::class,
+            'context_key' => 'web',
+            'parent' => $category->get('id'),
+            'template' => 0,
+        ]);
+        self::assertTrue($slave->save());
+
+        $link = $this->persistObject(msLink::class, [
+            'name' => 'TB Comp Link ' . $suffix,
+            'type' => 'many_to_many',
+        ]);
+        $this->persistObject(msProductLink::class, [
+            'link' => $link->get('id'),
+            'master' => $product->get('id'),
+            'slave' => $slave->get('id'),
+        ]);
+
+        $this->assertObjectExists(msCategoryMember::class, [
+            'product_id' => $product->get('id'),
+            'category_id' => $category->get('id'),
+        ]);
+        $this->assertObjectExists(msDeliveryMember::class, [
+            'delivery_id' => $delivery->get('id'),
+            'payment_id' => $payment->get('id'),
+        ]);
+        $this->assertObjectExists(msProductLink::class, [
+            'link' => $link->get('id'),
+            'master' => $product->get('id'),
+            'slave' => $slave->get('id'),
+        ]);
+        $this->assertObjectExists(msCategoryOption::class, [
+            'option_id' => $option->get('id'),
+            'category_id' => $category->get('id'),
+        ]);
+    }
+}

--- a/core/components/minishop3/tests/Modx/README.md
+++ b/core/components/minishop3/tests/Modx/README.md
@@ -53,3 +53,5 @@ The suite covers schema (`SHOW TABLES`), persist for every MiniShop3 table class
 Schema for this suite comes from `PackageDefinition::tables()` (xPDO `createObjectContainer`). Full Phinx migrate is not run here: `InitialSchema` boots a second kernel from `config.core.php` at the extra root, which is not a MODX install in git. `phinx.php` is still checked against the live `$modx` connection. A later change can inject that `$modx` into `InitialSchema`.
 
 Processors are PSR-4 classes under `src/Processors/`. Address them by FQCN (`Create::class`). A string action without `processors_path` is resolved against core processors and fails with “Requested processor not found”.
+
+`$permission` on processors is checked through `modContext::checkPolicy()`. That method returns true unless the MODX session is `SESSION_STATE_INITIALIZED`. Testbench boots in API mode without that session, so ACL-deny cases are skipped (`skipUnlessProcessorPoliciesAreEnforced()`). Sudo create/list still runs.

--- a/core/components/minishop3/tests/Modx/README.md
+++ b/core/components/minishop3/tests/Modx/README.md
@@ -1,0 +1,52 @@
+# Live MODX tests (modxkit/testbench)
+
+PHPUnit suite on a real MODX 3 kernel. Stub suites (`tests/Unit`, `tests/Integration`, `tests/WebApi`, smoke `tests/*Test.php`) stay on `phpunit.xml.dist` and do **not** boot MODX.
+
+## What runs where
+
+| Command | Kernel | Database |
+| --- | --- | --- |
+| `composer test:smoke` | no | no |
+| `composer test` / `test:unit` / `test:integration` / `test:web-api` | stubs | optional PDO via `MS3_TEST_MYSQL_*` |
+| `composer test:modx` | live MODX 3.1+ / 3.2 | MySQL via `MODX_TESTBENCH_DB_*` |
+
+`composer ci:php` does **not** include `test:modx`. That job stays green without a MODX install.
+
+## Requirements
+
+- PHP 8.2–8.4, extensions `pdo_mysql` and `zip`
+- MySQL 8 / MariaDB 10.11
+- MODX **3.1.2-pl** or **3.2.3-pl** (testbench default `3.2.3-pl`)
+
+MODX 3.0.x is not supported by [modxkit/testbench](https://github.com/modxkit/testbench): the core cannot boot in API mode (`reloadConfig()` redeclares model classes). MiniShop3 still documents 3.0.0+ for shops; this suite does not promise 3.0. See [modxcms/revolution#17020](https://github.com/modxcms/revolution/issues/17020).
+
+## Local run
+
+```bash
+export MODX_TESTBENCH_DB_HOST=127.0.0.1
+export MODX_TESTBENCH_DB_USER=root
+export MODX_TESTBENCH_DB_PASS=secret
+
+cd core/components/minishop3
+composer install
+vendor/bin/modx-testbench install
+composer test:modx
+```
+
+First install downloads MODX into `~/.cache/modx-testbench/`. Later runs reuse that cache.
+
+```bash
+vendor/bin/modx-testbench status
+vendor/bin/modx-testbench destroy
+```
+
+Do not run stub PHPUnit and `test:modx` in one PHP process (different bootstraps).
+
+## Layout
+
+- `Support/ExtraTestCase.php` — `PackageDefinition` matching `bootstrap.php`, `ServiceRegistry` via `ms3`
+- `phpunit.modx.xml` — testbench bootstrap, suite `Modx`
+
+Schema for this suite comes from `PackageDefinition::tables()` (xPDO `createObjectContainer`). Full Phinx migrate is not run here: `InitialSchema` boots a second kernel from `config.core.php` at the extra root, which is not a MODX install in git. `phinx.php` is still checked against the live `$modx` connection. A later change can inject that `$modx` into `InitialSchema`.
+
+Processors are PSR-4 classes under `src/Processors/`. Address them by FQCN (`Create::class`). A string action without `processors_path` is resolved against core processors and fails with “Requested processor not found”.

--- a/core/components/minishop3/tests/Modx/README.md
+++ b/core/components/minishop3/tests/Modx/README.md
@@ -14,9 +14,9 @@ PHPUnit suite on a real MODX 3 kernel. Stub suites (`tests/Unit`, `tests/Integra
 
 ## Requirements
 
-- PHP 8.2–8.4, extensions `pdo_mysql` and `zip`
+- PHP 8.2–8.4, extensions `pdo_mysql`, `zip`, and `gd` (or `imagick` for `ms3_image`)
 - MySQL 8 / MariaDB 10.11
-- MODX **3.1.2-pl** or **3.2.3-pl** (testbench default `3.2.3-pl`)
+- MODX **3.1.2-pl**, **3.2.3-pl**, or **3.2.4-pl** (testbench default `3.2.3-pl`)
 
 MODX 3.0.x is not supported by [modxkit/testbench](https://github.com/modxkit/testbench): the core cannot boot in API mode (`reloadConfig()` redeclares model classes). MiniShop3 still documents 3.0.0+ for shops; this suite does not promise 3.0. See [modxcms/revolution#17020](https://github.com/modxcms/revolution/issues/17020).
 
@@ -45,7 +45,10 @@ Do not run stub PHPUnit and `test:modx` in one PHP process (different bootstraps
 ## Layout
 
 - `Support/ExtraTestCase.php` — `PackageDefinition` matching `bootstrap.php`, `ServiceRegistry` via `ms3`
+- `Support/PackageModels.php` — xPDO table classes passed to `->tables()` (`msProduct` / `msCategory` stay on `modResource`)
 - `phpunit.modx.xml` — testbench bootstrap, suite `Modx`
+
+The suite covers schema (`SHOW TABLES`), persist for every MiniShop3 table class, product/category resources plus composite rows, GetList/Create/Enable/Disable processors, DI `has()`/`get()` for every default service, extra-field `loadMap()`, customer `RegisterService`, settings, and plugin events (`msOnSaveOrder`, `msOnVendorCreate`).
 
 Schema for this suite comes from `PackageDefinition::tables()` (xPDO `createObjectContainer`). Full Phinx migrate is not run here: `InitialSchema` boots a second kernel from `config.core.php` at the extra root, which is not a MODX install in git. `phinx.php` is still checked against the live `$modx` connection. A later change can inject that `$modx` into `InitialSchema`.
 

--- a/core/components/minishop3/tests/Modx/SchemaTablesTest.php
+++ b/core/components/minishop3/tests/Modx/SchemaTablesTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+use MiniShop3\Tests\Modx\Support\PackageModels;
+
+final class SchemaTablesTest extends ExtraTestCase
+{
+    public function testEveryRegisteredModelHasAMysqlTable(): void
+    {
+        foreach (PackageModels::tables() as $class) {
+            $this->assertTableExists($class);
+        }
+    }
+}

--- a/core/components/minishop3/tests/Modx/ServiceRegistryLiveTest.php
+++ b/core/components/minishop3/tests/Modx/ServiceRegistryLiveTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Controllers\Cart\Cart;
+use MiniShop3\Controllers\Customer\Customer;
+use MiniShop3\Controllers\Order\Order;
+use MiniShop3\MiniShop3;
+use MiniShop3\ServiceRegistry;
+use MiniShop3\Services\TokenService;
+use MiniShop3\Services\Validation\ValidationService;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+use Throwable;
+
+final class ServiceRegistryLiveTest extends ExtraTestCase
+{
+    public function testEveryDefaultServiceKeyIsRegistered(): void
+    {
+        foreach ($this->defaultServiceKeys() as $key) {
+            self::assertTrue($this->modx->services->has($key), 'DI missing ' . $key);
+        }
+
+        foreach (ServiceRegistry::SERVICE_DEPENDENCIES as $service => $deps) {
+            self::assertTrue($this->modx->services->has($service), 'Dependency parent missing ' . $service);
+            foreach ($deps as $dep) {
+                self::assertTrue($this->modx->services->has($dep), $service . ' depends on missing ' . $dep);
+            }
+        }
+    }
+
+    public function testDefaultServicesResolve(): void
+    {
+        $failures = [];
+        foreach ($this->defaultServiceKeys() as $key) {
+            try {
+                $service = $this->modx->services->get($key);
+                self::assertNotNull($service, $key . ' resolved to null');
+            } catch (Throwable $e) {
+                $failures[] = $key . ': ' . $e->getMessage();
+            }
+        }
+
+        self::assertSame([], $failures, "Service get() failed:\n" . implode("\n", $failures));
+        self::assertInstanceOf(MiniShop3::class, $this->modx->services->get('ms3'));
+        self::assertInstanceOf(Cart::class, $this->modx->services->get('ms3_cart'));
+        self::assertInstanceOf(Order::class, $this->modx->services->get('ms3_order'));
+        self::assertInstanceOf(Customer::class, $this->modx->services->get('ms3_customer'));
+    }
+
+    public function testValidationAndTokenServicesWork(): void
+    {
+        /** @var ValidationService $validator */
+        $validator = $this->modx->services->get('ms3_validation_service');
+        $ok = $validator->validate(['email' => 'a@b.c'], ['email' => 'required|email']);
+        self::assertFalse($ok->fails());
+        $bad = $validator->validate(['email' => ''], ['email' => 'required|email']);
+        self::assertTrue($bad->fails());
+
+        /** @var TokenService $tokens */
+        $tokens = $this->modx->services->get('ms3_token_service');
+        $payload = ['snippet' => 'msCart', 'tpl' => 'tb'];
+        $token = $tokens->generateSnippetToken($payload);
+        self::assertNotSame('', $token);
+        self::assertTrue($tokens->cacheSnippetData($token, $payload));
+        $cached = $tokens->getSnippetData($token);
+        self::assertIsArray($cached);
+        self::assertSame('msCart', $cached['snippet'] ?? null);
+    }
+}

--- a/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
+++ b/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
@@ -12,6 +12,7 @@ final class StatusCreateProcessorTest extends ExtraTestCase
 {
     public function testCreateRequiresMssettingSave(): void
     {
+        $this->skipUnlessProcessorPoliciesAreEnforced();
         $user = $this->createUser(['username' => 'editor-no-settings']);
         $this->actingAs($user);
 

--- a/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
+++ b/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msOrderStatus;
+use MiniShop3\Processors\Settings\Status\Create;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class StatusCreateProcessorTest extends ExtraTestCase
+{
+    public function testCreateRequiresMssettingSave(): void
+    {
+        $user = $this->createUser(['username' => 'editor-no-settings']);
+        $this->actingAs($user);
+
+        $response = $this->runProcessor(Create::class, [
+            'name' => 'testbench-denied',
+        ]);
+
+        $this->assertProcessorFailure($response);
+        self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
+        $this->assertObjectMissing(msOrderStatus::class, ['name' => 'testbench-denied']);
+    }
+
+    public function testCreateSucceedsForSudoUser(): void
+    {
+        $user = $this->createUser(['username' => 'sudo-settings', 'sudo' => true]);
+        $this->actingAs($user);
+
+        $response = $this->runProcessor(Create::class, [
+            'name' => 'testbench-status',
+        ], [
+            'processors_path' => dirname(__DIR__, 2) . '/src/Processors/',
+        ]);
+
+        $this->assertProcessorSuccess($response);
+        $this->assertObjectExists(msOrderStatus::class, ['name' => 'testbench-status']);
+    }
+
+    public function testStringActionWithoutProcessorsPathIsNotFound(): void
+    {
+        $user = $this->createUser(['username' => 'sudo-missing-path', 'sudo' => true]);
+        $this->actingAs($user);
+
+        $response = $this->runProcessor('settings/status/create', [
+            'name' => 'testbench-string-action',
+        ]);
+
+        $this->assertProcessorFailure($response);
+        self::assertStringContainsStringIgnoringCase('not found', $response->getMessage());
+        $this->assertObjectMissing(msOrderStatus::class, ['name' => 'testbench-string-action']);
+    }
+}

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -12,6 +12,7 @@ use ModxKit\Testbench\TestCase;
 use MODX\Revolution\modEvent;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPluginEvent;
+use MODX\Revolution\modX;
 use MODX\Revolution\Processors\ProcessorResponse;
 use ReflectionClass;
 use xPDO\Om\xPDOObject;
@@ -113,6 +114,9 @@ abstract class ExtraTestCase extends TestCase
         $object = $this->modx->newObject($class);
         self::assertNotNull($object, $class . ' is not in the xPDO map');
         $object->fromArray($fields);
+        // Composite PK / named-PK objects become "not new" after fromArray, and save() UPDATEs
+        // zero rows. persistObject always inserts.
+        $object->setNew(true);
         self::assertTrue($object->save(), 'Failed to save ' . $class);
 
         return $object;
@@ -143,11 +147,10 @@ abstract class ExtraTestCase extends TestCase
 
         if ($this->modx->getCount(modEvent::class, ['name' => $eventName]) === 0) {
             $event = $this->modx->newObject(modEvent::class);
-            $event->fromArray([
-                'name' => $eventName,
-                'service' => 1,
-                'groupname' => 'MiniShop3',
-            ]);
+            $event->set('name', $eventName);
+            $event->set('service', 1);
+            $event->set('groupname', 'MiniShop3');
+            $event->setNew(true);
             self::assertTrue($event->save(), 'Failed to save modEvent ' . $eventName);
         }
 
@@ -157,10 +160,29 @@ abstract class ExtraTestCase extends TestCase
             'event' => $eventName,
             'priority' => 0,
         ]);
+        $pluginEvent->setNew(true);
         self::assertTrue($pluginEvent->save(), 'Failed to attach plugin to ' . $eventName);
 
         $pluginId = (int) $plugin->get('id');
         $this->modx->pluginCache[(string) $pluginId] = $plugin->toArray();
         $this->modx->eventMap[$eventName][$pluginId] = $pluginId;
+    }
+
+    /**
+     * Processor $permission is enforced via context checkPolicy(), which returns true unless
+     * the session is INITIALIZED. Testbench boots the kernel in API mode without that session.
+     */
+    protected function processorPoliciesAreEnforced(): bool
+    {
+        return $this->modx->getSessionState() === modX::SESSION_STATE_INITIALIZED;
+    }
+
+    protected function skipUnlessProcessorPoliciesAreEnforced(): void
+    {
+        if (!$this->processorPoliciesAreEnforced()) {
+            self::markTestSkipped(
+                'Processor ACL is not enforced without an initialized MODX session (testbench API boot).'
+            );
+        }
     }
 }

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace MiniShop3\Tests\Modx\Support;
 
 use MiniShop3\MiniShop3;
-use MiniShop3\Model\msExtraField;
-use MiniShop3\Model\msOrder;
-use MiniShop3\Model\msOrderProduct;
-use MiniShop3\Model\msOrderStatus;
+use MiniShop3\ServiceRegistry;
 use ModxKit\Testbench\Concerns\RefreshesDatabase;
 use ModxKit\Testbench\Package\PackageDefinition;
 use ModxKit\Testbench\TestCase;
+use MODX\Revolution\modEvent;
+use MODX\Revolution\modPlugin;
+use MODX\Revolution\modPluginEvent;
+use MODX\Revolution\Processors\ProcessorResponse;
+use ReflectionClass;
+use xPDO\Om\xPDOObject;
 
 /**
  * Live MODX 3 kernel for MiniShop3 (testbench level 2).
@@ -32,12 +35,7 @@ abstract class ExtraTestCase extends TestCase
             ->corePath($core)
             ->assetsPath($assets)
             ->model('MiniShop3\\Model', $core . 'src/', null, 'MiniShop3\\')
-            ->tables(
-                msOrder::class,
-                msOrderProduct::class,
-                msOrderStatus::class,
-                msExtraField::class,
-            )
+            ->tables(...PackageModels::tables())
             ->settings([
                 'ms3_core_path' => $core,
                 'ms3_token_name' => 'ms3_token',
@@ -60,5 +58,109 @@ abstract class ExtraTestCase extends TestCase
     protected function extraAssetsPath(): string
     {
         return dirname($this->extraCorePath(), 3) . '/assets/components/minishop3/';
+    }
+
+    protected function processorsPath(): string
+    {
+        return $this->extraCorePath() . 'src/Processors/';
+    }
+
+    /**
+     * @param class-string $class
+     * @param array<string, mixed> $properties
+     */
+    protected function runExtraProcessor(string $class, array $properties = []): ProcessorResponse
+    {
+        return $this->runProcessor($class, $properties, [
+            'processors_path' => $this->processorsPath(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function defaultServiceKeys(): array
+    {
+        $reflection = new ReflectionClass(ServiceRegistry::class);
+        $registry = $reflection->newInstanceWithoutConstructor();
+        $map = $reflection->getProperty('defaultServices')->getValue($registry);
+        self::assertIsArray($map);
+
+        return array_keys($map);
+    }
+
+    protected function actingAsSudo(): void
+    {
+        $this->actingAs($this->createUser([
+            'username' => 'sudo-' . bin2hex(random_bytes(3)),
+            'sudo' => true,
+        ]));
+    }
+
+    protected function actingAsPlain(): void
+    {
+        $this->actingAs($this->createUser([
+            'username' => 'plain-' . bin2hex(random_bytes(3)),
+        ]));
+    }
+
+    /**
+     * @param class-string<xPDOObject> $class
+     * @param array<string, mixed> $fields
+     */
+    protected function persistObject(string $class, array $fields): xPDOObject
+    {
+        $object = $this->modx->newObject($class);
+        self::assertNotNull($object, $class . ' is not in the xPDO map');
+        $object->fromArray($fields);
+        self::assertTrue($object->save(), 'Failed to save ' . $class);
+
+        return $object;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    protected function assertTableExists(string $class): void
+    {
+        $quoted = $this->modx->getTableName($class);
+        self::assertNotFalse($quoted, 'No table name for ' . $class);
+        $table = str_replace('`', '', (string) $quoted);
+        $statement = $this->modx->prepare('SHOW TABLES LIKE ?');
+        $statement->execute([$table]);
+        self::assertNotFalse($statement->fetch(), 'Missing table ' . $table . ' for ' . $class);
+    }
+
+    protected function registerPlugin(string $eventName, string $phpCode): void
+    {
+        $plugin = $this->modx->newObject(modPlugin::class);
+        $plugin->fromArray([
+            'name' => 'testbench-' . $eventName . '-' . bin2hex(random_bytes(3)),
+            'plugincode' => $phpCode,
+            'disabled' => false,
+        ]);
+        self::assertTrue($plugin->save(), 'Failed to save test plugin');
+
+        if ($this->modx->getCount(modEvent::class, ['name' => $eventName]) === 0) {
+            $event = $this->modx->newObject(modEvent::class);
+            $event->fromArray([
+                'name' => $eventName,
+                'service' => 1,
+                'groupname' => 'MiniShop3',
+            ]);
+            self::assertTrue($event->save(), 'Failed to save modEvent ' . $eventName);
+        }
+
+        $pluginEvent = $this->modx->newObject(modPluginEvent::class);
+        $pluginEvent->fromArray([
+            'pluginid' => $plugin->get('id'),
+            'event' => $eventName,
+            'priority' => 0,
+        ]);
+        self::assertTrue($pluginEvent->save(), 'Failed to attach plugin to ' . $eventName);
+
+        $pluginId = (int) $plugin->get('id');
+        $this->modx->pluginCache[(string) $pluginId] = $plugin->toArray();
+        $this->modx->eventMap[$eventName][$pluginId] = $pluginId;
     }
 }

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -113,10 +113,8 @@ abstract class ExtraTestCase extends TestCase
     {
         $object = $this->modx->newObject($class);
         self::assertNotNull($object, $class . ' is not in the xPDO map');
-        $object->fromArray($fields);
-        // Composite PK / named-PK objects become "not new" after fromArray, and save() UPDATEs
-        // zero rows. persistObject always inserts.
-        $object->setNew(true);
+        // Third arg setPrimaryKeys: fromArray skips PK fields (composite keys) otherwise.
+        $object->fromArray($fields, '', true);
         self::assertTrue($object->save(), 'Failed to save ' . $class);
 
         return $object;
@@ -150,7 +148,6 @@ abstract class ExtraTestCase extends TestCase
             $event->set('name', $eventName);
             $event->set('service', 1);
             $event->set('groupname', 'MiniShop3');
-            $event->setNew(true);
             self::assertTrue($event->save(), 'Failed to save modEvent ' . $eventName);
         }
 
@@ -159,8 +156,7 @@ abstract class ExtraTestCase extends TestCase
             'pluginid' => $plugin->get('id'),
             'event' => $eventName,
             'priority' => 0,
-        ]);
-        $pluginEvent->setNew(true);
+        ], '', true);
         self::assertTrue($pluginEvent->save(), 'Failed to attach plugin to ' . $eventName);
 
         $pluginId = (int) $plugin->get('id');

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx\Support;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Model\msExtraField;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msOrderStatus;
+use ModxKit\Testbench\Concerns\RefreshesDatabase;
+use ModxKit\Testbench\Package\PackageDefinition;
+use ModxKit\Testbench\TestCase;
+
+/**
+ * Live MODX 3 kernel for MiniShop3 (testbench level 2).
+ *
+ * Isolated from stub PHPUnit via phpunit.modx.xml. RefreshesDatabase is required:
+ * PackageDefinition::tables() runs DDL, which commits the test transaction.
+ */
+abstract class ExtraTestCase extends TestCase
+{
+    use RefreshesDatabase;
+
+    protected function packageDefinition(): PackageDefinition
+    {
+        $core = $this->extraCorePath();
+        $assets = $this->extraAssetsPath();
+
+        return PackageDefinition::make('minishop3')
+            ->corePath($core)
+            ->assetsPath($assets)
+            ->model('MiniShop3\\Model', $core . 'src/', null, 'MiniShop3\\')
+            ->tables(
+                msOrder::class,
+                msOrderProduct::class,
+                msOrderStatus::class,
+                msExtraField::class,
+            )
+            ->settings([
+                'ms3_core_path' => $core,
+                'ms3_token_name' => 'ms3_token',
+            ])
+            ->service('ms3', fn (): MiniShop3 => new MiniShop3($this->modx));
+    }
+
+    protected function afterPackageRegistered(): void
+    {
+        /** @var MiniShop3 $ms3 */
+        $ms3 = $this->modx->services->get('ms3');
+        $ms3->loadMap();
+    }
+
+    protected function extraCorePath(): string
+    {
+        return dirname(__DIR__, 3) . '/';
+    }
+
+    protected function extraAssetsPath(): string
+    {
+        return dirname($this->extraCorePath(), 3) . '/assets/components/minishop3/';
+    }
+}

--- a/core/components/minishop3/tests/Modx/Support/PackageModels.php
+++ b/core/components/minishop3/tests/Modx/Support/PackageModels.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx\Support;
+
+use MiniShop3\Model\msCategoryMember;
+use MiniShop3\Model\msCategoryOption;
+use MiniShop3\Model\msCustomer;
+use MiniShop3\Model\msCustomerAddress;
+use MiniShop3\Model\msCustomerToken;
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msDeliveryMember;
+use MiniShop3\Model\msExtraField;
+use MiniShop3\Model\msGridField;
+use MiniShop3\Model\msLink;
+use MiniShop3\Model\msModelField;
+use MiniShop3\Model\msModelFieldSection;
+use MiniShop3\Model\msNotificationConfig;
+use MiniShop3\Model\msOption;
+use MiniShop3\Model\msOptionGroup;
+use MiniShop3\Model\msOrder;
+use MiniShop3\Model\msOrderAddress;
+use MiniShop3\Model\msOrderLog;
+use MiniShop3\Model\msOrderProduct;
+use MiniShop3\Model\msOrderStatus;
+use MiniShop3\Model\msPageSection;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Model\msProductData;
+use MiniShop3\Model\msProductField;
+use MiniShop3\Model\msProductFile;
+use MiniShop3\Model\msProductLink;
+use MiniShop3\Model\msProductOption;
+use MiniShop3\Model\msVendor;
+
+/**
+ * xPDO table classes for live testbench (not modResource subclasses).
+ */
+final class PackageModels
+{
+    /**
+     * @return list<class-string>
+     */
+    public static function tables(): array
+    {
+        return [
+            msCategoryMember::class,
+            msCategoryOption::class,
+            msCustomer::class,
+            msCustomerAddress::class,
+            msCustomerToken::class,
+            msDelivery::class,
+            msDeliveryMember::class,
+            msExtraField::class,
+            msGridField::class,
+            msLink::class,
+            msModelField::class,
+            msModelFieldSection::class,
+            msNotificationConfig::class,
+            msOption::class,
+            msOptionGroup::class,
+            msOrder::class,
+            msOrderAddress::class,
+            msOrderLog::class,
+            msOrderProduct::class,
+            msOrderStatus::class,
+            msPageSection::class,
+            msPayment::class,
+            msProductData::class,
+            msProductField::class,
+            msProductFile::class,
+            msProductLink::class,
+            msProductOption::class,
+            msVendor::class,
+        ];
+    }
+}

--- a/core/components/minishop3/tests/Modx/TokenNameSettingTest.php
+++ b/core/components/minishop3/tests/Modx/TokenNameSettingTest.php
@@ -17,6 +17,24 @@ final class TokenNameSettingTest extends ExtraTestCase
         self::assertSame('ms3_test_token', $this->modx->getOption('ms3_token_name'));
     }
 
+    public function testCatalogSettingsRoundTrip(): void
+    {
+        $settings = [
+            'ms3_currency' => 'EUR',
+            'ms3_register_frontend' => '0',
+            'ms3_customer_require_email_verification' => '0',
+            'ms3_customer_send_welcome_email' => '0',
+            'ms3_password_min_length' => '10',
+            'ms3_product_show_in_tree_default' => '1',
+        ];
+
+        foreach ($settings as $key => $value) {
+            $this->setSetting($key, $value);
+            $this->assertSettingEquals($key, $value);
+            self::assertSame($value, (string) $this->modx->getOption($key));
+        }
+    }
+
     public function testMs3ServiceAndRegistryAreRegistered(): void
     {
         self::assertTrue($this->modx->services->has('ms3'));

--- a/core/components/minishop3/tests/Modx/TokenNameSettingTest.php
+++ b/core/components/minishop3/tests/Modx/TokenNameSettingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\MiniShop3;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class TokenNameSettingTest extends ExtraTestCase
+{
+    public function testSetSettingWritesDatabaseAndMemory(): void
+    {
+        $this->setSetting('ms3_token_name', 'ms3_test_token');
+
+        $this->assertSettingEquals('ms3_token_name', 'ms3_test_token');
+        self::assertSame('ms3_test_token', $this->modx->getOption('ms3_token_name'));
+    }
+
+    public function testMs3ServiceAndRegistryAreRegistered(): void
+    {
+        self::assertTrue($this->modx->services->has('ms3'));
+        self::assertInstanceOf(MiniShop3::class, $this->modx->services->get('ms3'));
+        self::assertTrue($this->modx->services->has('ms3_order_status'));
+    }
+
+    public function testPhinxConfigUsesLiveModxDatabase(): void
+    {
+        $modx = $this->modx;
+        $config = require $this->extraCorePath() . 'phinx.php';
+
+        self::assertSame(
+            $modx->getOption('dbname'),
+            $config['environments']['production']['name'] ?? null,
+        );
+    }
+}

--- a/core/components/minishop3/tests/Modx/VendorCreateEventTest.php
+++ b/core/components/minishop3/tests/Modx/VendorCreateEventTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msVendor;
+use MiniShop3\Processors\Settings\Vendor\Create as VendorCreate;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+final class VendorCreateEventTest extends ExtraTestCase
+{
+    public function testMsOnVendorCreatePluginRunsFromProcessor(): void
+    {
+        $this->registerPlugin(
+            'msOnVendorCreate',
+            '$modx->setPlaceholder("ms3_testbench_vendor", $object->get("name"));',
+        );
+
+        $this->actingAsSudo();
+        $name = 'TB Event Vendor ' . bin2hex(random_bytes(3));
+        $response = $this->runExtraProcessor(VendorCreate::class, ['name' => $name]);
+
+        $this->assertProcessorSuccess($response);
+        $this->assertObjectExists(msVendor::class, ['name' => $name]);
+        self::assertSame($name, $this->modx->getPlaceholder('ms3_testbench_vendor'));
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,9 @@ parameters:
     excludePaths:
         analyseAndScan:
             - core/components/minishop3/src/Model/mysql (?)
+            # Testbench PHPStan stubs redeclare empty MODX/xPDO classes and collide with
+            # .phpstan-deps/modx. MiniShop3 src does not import modxkit.
+            - core/components/minishop3/vendor/modxkit
     scanDirectories:
         - core/components/minishop3/vendor
         # Filled by composer stan:prepare (or MS3_PHPSTAN_* env overrides).

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@
 
 | Компонент | Версия |
 |-----------|--------|
-| MODX Revolution | 3.0.0+ |
+| MODX Revolution | 3.0.0+ (CI live-тесты: 3.1.2-pl и 3.2.3-pl) |
 | PHP | 8.2+ |
 | MySQL | 5.7+ / MariaDB 10.3+ |
 
@@ -152,6 +152,21 @@ MiniShop3/
 3. Закоммитьте изменения (`git commit -m 'Add amazing feature'`)
 4. Запушьте ветку (`git push origin feature/amazing-feature`)
 5. Откройте Pull Request
+
+### Тесты PHP
+
+Из `core/components/minishop3` после `composer install`:
+
+| Команда | Что проверяет |
+| --- | --- |
+| `composer test:smoke` | Скрипты `tests/*Test.php` без ядра MODX |
+| `composer test` | PHPUnit Unit + Integration + WebApi на стабах xPDO |
+| `composer ci:php` | `php -l` + smoke + `composer test` (как job `PHP lint + smoke`) |
+| `composer test:modx` | Живое ядро MODX 3.1+ / 3.2 через [modxkit/testbench](https://github.com/modxkit/testbench) |
+
+`composer test` и `ci:php` **не** поднимают ядро. Для `test:modx` нужны MySQL и переменные `MODX_TESTBENCH_DB_HOST` / `USER` / `PASS`. Подробности: [`core/components/minishop3/tests/Modx/README.md`](core/components/minishop3/tests/Modx/README.md).
+
+CI гоняет live-сьют на MODX 3.1.2-pl и 3.2.3-pl. Линейка 3.0.x в этом сьюте не проверяется (ядро не поднимается в API-режиме).
 
 ## 📝 Changelog
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@
 
 | Компонент | Версия |
 |-----------|--------|
-| MODX Revolution | 3.0.0+ (CI live-тесты: 3.1.2-pl и 3.2.3-pl) |
+| MODX Revolution | 3.0.0+ (CI live-тесты: 3.1.2-pl, 3.2.3-pl, 3.2.4-pl) |
 | PHP | 8.2+ |
 | MySQL | 5.7+ / MariaDB 10.3+ |
 
@@ -166,7 +166,7 @@ MiniShop3/
 
 `composer test` и `ci:php` **не** поднимают ядро. Для `test:modx` нужны MySQL и переменные `MODX_TESTBENCH_DB_HOST` / `USER` / `PASS`. Подробности: [`core/components/minishop3/tests/Modx/README.md`](core/components/minishop3/tests/Modx/README.md).
 
-CI гоняет live-сьют на MODX 3.1.2-pl и 3.2.3-pl. Линейка 3.0.x в этом сьюте не проверяется (ядро не поднимается в API-режиме).
+CI гоняет live-сьют на MODX 3.1.2-pl, 3.2.3-pl и 3.2.4-pl. Линейка 3.0.x в этом сьюте не проверяется (ядро не поднимается в API-режиме).
 
 ## 📝 Changelog
 


### PR DESCRIPTION
## Описание

Подключён [modxkit/testbench](https://packagist.org/packages/modxkit/testbench) для PHPUnit на живом ядре MODX 3. Стабы (`composer test` / `ci:php`) по-прежнему работают без установки ядра. Процессоры, события, настройки и права закрывает отдельный сьют `composer test:modx` и job `modx-testbench`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [x] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [x] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #686

## Как это было протестировано?

Локально, без живого ядра:

```bash
cd core/components/minishop3
php -l tests/Modx/Support/ExtraTestCase.php   # exit 0
php -l tests/Modx/MsOrderPersistTest.php      # exit 0
composer test                                 # exit 0, 308 tests
composer test:smoke                           # exit 0, 99 scripts
composer ci:php                               # exit 0
```

`composer test:modx` локально не гонялся: к MySQL на 127.0.0.1 нет доступа. Ожидается зелёный job `MODX testbench` в этом PR (матрица 3.1.2-pl и 3.2.3-pl).

Vue/ESLint и PHPStan не затрагивались (тесты вне `phpstan.neon`).

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `feat/issue-686-testbench`
- MODX: стабы локально; CI — 3.1.2-pl и 3.2.3-pl
- PHP: 8.4.23 локально; CI job php — 8.2, testbench — 8.2

## Скриншоты (если применимо)

Не применимо.

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Решение по MODX 3.0.x: продукт по-прежнему 3.0.0+, live-сьют и CI его не обещают (testbench не поднимает 3.0 в API-режиме). См. [modxcms/revolution#17020](https://github.com/modxcms/revolution/issues/17020).
- Схема в ExtraTestCase — `PackageDefinition::tables()` по xPDO map. Полный Phinx migrate отложен: `InitialSchema` поднимает второе ядро из `config.core.php` в корне экстра, которого в git нет. `phinx.php` проверяется на живом `$modx`.
- Положительный кейс процессора идёт через `sudo`, не через выдачу `mssetting_save`. Отказ без права проверяет текст `access denied`.
- Кэш CI — только `~/.cache/modx-testbench/releases`, без workspace/`config.inc.php`.

Документация: [`core/components/minishop3/tests/Modx/README.md`](core/components/minishop3/tests/Modx/README.md).