### PR TITLE
Keep legacy connector JSON valid on broken UTF-8

### DIFF
--- a/assets/components/minishop3/connector.php
+++ b/assets/components/minishop3/connector.php
@@ -44,6 +44,10 @@ if (!empty($_REQUEST['class_key'])) {
     }
 }
 
+// All processors on this connector share UTF-8-safe JSON (issue #689).
+$modx->setOption('modResponse.class', \MiniShop3\Router\Utf8SafeConnectorResponse::class);
+$modx->response = new \MiniShop3\Router\Utf8SafeConnectorResponse($modx);
+
 /** @var modConnectorRequest $request */
 $request = $modx->request;
 $request->handleRequest([

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -381,7 +381,7 @@ class Response
         $clean = self::sanitizeUtf8ForJson($data, $modx);
         $json = $clean !== null ? json_encode($clean) : false;
 
-        if ($json === false || $json === '') {
+        if ($json === false) {
             return [self::connectorFailClosedJson(), true];
         }
 

--- a/core/components/minishop3/src/Router/Response.php
+++ b/core/components/minishop3/src/Router/Response.php
@@ -348,6 +348,52 @@ class Response
     }
 
     /**
+     * Envelope that modConnectorResponse::outputContent() passes to toJSON().
+     *
+     * @param array<string, mixed> $body Processor success()/failure() array
+     *
+     * @return array<string, mixed>
+     */
+    public static function connectorProcessorEnvelope(array $body, ?object $modx = null): array
+    {
+        $errorMessage = ($modx !== null && method_exists($modx, 'lexicon'))
+            ? (string) $modx->lexicon('error')
+            : 'error';
+
+        return [
+            'success' => $body['success'] ?? 0,
+            'message' => $body['message'] ?? $errorMessage,
+            'total' => (isset($body['total']) && $body['total'] > 0)
+                ? (int) $body['total']
+                : (isset($body['errors']) ? count($body['errors']) : 1),
+            'data' => $body['errors'] ?? [],
+            'object' => $body['object'] ?? [],
+        ];
+    }
+
+    /**
+     * JSON for the MiniShop3 connector die() path (#689). Never returns an empty string.
+     *
+     * @return array{0: string, 1: bool} Encoded body and whether encoding failed closed
+     */
+    public static function encodeConnectorJson(mixed $data, ?object $modx = null): array
+    {
+        $clean = self::sanitizeUtf8ForJson($data, $modx);
+        $json = $clean !== null ? json_encode($clean) : false;
+
+        if ($json === false || $json === '') {
+            return [self::connectorFailClosedJson(), true];
+        }
+
+        return [$json, false];
+    }
+
+    public static function connectorFailClosedJson(): string
+    {
+        return '{"success":false,"message":"Internal server error","total":1,"data":[],"object":{"code":500}}';
+    }
+
+    /**
      * json_encode with UTF-8 substitute fallback and MODX logging (#654 / #671).
      *
      * @return string|null JSON string, or null when unencodable even after substitute.

--- a/core/components/minishop3/src/Router/Utf8SafeConnectorResponse.php
+++ b/core/components/minishop3/src/Router/Utf8SafeConnectorResponse.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace MiniShop3\Router;
+
+use MODX\Revolution\modConnectorResponse;
+use MODX\Revolution\modX;
+
+/**
+ * Shared JSON exit for every MiniShop3 processor on connector.php (#689).
+ *
+ * Decision: sanitize at the connector response, not per-processor and not by
+ * abandoning the legacy path. New processors inherit this automatically because
+ * connector.php installs this class before handleRequest().
+ *
+ * Keep the control flow aligned with MODX 3 modConnectorResponse::outputContent().
+ */
+class Utf8SafeConnectorResponse extends modConnectorResponse
+{
+    public function outputContent(array $options = [])
+    {
+        $modx = &$this->modx;
+        $target = preg_replace('/[\.]{2,}/', '', htmlspecialchars((string) ($options['action'] ?? '')));
+
+        $siteId = $this->modx->user->getUserToken($this->modx->context->get('key'));
+        $isLogin = $target == 'Login' || $target == 'Security/Login';
+
+        if (empty($siteId) && (!defined('MODX_REQP') || MODX_REQP === true)) {
+            $this->responseCode = 401;
+            $this->body = $modx->error->failure($modx->lexicon('access_denied'), ['code' => 401]);
+        } elseif (!$isLogin && !isset($_SERVER['HTTP_MODAUTH']) && (!isset($_REQUEST['HTTP_MODAUTH']) || empty($_REQUEST['HTTP_MODAUTH']))) {
+            $this->responseCode = 401;
+            $this->body = $modx->error->failure($modx->lexicon('access_denied'), ['code' => 401]);
+        } elseif (!$isLogin && isset($_SERVER['HTTP_MODAUTH']) && $_SERVER['HTTP_MODAUTH'] != $siteId) {
+            $this->responseCode = 401;
+            $this->body = $modx->error->failure($modx->lexicon('access_denied'), ['code' => 401]);
+        } elseif (!$isLogin && isset($_REQUEST['HTTP_MODAUTH']) && $_REQUEST['HTTP_MODAUTH'] != $siteId) {
+            $this->responseCode = 401;
+            $this->body = $modx->error->failure($modx->lexicon('access_denied'), ['code' => 401]);
+        } elseif (empty($options['action'])) {
+            $this->responseCode = 404;
+            $this->body = $this->modx->error->failure($modx->lexicon('action_err_ns'), ['code' => 404]);
+        } else {
+            if (!isset($_POST)) {
+                $_POST = [];
+            }
+            if (!isset($_GET) || $isLogin) {
+                $_GET = [];
+            }
+            $scriptProperties = array_merge($_GET, $_POST);
+            if (isset($_FILES) && !empty($_FILES)) {
+                $scriptProperties = array_merge($scriptProperties, $_FILES);
+            }
+
+            $response = $this->modx->runProcessor($target, $scriptProperties, $options);
+            if (!$response) {
+                $this->responseCode = 404;
+                $this->body = $this->modx->error->failure($this->modx->lexicon('processor_err_nf', [
+                    'target' => $target,
+                ]));
+            } else {
+                $this->body = $response->getResponse();
+            }
+        }
+
+        [$json, $failedClosed] = $this->encodeUtf8SafeBody($modx);
+        if ($failedClosed) {
+            $this->responseCode = 500;
+        }
+
+        if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
+            header('Content-Type: application/json; charset=UTF-8');
+            $message = 'OK';
+            if (array_key_exists($this->responseCode, $this->_responseCodes)) {
+                $message = $this->_responseCodes[$this->responseCode];
+            }
+            header('Status: ' . $this->responseCode . ' ' . $message);
+            header('Version: ' . $_SERVER['SERVER_PROTOCOL']);
+        }
+        if (is_array($this->header)) {
+            foreach ($this->header as $header) {
+                header($header);
+            }
+        }
+
+        @session_write_close();
+        if ($failedClosed) {
+            http_response_code(500);
+        }
+        die($json);
+    }
+
+    /**
+     * @param modX $modx
+     * @return array{0: string, 1: bool}
+     */
+    private function encodeUtf8SafeBody(object $modx): array
+    {
+        if (is_array($this->body)) {
+            return Response::encodeConnectorJson(
+                Response::connectorProcessorEnvelope($this->body, $modx),
+                $modx
+            );
+        }
+
+        $raw = (string) $this->body;
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return [$raw, false];
+        }
+
+        return Response::encodeConnectorJson($decoded, $modx);
+    }
+}

--- a/core/components/minishop3/src/Router/Utf8SafeConnectorResponse.php
+++ b/core/components/minishop3/src/Router/Utf8SafeConnectorResponse.php
@@ -40,14 +40,11 @@ class Utf8SafeConnectorResponse extends modConnectorResponse
             $this->responseCode = 404;
             $this->body = $this->modx->error->failure($modx->lexicon('action_err_ns'), ['code' => 404]);
         } else {
-            if (!isset($_POST)) {
-                $_POST = [];
-            }
-            if (!isset($_GET) || $isLogin) {
+            if ($isLogin) {
                 $_GET = [];
             }
             $scriptProperties = array_merge($_GET, $_POST);
-            if (isset($_FILES) && !empty($_FILES)) {
+            if ($_FILES !== []) {
                 $scriptProperties = array_merge($scriptProperties, $_FILES);
             }
 

--- a/core/components/minishop3/tests/ConnectorUtf8SafeResponseTest.php
+++ b/core/components/minishop3/tests/ConnectorUtf8SafeResponseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * #689: legacy connector processors share UTF-8-safe JSON at one exit.
+ *
+ * Run: php tests/ConnectorUtf8SafeResponseTest.php
+ */
+
+declare(strict_types=1);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL ConnectorUtf8SafeResponseTest: {$message}\n");
+    exit(1);
+};
+
+$assertTrue = static function (bool $cond, string $case) use ($fail): void {
+    if (!$cond) {
+        $fail($case);
+    }
+};
+
+$root = dirname(__DIR__);
+$connector = dirname(__DIR__, 4) . '/assets/components/minishop3/connector.php';
+$responseClass = $root . '/src/Router/Utf8SafeConnectorResponse.php';
+$responseSrc = file_get_contents($root . '/src/Router/Response.php');
+$traitSrc = file_get_contents($root . '/src/Processors/Api/ProcessesManagerConnectorRouteTrait.php');
+$connectorSrc = file_get_contents($connector);
+$classSrc = file_get_contents($responseClass);
+
+$assertTrue(is_string($connectorSrc), 'connector.php missing');
+$assertTrue(is_string($classSrc), 'Utf8SafeConnectorResponse.php missing');
+$assertTrue(is_string($responseSrc), 'Response.php missing');
+$assertTrue(is_string($traitSrc), 'ProcessesManagerConnectorRouteTrait.php missing');
+
+$assertTrue(
+    str_contains($connectorSrc, 'Utf8SafeConnectorResponse'),
+    'connector.php must install Utf8SafeConnectorResponse'
+);
+$assertTrue(
+    str_contains($classSrc, 'extends modConnectorResponse'),
+    'Utf8SafeConnectorResponse must extend modConnectorResponse'
+);
+$assertTrue(
+    str_contains($classSrc, 'encodeConnectorJson'),
+    'Utf8SafeConnectorResponse must encode via Response::encodeConnectorJson'
+);
+$assertTrue(
+    str_contains($responseSrc, 'function encodeConnectorJson'),
+    'Response::encodeConnectorJson must exist as the single encode helper'
+);
+$assertTrue(
+    str_contains($traitSrc, 'sanitizeUtf8ForJson'),
+    'routed manager connector must keep sanitizeUtf8ForJson'
+);
+
+fwrite(STDOUT, "OK ConnectorUtf8SafeResponseTest\n");
+exit(0);

--- a/core/components/minishop3/tests/Unit/Router/ResponseJsonEncodeTest.php
+++ b/core/components/minishop3/tests/Unit/Router/ResponseJsonEncodeTest.php
@@ -70,6 +70,59 @@ final class ResponseJsonEncodeTest extends TestCase
         self::assertStringContainsString('hex=', $modx->logs[0]);
     }
 
+    public function testEncodeConnectorJsonSubstitutesInvalidUtf8WithoutEmptyBody(): void
+    {
+        $modx = $this->makeLogger();
+        $envelope = Response::connectorProcessorEnvelope([
+            'success' => true,
+            'message' => '',
+            'object' => ['label' => "ab\xC3\x28cd"],
+        ], $modx);
+        [$json, $failed] = Response::encodeConnectorJson($envelope, $modx);
+
+        self::assertFalse($failed);
+        self::assertNotSame('', $json);
+        self::assertNotFalse(json_decode($json, true));
+        $decoded = json_decode($json, true);
+        self::assertTrue((bool) $decoded['success']);
+        self::assertStringContainsString("\u{FFFD}", $decoded['object']['label']);
+        self::assertNotEmpty($modx->logs);
+    }
+
+    public function testEncodeConnectorJsonFailsClosedOnNan(): void
+    {
+        $modx = $this->makeLogger();
+        [$json, $failed] = Response::encodeConnectorJson(['value' => NAN], $modx);
+
+        self::assertTrue($failed);
+        self::assertSame(Response::connectorFailClosedJson(), $json);
+        self::assertNotSame('', $json);
+        $decoded = json_decode($json, true);
+        self::assertFalse($decoded['success']);
+        self::assertSame(500, $decoded['object']['code']);
+    }
+
+    public function testConnectorProcessorEnvelopeMatchesModxShape(): void
+    {
+        $modx = new class {
+            public function lexicon(string $key): string
+            {
+                return $key === 'error' ? 'Error' : $key;
+            }
+        };
+        $envelope = Response::connectorProcessorEnvelope([
+            'success' => true,
+            'message' => 'ok',
+            'object' => ['id' => 1],
+        ], $modx);
+
+        self::assertSame(true, $envelope['success']);
+        self::assertSame('ok', $envelope['message']);
+        self::assertSame(1, $envelope['total']);
+        self::assertSame([], $envelope['data']);
+        self::assertSame(['id' => 1], $envelope['object']);
+    }
+
     public function testSanitizeUtf8ForJsonLeavesValidDataUnchanged(): void
     {
         $payload = ['title' => 'Товар', 'n' => 1];


### PR DESCRIPTION
## Описание

Легаси-процессоры через `connector.php` уходили в `xPDO::toJSON()` без UTF-8 fallback и при битой последовательности отдавали пустое тело с кодом 200.

Решение: одна точка выхода. `connector.php` ставит `Utf8SafeConnectorResponse` до `handleRequest()`. Все процессоры, в том числе новые, проходят `Response::encodeConnectorJson()`: невалидный UTF-8 заменяется на U+FFFD, иначе ASCII-конверт 500. Процессоры поштучно не трогаем.

Маршрутизируемый путь (`ProcessesManagerConnectorRouteTrait`, #676) не убирали.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #689

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Router/Response.php
php -l src/Router/Utf8SafeConnectorResponse.php
php tests/ConnectorUtf8SafeResponseTest.php
php tests/ProcessorPermissionsSmokeTest.php
vendor/bin/phpunit tests/Unit/Router/ResponseJsonEncodeTest.php
composer test:smoke
```

Все команды завершились с кодом 0. PHPUnit: 12 tests, 57 assertions. `composer test:smoke`: 100 скриптов.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-689-legacy-utf8`
- MODX: не требовался для unit/smoke (класс ответа наследует `modConnectorResponse` только в живом connector)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
|    |       |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

Конверт `success` / `message` / `total` / `data` / `object` совпадает с тем, что `modConnectorResponse` передаёт в `toJSON()`.

Не покрыто: живой `outputContent` с ядром MODX (auth + `runProcessor`). Двойная sanitize на routed manager path (#676 + этот слой) идемпотентна.