### PR TITLE
test(modx): схема live-сьюта из Phinx-миграций

### DIFF
--- a/core/components/minishop3/migrations/20251020000000_initial_schema.php
+++ b/core/components/minishop3/migrations/20251020000000_initial_schema.php
@@ -47,26 +47,14 @@ class InitialSchema extends AbstractMigration
      */
     public function up()
     {
-        // Get MODX instance
-        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
-        if (!file_exists($modxConfigPath)) {
-            throw new \RuntimeException('MODX config.core.php not found');
+        require_once __DIR__ . '/_modx.php';
+
+        $modx = ms3MigrationBootstrap();
+        if ($modx === null) {
+            throw new \RuntimeException('MODX could not be bootstrapped for InitialSchema migration');
         }
 
-        require_once $modxConfigPath;
-        if (!defined('MODX_CORE_PATH')) {
-            throw new \RuntimeException('MODX_CORE_PATH not defined');
-        }
-
-        require_once MODX_CORE_PATH . 'vendor/autoload.php';
-        require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
-
-        $modx = new \MODX\Revolution\modX();
-        $modx->initialize('mgr');
-
-        // Add MiniShop3 package with correct path
-        $modelPath = MODX_CORE_PATH . 'components/minishop3/src/Model/';
-        $modx->addPackage('MiniShop3\\Model', $modelPath, null, 'MiniShop3\\');
+        $modelPath = ms3MigrationModelPath($modx);
 
         $manager = $modx->getManager();
         $failedTables = [];

--- a/core/components/minishop3/migrations/20251020000000_initial_schema.php
+++ b/core/components/minishop3/migrations/20251020000000_initial_schema.php
@@ -75,12 +75,11 @@ class InitialSchema extends AbstractMigration
 
             $tableName = $modx->getTableName($fullClassName);
 
-            // Check if table already exists
+            // Existence check on the same PDO that runs DDL. Phinx's connection is inside
+            // START TRANSACTION and MySQL 8 will not see tables created on another connection.
             $sql = "SHOW TABLES LIKE '" . trim($tableName, '`') . "'";
-            $stmt = $this->adapter->getConnection()->prepare($sql);
-            $stmt->execute();
-
-            if ($stmt->fetch()) {
+            $exists = $modx->query($sql);
+            if ($exists && $exists->fetch()) {
                 $this->output->writeln("<comment>  Table {$tableName} already exists, skipping</comment>");
                 continue;
             }
@@ -101,8 +100,9 @@ class InitialSchema extends AbstractMigration
                 continue;
             }
 
-            $logicalTable = $this->resolveLogicalTableName($className);
-            if ($logicalTable !== null && !$this->hasTable($logicalTable)) {
+            $verify = $modx->query($sql);
+            if (!$verify || !$verify->fetch()) {
+                $logicalTable = $this->resolveLogicalTableName($className) ?? trim($tableName, '`');
                 $this->output->writeln(
                     "<error>  ✗ Failed to create table: {$tableName} (createObjectContainer succeeded but table is missing)</error>"
                 );
@@ -117,6 +117,9 @@ class InitialSchema extends AbstractMigration
         }
 
         $this->output->writeln('<info>MiniShop3 schema creation completed!</info>');
+
+        // Re-open Phinx TX so hasTable / addForeignKey see xPDO-created tables.
+        ms3MigrationRefreshPhinxTransaction($this->getAdapter());
 
         // Add foreign keys after all tables are created
         $this->addForeignKeys();

--- a/core/components/minishop3/migrations/20260518120000_create_option_groups_and_migrate.php
+++ b/core/components/minishop3/migrations/20260518120000_create_option_groups_and_migrate.php
@@ -30,7 +30,8 @@ class CreateOptionGroupsAndMigrate extends AbstractMigration
 
         // --- Step 1: create ms3_option_groups table via xPDO Manager ---
         if (!$this->hasTable('ms3_option_groups')) {
-            $modx = $this->bootstrapModx();
+            require_once __DIR__ . '/_modx.php';
+            $modx = ms3MigrationBootstrap();
             if ($modx === null) {
                 $this->output->writeln('<error>Cannot bootstrap MODX, aborting migration</error>');
                 return;
@@ -72,12 +73,7 @@ class CreateOptionGroupsAndMigrate extends AbstractMigration
         // Only run while modcategory_id still exists; on re-run after step 4 this becomes a no-op.
         $optionsTable = $this->table('ms3_options'); // refresh handle after schema change
         if ($optionsTable->hasColumn('modcategory_id')) {
-            $modxPrefix = $this->getModxTablePrefix();
-            if ($modxPrefix !== null) {
-                $this->migrateGroupData($modxPrefix, $optionsFqn, $optionGroupsFqn);
-            } else {
-                $this->output->writeln('<error>Cannot resolve MODX table prefix — skipping data migration. Existing modcategory_id values will be lost on column drop.</error>');
-            }
+            $this->migrateGroupData($prefix, $optionsFqn, $optionGroupsFqn);
 
             // --- Step 4: drop modcategory_id ---
             $optionsTable = $this->table('ms3_options'); // refresh handle
@@ -127,76 +123,6 @@ class CreateOptionGroupsAndMigrate extends AbstractMigration
         if ($this->hasTable('ms3_option_groups')) {
             $this->table('ms3_option_groups')->drop()->update();
         }
-    }
-
-    /**
-     * Bootstrap MODX with MS3 package registered. Returns null on failure.
-     *
-     * Same pattern as 20251020000000_initial_schema.php.
-     */
-    private function bootstrapModx(): ?\MODX\Revolution\modX
-    {
-        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
-        if (!file_exists($modxConfigPath)) {
-            $this->output->writeln('<error>MODX config.core.php not found</error>');
-            return null;
-        }
-
-        require_once $modxConfigPath;
-        if (!defined('MODX_CORE_PATH')) {
-            $this->output->writeln('<error>MODX_CORE_PATH not defined</error>');
-            return null;
-        }
-
-        require_once MODX_CORE_PATH . 'vendor/autoload.php';
-        require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
-
-        $modx = new \MODX\Revolution\modX();
-        $modx->initialize('mgr');
-
-        $modelPath = MODX_CORE_PATH . 'components/minishop3/src/Model/';
-        $modx->addPackage('MiniShop3\\Model', $modelPath, null, 'MiniShop3\\');
-
-        return $modx;
-    }
-
-    /**
-     * Read MODX table prefix from config.core.php → MODX_CONFIG_KEY → core/config/{key}.inc.php.
-     */
-    private function getModxTablePrefix(): ?string
-    {
-        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
-        if (!file_exists($modxConfigPath)) {
-            return null;
-        }
-        require_once $modxConfigPath;
-        if (!defined('MODX_CORE_PATH') || !defined('MODX_CONFIG_KEY')) {
-            return null;
-        }
-
-        $cfgPath = MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
-        if (!file_exists($cfgPath)) {
-            return null;
-        }
-
-        // The MODX config script defines $config_options['table_prefix'] and other variables.
-        $config_options = [];
-        $database_dsn = null;
-        $database_user = null;
-        $database_password = null;
-        $database_type = null;
-        $table_prefix = null;
-
-        // phpcs:ignore — variables become available after include
-        include $cfgPath;
-
-        if (is_string($table_prefix)) {
-            return $table_prefix;
-        }
-        if (is_array($config_options) && isset($config_options['table_prefix'])) {
-            return (string) $config_options['table_prefix'];
-        }
-        return null;
     }
 
     /**

--- a/core/components/minishop3/migrations/20260518120000_create_option_groups_and_migrate.php
+++ b/core/components/minishop3/migrations/20260518120000_create_option_groups_and_migrate.php
@@ -42,6 +42,8 @@ class CreateOptionGroupsAndMigrate extends AbstractMigration
                 $this->output->writeln('<error>Failed to create table ' . $optionGroupsFqn . '</error>');
                 return;
             }
+            // xPDO DDL is on another PDO; refresh Phinx TX so later hasTable/table() see it.
+            ms3MigrationRefreshPhinxTransaction($this->getAdapter());
             $this->output->writeln('<info>Created table ' . $optionGroupsFqn . '</info>');
         } else {
             $this->output->writeln('<comment>Table ' . $optionGroupsFqn . ' already exists, skipping create</comment>');

--- a/core/components/minishop3/migrations/20260522120000_repair_grid_fields_if_missing.php
+++ b/core/components/minishop3/migrations/20260522120000_repair_grid_fields_if_missing.php
@@ -113,6 +113,7 @@ final class RepairGridFieldsIfMissing extends AbstractMigration
 
         $tableFqn = $modx->getTableName(\MiniShop3\Model\msGridField::class);
         $created = $modx->getManager()->createObjectContainer(\MiniShop3\Model\msGridField::class);
+        ms3MigrationRefreshPhinxTransaction($this->getAdapter());
         if (!$created || !$this->hasTable('ms3_grid_fields')) {
             throw new \RuntimeException('Failed to create table ' . trim($tableFqn, '`'));
         }

--- a/core/components/minishop3/migrations/20260522120000_repair_grid_fields_if_missing.php
+++ b/core/components/minishop3/migrations/20260522120000_repair_grid_fields_if_missing.php
@@ -105,7 +105,12 @@ final class RepairGridFieldsIfMissing extends AbstractMigration
 
     private function ensureGridFieldsTable(): void
     {
-        $modx = $this->bootstrapModx();
+        require_once __DIR__ . '/_modx.php';
+        $modx = ms3MigrationBootstrap();
+        if ($modx === null) {
+            throw new \RuntimeException('MODX could not be bootstrapped for RepairGridFields migration');
+        }
+
         $tableFqn = $modx->getTableName(\MiniShop3\Model\msGridField::class);
         $created = $modx->getManager()->createObjectContainer(\MiniShop3\Model\msGridField::class);
         if (!$created || !$this->hasTable('ms3_grid_fields')) {
@@ -162,27 +167,4 @@ final class RepairGridFieldsIfMissing extends AbstractMigration
         $migration->up();
     }
 
-    private function bootstrapModx(): \MODX\Revolution\modX
-    {
-        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
-        if (!file_exists($modxConfigPath)) {
-            throw new \RuntimeException('MODX config.core.php not found');
-        }
-
-        require_once $modxConfigPath;
-        if (!defined('MODX_CORE_PATH')) {
-            throw new \RuntimeException('MODX_CORE_PATH not defined');
-        }
-
-        require_once MODX_CORE_PATH . 'vendor/autoload.php';
-        require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
-
-        $modx = new \MODX\Revolution\modX();
-        $modx->initialize('mgr');
-
-        $modelPath = MODX_CORE_PATH . 'components/minishop3/src/Model/';
-        $modx->addPackage('MiniShop3\\Model', $modelPath, null, 'MiniShop3\\');
-
-        return $modx;
-    }
 }

--- a/core/components/minishop3/migrations/_modx.php
+++ b/core/components/minishop3/migrations/_modx.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Self-contained MODX bootstrap helper for Phinx migrations.
+ *
+ * Migrations must not import MiniShop3 application code (transport install runs Phinx before the
+ * new component classes are autoloaded). This helper keeps that contract: no `use MiniShop3\`.
+ *
+ * Resolution order for the MODX instance:
+ *  1. A pre-set $GLOBALS['modx'] — injected by phinx.php (CLI on a real site) or by the testbench
+ *     live suite (see tests/Modx/Support/ExtraTestCase.php). Reusing the booted kernel avoids a
+ *     second modX instance and its separate connection in the same process.
+ *  2. CLI fallback: boot MODX from config.core.php at the extra root, for `vendor/bin/phinx` on a
+ *     real MODX install where no $modx is in scope yet.
+ *
+ * Resolution order for the model path (addPackage):
+ *  1. The `ms3_core_path` system setting — set by the transport resolver on a real install and
+ *     injected via $modx->setOption() by the testbench hook before Phinx runs.
+ *  2. Fallback: MODX_CORE_PATH . 'components/minishop3/src/Model/' — the standard install layout.
+ */
+
+if (!function_exists('ms3MigrationModx')) {
+    function ms3MigrationModx(): ?\MODX\Revolution\modX
+    {
+        if (isset($GLOBALS['modx']) && $GLOBALS['modx'] instanceof \MODX\Revolution\modX) {
+            return $GLOBALS['modx'];
+        }
+
+        $modxConfigPath = dirname(__FILE__, 5) . '/config.core.php';
+        if (!file_exists($modxConfigPath)) {
+            return null;
+        }
+
+        require_once $modxConfigPath;
+        if (!defined('MODX_CORE_PATH')) {
+            return null;
+        }
+
+        require_once MODX_CORE_PATH . 'vendor/autoload.php';
+        require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+
+        $modxClass = class_exists(\MODX\Revolution\modX::class, false)
+            ? \MODX\Revolution\modX::class
+            : (class_exists('modX', false) ? 'modX' : \MODX\Revolution\modX::class);
+
+        $modx = new $modxClass();
+        $modx->initialize('mgr');
+
+        $GLOBALS['modx'] = $modx;
+
+        return $modx;
+    }
+}
+
+if (!function_exists('ms3MigrationModelPath')) {
+    function ms3MigrationModelPath(\MODX\Revolution\modX $modx): string
+    {
+        $core = $modx->getOption('ms3_core_path', null, null);
+        if (is_string($core) && $core !== '') {
+            $path = rtrim($core, '/') . '/src/Model/';
+            if (is_dir($path)) {
+                return $path;
+            }
+        }
+
+        return MODX_CORE_PATH . 'components/minishop3/src/Model/';
+    }
+}
+
+if (!function_exists('ms3MigrationAddPackage')) {
+    /**
+     * Registers the MiniShop3 xPDO model on $modx using the resolved model path. Idempotent: a
+     * repeated addPackage() in the same process is a no-op for xPDO.
+     */
+    function ms3MigrationAddPackage(\MODX\Revolution\modX $modx): string
+    {
+        $modelPath = ms3MigrationModelPath($modx);
+        $modx->addPackage('MiniShop3\\Model', $modelPath, null, 'MiniShop3\\');
+
+        return $modelPath;
+    }
+}
+
+if (!function_exists('ms3MigrationBootstrap')) {
+    function ms3MigrationBootstrap(): ?\MODX\Revolution\modX
+    {
+        $modx = ms3MigrationModx();
+        if ($modx === null) {
+            return null;
+        }
+
+        ms3MigrationAddPackage($modx);
+
+        return $modx;
+    }
+}

--- a/core/components/minishop3/migrations/_modx.php
+++ b/core/components/minishop3/migrations/_modx.php
@@ -16,7 +16,9 @@
  * Resolution order for the model path (addPackage):
  *  1. The `ms3_core_path` system setting — set by the transport resolver on a real install and
  *     injected via $modx->setOption() by the testbench hook before Phinx runs.
- *  2. Fallback: MODX_CORE_PATH . 'components/minishop3/src/Model/' — the standard install layout.
+ *  2. Fallback: MODX_CORE_PATH . 'components/minishop3/src/' — PSR-4 root (same as composer.json
+ *     and PackageDefinition::model()). With namespacePrefix MiniShop3\, xPDO loads
+ *     {path}Model/metadata.mysql.php — so the path must be .../src/, not .../src/Model/.
  */
 
 if (!function_exists('ms3MigrationModx')) {
@@ -55,15 +57,25 @@ if (!function_exists('ms3MigrationModx')) {
 if (!function_exists('ms3MigrationModelPath')) {
     function ms3MigrationModelPath(\MODX\Revolution\modX $modx): string
     {
+        $candidates = [];
         $core = $modx->getOption('ms3_core_path', null, null);
         if (is_string($core) && $core !== '') {
-            $path = rtrim($core, '/') . '/src/Model/';
-            if (is_dir($path)) {
+            $candidates[] = rtrim($core, '/\\') . '/src/';
+        }
+        if (defined('MODX_CORE_PATH')) {
+            $candidates[] = MODX_CORE_PATH . 'components/minishop3/src/';
+        }
+
+        foreach ($candidates as $path) {
+            if (is_file($path . 'Model/metadata.mysql.php')) {
                 return $path;
             }
         }
 
-        return MODX_CORE_PATH . 'components/minishop3/src/Model/';
+        // Last resort: keep a directory that exists so addPackage does not fall back to XPDO_CORE_PATH.
+        return $candidates[0] ?? (defined('MODX_CORE_PATH')
+            ? MODX_CORE_PATH . 'components/minishop3/src/'
+            : __DIR__ . '/../src/');
     }
 }
 

--- a/core/components/minishop3/migrations/_modx.php
+++ b/core/components/minishop3/migrations/_modx.php
@@ -106,3 +106,31 @@ if (!function_exists('ms3MigrationBootstrap')) {
         return $modx;
     }
 }
+
+if (!function_exists('ms3MigrationRefreshPhinxTransaction')) {
+    /**
+     * Phinx wraps each migration in START TRANSACTION. xPDO DDL uses a separate PDO.
+     * MySQL 8 data-dictionary reads inside that open transaction do not see tables created
+     * on the other connection, so Phinx hasTable()/SHOW TABLES return false. Call after
+     * cross-connection DDL and before Phinx metadata checks or $this->table() on those tables.
+     *
+     * Duck-typed for AdapterInterface (no Phinx import — keeps migrations self-contained).
+     */
+    function ms3MigrationRefreshPhinxTransaction(object $adapter): void
+    {
+        if (
+            !method_exists($adapter, 'getConnection')
+            || !method_exists($adapter, 'commitTransaction')
+            || !method_exists($adapter, 'beginTransaction')
+        ) {
+            return;
+        }
+
+        $connection = $adapter->getConnection();
+        if ($connection instanceof \PDO && $connection->inTransaction()) {
+            $adapter->commitTransaction();
+        }
+
+        $adapter->beginTransaction();
+    }
+}

--- a/core/components/minishop3/phinx.php
+++ b/core/components/minishop3/phinx.php
@@ -34,6 +34,10 @@ if (!isset($modx)) {
     $modx->initialize('mgr');
 }
 
+// Expose the booted $modx to migrations: the three MODX-bootstrapping migrations resolve the
+// instance via $GLOBALS['modx'] (see migrations/_modx.php) instead of booting a second kernel.
+$GLOBALS['modx'] = $modx;
+
 require_once __DIR__ . '/phinx_mysql_charset.php';
 
 $dsnCharset = ms3PhinxExtractDsnCharset($modx->getOption('database_dsn', null, null));

--- a/core/components/minishop3/tests/MigrationSelfContainedTest.php
+++ b/core/components/minishop3/tests/MigrationSelfContainedTest.php
@@ -15,7 +15,7 @@ $fail = static function (string $message): never {
     exit(1);
 };
 
-$files = glob($migrationsDir . '/*.php') ?: [];
+$files = glob($migrationsDir . '/[0-9]*.php') ?: [];
 if ($files === []) {
     $fail('no migration files found');
 }
@@ -26,6 +26,15 @@ foreach ($files as $file) {
 
     if (preg_match('/^use MiniShop3\\\\/m', $source)) {
         $fail("{$basename} imports MiniShop3 namespace — keep migrations self-contained");
+    }
+}
+
+// Helpers colocated under migrations/ (e.g. _modx.php) must also stay free of use MiniShop3\.
+foreach (glob($migrationsDir . '/_*.php') ?: [] as $helper) {
+    $source = (string) file_get_contents($helper);
+    $basename = basename($helper);
+    if (preg_match('/^use MiniShop3\\\\/m', $source)) {
+        $fail("{$basename} imports MiniShop3 namespace — keep migration helpers self-contained");
     }
 }
 

--- a/core/components/minishop3/tests/Modx/ModelPersistTest.php
+++ b/core/components/minishop3/tests/Modx/ModelPersistTest.php
@@ -154,10 +154,15 @@ final class ModelPersistTest extends ExtraTestCase
             'name' => 'tb_' . $suffix,
             'label' => 'TB',
         ]);
+        // Phinx InitialSchema adds FK ms3_product_fields.section → ms3_page_sections.id (#695).
+        $productSection = $this->persistObject(msPageSection::class, [
+            'page_key' => 'product',
+            'section_key' => 'tb_pf_' . $suffix,
+        ]);
         $this->persistObject(msProductField::class, [
             'name' => 'tb_' . $suffix,
             'label' => 'TB',
-            'section' => 'main',
+            'section' => (int) $productSection->get('id'),
         ]);
 
         $this->assertObjectExists(msVendor::class, ['name' => 'TB Vendor ' . $suffix]);

--- a/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
+++ b/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
@@ -88,11 +88,18 @@ final class PhinxSchemaLiveTest extends ExtraTestCase
             /** @var array{fields?: array<string, mixed>} $metaMap */
             $metaMap = $mysqlClass::$metaMap;
             $mapFields = array_keys($metaMap['fields'] ?? []);
-            // PK comes from xPDOSimpleObject; generated maps omit it from fields.
-            if (!in_array('id', $mapFields, true)) {
+            $dbColumns = $this->listColumns($table);
+            // xPDOSimpleObject PK `id` is often omitted from generated `fields` but present on
+            // the table. Some maps still extend SimpleObject without an `id` column
+            // (e.g. msProductOption) — only expect `id` when it exists physically.
+            $extends = (string) ($metaMap['extends'] ?? '');
+            if (
+                str_ends_with($extends, 'xPDOSimpleObject')
+                && !in_array('id', $mapFields, true)
+                && in_array('id', $dbColumns, true)
+            ) {
                 $mapFields[] = 'id';
             }
-            $dbColumns = $this->listColumns($table);
 
             self::assertSame(
                 [],

--- a/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
+++ b/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
@@ -81,7 +81,17 @@ final class PhinxSchemaLiveTest extends ExtraTestCase
             $table = str_replace('`', '', (string) $quoted);
             $mappedTables[$table] = $class;
 
-            $mapFields = array_keys($this->modx->getFields($class));
+            // Compare against the generated mysql map, not runtime $modx->map (ExtraFields::loadMap
+            // can leave process-local fields after ExtraFieldMapTest).
+            $mysqlClass = str_replace('\\Model\\', '\\Model\\mysql\\', $class);
+            self::assertTrue(class_exists($mysqlClass), 'missing mysql map class ' . $mysqlClass);
+            /** @var array{fields?: array<string, mixed>} $metaMap */
+            $metaMap = $mysqlClass::$metaMap;
+            $mapFields = array_keys($metaMap['fields'] ?? []);
+            // PK comes from xPDOSimpleObject; generated maps omit it from fields.
+            if (!in_array('id', $mapFields, true)) {
+                $mapFields[] = 'id';
+            }
             $dbColumns = $this->listColumns($table);
 
             self::assertSame(

--- a/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
+++ b/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Model\msDelivery;
+use MiniShop3\Model\msGridField;
+use MiniShop3\Model\msOrderStatus;
+use MiniShop3\Model\msPayment;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+use MiniShop3\Tests\Modx\Support\PackageModels;
+use MiniShop3\Tests\Modx\Support\PhinxSchemaBootstrap;
+
+/**
+ * Asserts the live suite schema comes from Phinx migrations (#695), not PackageDefinition::tables().
+ *
+ * ExtraTestCase already migrated once per process before setUp(); these tests check outcomes.
+ */
+final class PhinxSchemaLiveTest extends ExtraTestCase
+{
+    /**
+     * Phinx metadata table is not an xPDO model — expected DB-only table.
+     *
+     * @var list<string> logical (unprefixed) names
+     */
+    private const DB_ONLY_TABLES = [
+        'ms3_migrations',
+    ];
+
+    public function testTablePrefixIsNonEmpty(): void
+    {
+        $prefix = (string) $this->modx->getOption('table_prefix', null, '');
+        self::assertNotSame('', $prefix, 'testbench must use a non-empty table prefix (#276)');
+    }
+
+    public function testSeedOrderStatusesExist(): void
+    {
+        $expected = [
+            'ms3_order_status_draft',
+            'ms3_order_status_new',
+            'ms3_order_status_paid',
+            'ms3_order_status_sent',
+            'ms3_order_status_cancelled',
+        ];
+        foreach ($expected as $name) {
+            self::assertGreaterThanOrEqual(
+                1,
+                $this->modx->getCount(msOrderStatus::class, ['name' => $name]),
+                'missing seeded status ' . $name
+            );
+        }
+    }
+
+    public function testSeedDeliveryAndPaymentExist(): void
+    {
+        self::assertGreaterThanOrEqual(1, $this->modx->getCount(msDelivery::class));
+        self::assertGreaterThanOrEqual(1, $this->modx->getCount(msPayment::class));
+    }
+
+    public function testSeedGridConfigsExist(): void
+    {
+        foreach (['orders', 'customers', 'deliveries', 'vendors', 'order_products', 'category-products'] as $gridKey) {
+            self::assertGreaterThanOrEqual(
+                1,
+                $this->modx->getCount(msGridField::class, ['grid_key' => $gridKey]),
+                'missing grid config rows for ' . $gridKey
+            );
+        }
+    }
+
+    public function testSchemaMatchesXpdoMapBidirectionally(): void
+    {
+        $prefix = (string) $this->modx->getOption('table_prefix', null, '');
+        // PackageModels lists dedicated ms3_* tables only. msProduct/msCategory extend
+        // modResource (site_content) and are checked via SchemaTablesTest / persist tests.
+        $mappedTables = [];
+        foreach (PackageModels::tables() as $class) {
+            $quoted = $this->modx->getTableName($class);
+            self::assertNotFalse($quoted, 'no table for ' . $class);
+            $table = str_replace('`', '', (string) $quoted);
+            $mappedTables[$table] = $class;
+
+            $mapFields = array_keys($this->modx->getFields($class));
+            $dbColumns = $this->listColumns($table);
+
+            self::assertSame(
+                [],
+                array_values(array_diff($mapFields, $dbColumns)),
+                $class . ' map fields missing in ' . $table
+            );
+            self::assertSame(
+                [],
+                array_values(array_diff($dbColumns, $mapFields)),
+                $table . ' has columns absent from ' . $class . ' map'
+            );
+        }
+
+        $allowedExtra = array_map(
+            static fn (string $logical): string => $prefix . $logical,
+            self::DB_ONLY_TABLES
+        );
+        $unexpected = array_values(array_diff(
+            $this->listPrefixedMs3Tables($prefix),
+            array_keys($mappedTables),
+            $allowedExtra
+        ));
+
+        self::assertSame([], $unexpected, 'ms3 tables present in DB but not in xPDO map allowlist');
+    }
+
+    public function testSecondMigrateIsIdempotent(): void
+    {
+        $seedClasses = [msOrderStatus::class, msDelivery::class, msPayment::class, msGridField::class];
+        $before = [];
+        foreach ($seedClasses as $class) {
+            $before[$class] = $this->modx->getCount($class);
+        }
+
+        PhinxSchemaBootstrap::migrate($this->modx, $this->extraCorePath());
+
+        foreach ($seedClasses as $class) {
+            self::assertSame($before[$class], $this->modx->getCount($class), $class);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listColumns(string $table): array
+    {
+        $statement = $this->modx->query('SHOW COLUMNS FROM `' . str_replace('`', '``', $table) . '`');
+        self::assertNotFalse($statement);
+        $columns = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $columns[] = (string) $row['Field'];
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listPrefixedMs3Tables(string $prefix): array
+    {
+        $like = $prefix . 'ms3\_%';
+        $statement = $this->modx->prepare('SHOW TABLES LIKE ?');
+        $statement->execute([$like]);
+        $tables = [];
+        while ($row = $statement->fetch(\PDO::FETCH_NUM)) {
+            $tables[] = (string) $row[0];
+        }
+
+        return $tables;
+    }
+}

--- a/core/components/minishop3/tests/Modx/README.md
+++ b/core/components/minishop3/tests/Modx/README.md
@@ -42,15 +42,32 @@ vendor/bin/modx-testbench destroy
 
 Do not run stub PHPUnit and `test:modx` in one PHP process (different bootstraps).
 
+## Schema source: Phinx migrations (#695)
+
+Live tests do **not** call `PackageDefinition::tables()`. Schema and seed data come from the same Phinx path as a real install (`resolver_02_migrations.php` → `phinx.php` → `Manager::migrate('production')`).
+
+How it runs in testbench:
+
+1. `ExtraTestCase` calls `PhinxSchemaBootstrap::ensure()` before opening snapshot isolation and sets `ms3_core_path` to the checkout core.
+2. On the **first** test of a process it runs all pending migrations (no-op when already applied), then **always** recaptures the RefreshesDatabase baseline so snapshot and DB cannot diverge after a crash between migrate and capture.
+3. Migrations that need xPDO Manager (`initial_schema`, `create_option_groups_and_migrate`, `repair_grid_fields_if_missing`) resolve `$modx` via `migrations/_modx.php` (injected instance first, `config.core.php` fallback for CLI on a real site).
+4. The lock `table_count` is synced via `SchemaInventory::countTablesWithPrefix()` so the next process does not reinstall.
+
+CI job `modx-testbench` already runs `composer test:modx` with a non-empty `MODX_TESTBENCH_DB_PREFIX` (`modx_`). `PhinxSchemaLiveTest` asserts seeds, bidirectional map↔table columns, and a second `migrate()` without duplicate rows.
+
+All other live tests in this suite share that post-migration snapshot through `ExtraTestCase`.
+
+To force a clean reinstall (drop migrated baseline): `MODX_TESTBENCH_FORCE_INSTALL=1 vendor/bin/modx-testbench install`.
+
 ## Layout
 
-- `Support/ExtraTestCase.php` — `PackageDefinition` matching `bootstrap.php`, `ServiceRegistry` via `ms3`
-- `Support/PackageModels.php` — xPDO table classes passed to `->tables()` (`msProduct` / `msCategory` stay on `modResource`)
+- `Support/ExtraTestCase.php` — `PackageDefinition` without `->tables()`, delegates schema to `PhinxSchemaBootstrap`
+- `Support/PhinxSchemaBootstrap.php` — once-per-process migrate + snapshot recapture + lock sync
+- `Support/PackageModels.php` — xPDO table classes for schema comparison (`msProduct` / `msCategory` are separate because they extend `modResource`)
+- `PhinxSchemaLiveTest.php` — migration outcome checks (#695)
 - `phpunit.modx.xml` — testbench bootstrap, suite `Modx`
 
 The suite covers schema (`SHOW TABLES`), persist for every MiniShop3 table class, product/category resources plus composite rows, GetList/Create/Enable/Disable processors, DI `has()`/`get()` for every default service, extra-field `loadMap()`, customer `RegisterService`, settings, and plugin events (`msOnSaveOrder`, `msOnVendorCreate`).
-
-Schema for this suite comes from `PackageDefinition::tables()` (xPDO `createObjectContainer`). Full Phinx migrate is not run here: `InitialSchema` boots a second kernel from `config.core.php` at the extra root, which is not a MODX install in git. `phinx.php` is still checked against the live `$modx` connection. A later change can inject that `$modx` into `InitialSchema`.
 
 Processors are PSR-4 classes under `src/Processors/`. Address them by FQCN (`Create::class`). A string action without `processors_path` is resolved against core processors and fails with “Requested processor not found”.
 

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -21,7 +21,8 @@ use xPDO\Om\xPDOObject;
  * Live MODX 3 kernel for MiniShop3 (testbench level 2).
  *
  * Isolated from stub PHPUnit via phpunit.modx.xml. RefreshesDatabase is required:
- * PackageDefinition::tables() runs DDL, which commits the test transaction.
+ * Phinx migrations run DDL once per process, then the baseline snapshot is recaptured
+ * ({@see PhinxSchemaBootstrap}).
  */
 abstract class ExtraTestCase extends TestCase
 {
@@ -32,16 +33,24 @@ abstract class ExtraTestCase extends TestCase
         $core = $this->extraCorePath();
         $assets = $this->extraAssetsPath();
 
+        // No ->tables(...): schema comes from Phinx (PhinxSchemaBootstrap).
         return PackageDefinition::make('minishop3')
             ->corePath($core)
             ->assetsPath($assets)
             ->model('MiniShop3\\Model', $core . 'src/', null, 'MiniShop3\\')
-            ->tables(...PackageModels::tables())
             ->settings([
                 'ms3_core_path' => $core,
                 'ms3_token_name' => 'ms3_token',
             ])
             ->service('ms3', fn (): MiniShop3 => new MiniShop3($this->modx));
+    }
+
+    protected function setUp(): void
+    {
+        // Before parent::setUp() opens snapshot isolation and loadMap() hits ms3_extra_fields.
+        PhinxSchemaBootstrap::ensure($this->extraCorePath());
+
+        parent::setUp();
     }
 
     protected function afterPackageRegistered(): void

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -6,6 +6,7 @@ namespace MiniShop3\Tests\Modx\Support;
 
 use MiniShop3\MiniShop3;
 use MiniShop3\ServiceRegistry;
+use MiniShop3\Utils\ExtraFields;
 use ModxKit\Testbench\Concerns\RefreshesDatabase;
 use ModxKit\Testbench\Package\PackageDefinition;
 use ModxKit\Testbench\TestCase;
@@ -15,6 +16,7 @@ use MODX\Revolution\modPluginEvent;
 use MODX\Revolution\modX;
 use MODX\Revolution\Processors\ProcessorResponse;
 use ReflectionClass;
+use ReflectionProperty;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -57,6 +59,29 @@ abstract class ExtraTestCase extends TestCase
     {
         /** @var MiniShop3 $ms3 */
         $ms3 = $this->modx->services->get('ms3');
+
+        // ExtraFields::loadMap() merges into $modx->map and file-caches meta. RefreshesDatabase
+        // rolls back msExtraField rows but leaves map/cache dirty across tests
+        // (ExtraFieldMapTest → later msVendor asserts). Rebuild a clean map each test.
+        (new ExtraFields($this->modx))->clearCache();
+        $mapLoaded = new ReflectionProperty(MiniShop3::class, 'mapLoaded');
+        $mapLoaded->setAccessible(true);
+        $mapLoaded->setValue($ms3, false);
+
+        $inner = new ReflectionProperty($this->modx->map, 'map');
+        $inner->setAccessible(true);
+        /** @var array<string, mixed> $loaded */
+        $loaded = $inner->getValue($this->modx->map);
+        foreach (array_keys($loaded) as $class) {
+            if (
+                is_string($class)
+                && str_starts_with($class, 'MiniShop3\\Model\\')
+                && !str_contains($class, '\\mysql\\')
+            ) {
+                unset($this->modx->map[$class]);
+            }
+        }
+
         $ms3->loadMap();
     }
 

--- a/core/components/minishop3/tests/Modx/Support/PhinxSchemaBootstrap.php
+++ b/core/components/minishop3/tests/Modx/Support/PhinxSchemaBootstrap.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx\Support;
+
+use ModxKit\Testbench\Database\SchemaInventory;
+use ModxKit\Testbench\Environment\LockFile;
+use ModxKit\Testbench\Environment\TestbenchKernel;
+use MODX\Revolution\modX;
+use Phinx\Config\Config as PhinxConfig;
+use Phinx\Migration\Manager as PhinxManager;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Once-per-process Phinx migrate + testbench snapshot recapture for live tests (#695).
+ *
+ * Mirrors resolver_02_migrations.php. Always migrates (no-op when pending is empty) and
+ * recaptures the RefreshesDatabase baseline so a crash between migrate and capture cannot
+ * leave a bare-MODX snapshot while ms3 tables already exist.
+ */
+final class PhinxSchemaBootstrap
+{
+    private static bool $ready = false;
+
+    public static function ensure(string $componentCorePath): void
+    {
+        if (self::$ready) {
+            return;
+        }
+
+        $kernel = TestbenchKernel::instance();
+        $modx = $kernel->modx();
+        $modx->setOption('ms3_core_path', $componentCorePath);
+
+        self::migrate($modx, $componentCorePath);
+        $kernel->snapshots()->capture();
+        self::syncLockTableCount($kernel);
+
+        self::$ready = true;
+    }
+
+    public static function migrate(modX $modx, string $componentCorePath): void
+    {
+        $GLOBALS['modx'] = $modx;
+        $configArray = require rtrim($componentCorePath, '/\\') . '/phinx.php';
+
+        if (!isset($configArray['paths']['migrations'])) {
+            throw new \RuntimeException('MiniShop3 phinx.php did not return a migrations path');
+        }
+
+        $manager = new PhinxManager(
+            new PhinxConfig($configArray),
+            new StringInput(''),
+            new BufferedOutput(),
+        );
+        $manager->migrate('production');
+    }
+
+    private static function syncLockTableCount(TestbenchKernel $kernel): void
+    {
+        $workspace = $kernel->workspace();
+        $lock = $workspace->readLock();
+        if ($lock === null) {
+            return;
+        }
+
+        $tableCount = SchemaInventory::countTablesWithPrefix($kernel->config()->database);
+        $format = $kernel->snapshots()->format();
+        $workspace->writeLock(new LockFile(
+            fingerprint: $lock->fingerprint,
+            modxVersion: $lock->modxVersion,
+            provider: $lock->provider,
+            tablePrefix: $lock->tablePrefix,
+            installedAt: $lock->installedAt,
+            hasSnapshot: true,
+            tableCount: $tableCount,
+            snapshotFormat: $format !== '' ? $format : $lock->snapshotFormat,
+            installRevision: $lock->installRevision,
+        ));
+    }
+}

--- a/core/components/minishop3/tests/Modx/Support/PhinxSchemaBootstrap.php
+++ b/core/components/minishop3/tests/Modx/Support/PhinxSchemaBootstrap.php
@@ -50,12 +50,27 @@ final class PhinxSchemaBootstrap
             throw new \RuntimeException('MiniShop3 phinx.php did not return a migrations path');
         }
 
+        $output = new BufferedOutput();
         $manager = new PhinxManager(
             new PhinxConfig($configArray),
             new StringInput(''),
-            new BufferedOutput(),
+            $output,
         );
-        $manager->migrate('production');
+
+        try {
+            $manager->migrate('production');
+        } catch (\Throwable $e) {
+            $buffer = trim($output->fetch());
+            if ($buffer !== '') {
+                throw new \RuntimeException(
+                    $e->getMessage() . "\n--- Phinx output ---\n" . $buffer,
+                    (int) $e->getCode(),
+                    $e
+                );
+            }
+
+            throw $e;
+        }
     }
 
     private static function syncLockTableCount(TestbenchKernel $kernel): void


### PR DESCRIPTION
## Описание

Live-сьют testbench создаёт схему через полный прогон Phinx (как `resolver_02_migrations.php`), а не через `PackageDefinition::tables()`. Три миграции с bootstrap MODX принимают инжектированный `$modx` (`migrations/_modx.php` + `$GLOBALS['modx']` в `phinx.php`).

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [x] Документация
- [x] Другое (опишите): tech-debt live-тестов / coverage миграций

## Связанные Issues

Closes #695

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l migrations/_modx.php \
  migrations/20251020000000_initial_schema.php \
  migrations/20260518120000_create_option_groups_and_migrate.php \
  migrations/20260522120000_repair_grid_fields_if_missing.php \
  phinx.php \
  tests/Modx/Support/ExtraTestCase.php \
  tests/Modx/Support/PhinxSchemaBootstrap.php \
  tests/Modx/PhinxSchemaLiveTest.php
# exit 0

php tests/MigrationSelfContainedTest.php   # OK, exit 0
php tests/PhinxMigrationTablePrefixTest.php # OK, exit 0
```

`composer test:modx` локально не гонялся (нет доступа к MySQL testbench). Ожидается зелёный job `modx-testbench` в CI.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / smoke; live — CI `test:modx`)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `test/issue-695-phinx-live-schema`
- MODX: testbench 3.1 / 3.2 (CI matrix)
- PHP: 8.2+

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — не требуется
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`) — затронут в основном `tests/Modx` + миграции
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — не требуется
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — не трогаем вне релиза

## Дополнительные заметки

**Способ запуска в testbench (AC):** `PhinxSchemaBootstrap::ensure()` до `parent::setUp()` — migrate (idempotent) + recapture snapshot + sync `table_count` через `SchemaInventory::countTablesWithPrefix()`.

**Выпущенные миграции:** меняется только bootstrap (`_modx.php`), не схема/данные. На уже применённых сайтах `up()` не повторится. Нужна ручная проверка **чистой установки** на тестовом сайте (AC human gate).

**Вне скоупа:** upgrade-path с дампом старого релиза; статическая сверка `schema.xml` ↔ карта.