### PR TITLE
Live-тесты: реальные проверки прав процессоров

### DIFF
--- a/core/components/minishop3/tests/Modx/ExtraFieldMapTest.php
+++ b/core/components/minishop3/tests/Modx/ExtraFieldMapTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Modx;
 
+use MiniShop3\MiniShop3;
 use MiniShop3\Model\msExtraField;
 use MiniShop3\Model\msVendor;
 use MiniShop3\Tests\Modx\Support\ExtraTestCase;
 use MiniShop3\Utils\ExtraFields;
+use ReflectionProperty;
 
 final class ExtraFieldMapTest extends ExtraTestCase
 {
@@ -33,5 +35,23 @@ final class ExtraFieldMapTest extends ExtraTestCase
         self::assertArrayHasKey($key, $this->modx->map[msVendor::class]['fields'] ?? []);
         self::assertSame('varchar', $this->modx->map[msVendor::class]['fieldMeta'][$key]['dbtype'] ?? null);
         self::assertSame('string', $this->modx->map[msVendor::class]['fieldMeta'][$key]['phptype'] ?? null);
+    }
+
+    protected function tearDown(): void
+    {
+        // RefreshesDatabase rolls back msExtraField rows; clear in-memory merge + file cache
+        // so later tests do not SELECT phantom columns on msVendor.
+        (new ExtraFields($this->modx))->clearCache();
+        unset($this->modx->map[msVendor::class]);
+
+        if ($this->modx->services->has('ms3')) {
+            /** @var MiniShop3 $ms3 */
+            $ms3 = $this->modx->services->get('ms3');
+            $mapLoaded = new ReflectionProperty(MiniShop3::class, 'mapLoaded');
+            $mapLoaded->setAccessible(true);
+            $mapLoaded->setValue($ms3, false);
+        }
+
+        parent::tearDown();
     }
 }

--- a/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
+++ b/core/components/minishop3/tests/Modx/ProcessorCoverageTest.php
@@ -51,16 +51,17 @@ final class ProcessorCoverageTest extends ExtraTestCase
 
     public function testGetListProcessorsDenyAnonymousWhenPoliciesAreEnforced(): void
     {
-        $this->skipUnlessProcessorPoliciesAreEnforced();
+        $this->withProcessorPoliciesEnforced(function (): void {
+            $this->actingAsPlain();
 
-        $this->actingAsPlain();
-
-        foreach ($this->getListProcessors() as [$class, $properties]) {
-            $this->modx->error->reset();
-            $response = $this->runExtraProcessor($class, $properties);
-            $this->assertProcessorFailure($response);
-            self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
-        }
+            foreach ($this->getListProcessors() as [$class, $properties, $permission]) {
+                $this->modx->error->reset();
+                $response = $this->runExtraProcessor($class, $properties + [
+                    'action' => 'ms3_acl_deny',
+                ]);
+                $this->assertProcessorPermissionDenied($response, $permission, 'ms3_acl_deny');
+            }
+        });
     }
 
     public function testSettingsCreateEnableDisableRoundTrip(): void
@@ -114,19 +115,19 @@ final class ProcessorCoverageTest extends ExtraTestCase
     }
 
     /**
-     * @return list<array{0: class-string, 1: array<string, mixed>}>
+     * @return list<array{0: class-string, 1: array<string, mixed>, 2: string}>
      */
     private function getListProcessors(): array
     {
         return [
-            [VendorGetList::class, ['limit' => 10]],
-            [PaymentGetList::class, ['limit' => 10]],
-            [DeliveryGetList::class, ['limit' => 10]],
-            [LinkGetList::class, ['limit' => 10]],
-            [StatusGetList::class, ['limit' => 10]],
-            [CustomerGetList::class, ['limit' => 10]],
-            [CustomerAddressGetList::class, ['limit' => 10]],
-            [GalleryGetList::class, ['product_id' => 0, 'limit' => 10]],
+            [VendorGetList::class, ['limit' => 10], 'mssetting_list'],
+            [PaymentGetList::class, ['limit' => 10], 'mssetting_list'],
+            [DeliveryGetList::class, ['limit' => 10], 'mssetting_list'],
+            [LinkGetList::class, ['limit' => 10], 'mssetting_list'],
+            [StatusGetList::class, ['limit' => 10], 'mssetting_list'],
+            [CustomerGetList::class, ['limit' => 10], 'msorder_list'],
+            [CustomerAddressGetList::class, ['limit' => 10], 'msorder_list'],
+            [GalleryGetList::class, ['product_id' => 0, 'limit' => 10], 'msproductfile_list'],
         ];
     }
 }

--- a/core/components/minishop3/tests/Modx/ProductProcessorAclTest.php
+++ b/core/components/minishop3/tests/Modx/ProductProcessorAclTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Modx;
+
+use MiniShop3\Processors\Product\Multiple;
+use MiniShop3\Tests\Modx\Support\ExtraTestCase;
+
+/** Product\Multiple is an ACL canary: without $permission it returns success() for empty ids (#696). */
+final class ProductProcessorAclTest extends ExtraTestCase
+{
+    public function testMultipleDeniesPlainUserWithoutMsproductSave(): void
+    {
+        $this->withProcessorPoliciesEnforced(function (): void {
+            $this->actingAsPlain();
+
+            $response = $this->runExtraProcessor(Multiple::class, [
+                'method' => 'Delete',
+                'ids' => '[]',
+                'action' => 'ms3_acl_deny',
+            ]);
+
+            $this->assertProcessorPermissionDenied($response, 'msproduct_save', 'ms3_acl_deny');
+        });
+    }
+}

--- a/core/components/minishop3/tests/Modx/README.md
+++ b/core/components/minishop3/tests/Modx/README.md
@@ -54,4 +54,9 @@ Schema for this suite comes from `PackageDefinition::tables()` (xPDO `createObje
 
 Processors are PSR-4 classes under `src/Processors/`. Address them by FQCN (`Create::class`). A string action without `processors_path` is resolved against core processors and fails with “Requested processor not found”.
 
-`$permission` on processors is checked through `modContext::checkPolicy()`. That method returns true unless the MODX session is `SESSION_STATE_INITIALIZED`. Testbench boots in API mode without that session, so ACL-deny cases are skipped (`skipUnlessProcessorPoliciesAreEnforced()`). Sudo create/list still runs.
+Processor `$permission` runs through `modContext::checkPolicy()` only when the session is
+`SESSION_STATE_INITIALIZED`. Testbench boots in API/CLI (`SESSION_STATE_UNAVAILABLE`), so deny
+tests use `ExtraTestCase::withProcessorPoliciesEnforced()` to force INITIALIZED for the callback
+and restore afterward (#696). Use `assertProcessorPermissionDenied()` — it compares the full
+`permission_denied_processor` lexicon string (pass the same `action` property you give the
+processor). Pass `action` so core `preg_replace` on PHP 8.4+ does not see `null`.

--- a/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
+++ b/core/components/minishop3/tests/Modx/StatusCreateProcessorTest.php
@@ -12,28 +12,25 @@ final class StatusCreateProcessorTest extends ExtraTestCase
 {
     public function testCreateRequiresMssettingSave(): void
     {
-        $this->skipUnlessProcessorPoliciesAreEnforced();
-        $user = $this->createUser(['username' => 'editor-no-settings']);
-        $this->actingAs($user);
+        $this->withProcessorPoliciesEnforced(function (): void {
+            $this->actingAsPlain();
 
-        $response = $this->runProcessor(Create::class, [
-            'name' => 'testbench-denied',
-        ]);
+            $response = $this->runExtraProcessor(Create::class, [
+                'name' => 'testbench-denied',
+                'action' => 'ms3_acl_deny',
+            ]);
 
-        $this->assertProcessorFailure($response);
-        self::assertStringContainsStringIgnoringCase('access denied', $response->getMessage());
-        $this->assertObjectMissing(msOrderStatus::class, ['name' => 'testbench-denied']);
+            $this->assertProcessorPermissionDenied($response, 'mssetting_save', 'ms3_acl_deny');
+            $this->assertObjectMissing(msOrderStatus::class, ['name' => 'testbench-denied']);
+        });
     }
 
     public function testCreateSucceedsForSudoUser(): void
     {
-        $user = $this->createUser(['username' => 'sudo-settings', 'sudo' => true]);
-        $this->actingAs($user);
+        $this->actingAsSudo();
 
-        $response = $this->runProcessor(Create::class, [
+        $response = $this->runExtraProcessor(Create::class, [
             'name' => 'testbench-status',
-        ], [
-            'processors_path' => dirname(__DIR__, 2) . '/src/Processors/',
         ]);
 
         $this->assertProcessorSuccess($response);

--- a/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
+++ b/core/components/minishop3/tests/Modx/Support/ExtraTestCase.php
@@ -15,6 +15,7 @@ use MODX\Revolution\modPluginEvent;
 use MODX\Revolution\modX;
 use MODX\Revolution\Processors\ProcessorResponse;
 use ReflectionClass;
+use ReflectionProperty;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -165,20 +166,59 @@ abstract class ExtraTestCase extends TestCase
     }
 
     /**
-     * Processor $permission is enforced via context checkPolicy(), which returns true unless
-     * the session is INITIALIZED. Testbench boots the kernel in API mode without that session.
+     * Force SESSION_STATE_INITIALIZED so processor $permission checks run (#696).
+     * Testbench defaults to UNAVAILABLE and checkPolicy() short-circuits to true.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
      */
-    protected function processorPoliciesAreEnforced(): bool
+    protected function withProcessorPoliciesEnforced(callable $callback): mixed
     {
-        return $this->modx->getSessionState() === modX::SESSION_STATE_INITIALIZED;
+        $sessionState = new ReflectionProperty(modX::class, '_sessionState');
+        $sessionState->setAccessible(true);
+        $previous = $sessionState->getValue($this->modx);
+        $sessionState->setValue($this->modx, modX::SESSION_STATE_INITIALIZED);
+
+        try {
+            // Processor::run() emits permission_denied_processor before loading getLanguageTopics().
+            $this->modx->lexicon->load('default');
+
+            return $callback();
+        } finally {
+            $sessionState->setValue($this->modx, $previous);
+            $this->clearUserAttributeSessionCache();
+        }
     }
 
-    protected function skipUnlessProcessorPoliciesAreEnforced(): void
+    /**
+     * @param non-empty-string $permission Processor $permission value expected in the lexicon message
+     * @param string $action Value for [[+action]] (empty string matches Processor::run when action is unset)
+     */
+    protected function assertProcessorPermissionDenied(
+        ProcessorResponse $response,
+        string $permission,
+        string $action = ''
+    ): void {
+        $this->assertProcessorFailure($response);
+        self::assertSame(
+            $this->modx->lexicon('permission_denied_processor', [
+                'permission' => $permission,
+                'action' => $action,
+            ]),
+            $response->getMessage()
+        );
+    }
+
+    private function clearUserAttributeSessionCache(): void
     {
-        if (!$this->processorPoliciesAreEnforced()) {
-            self::markTestSkipped(
-                'Processor ACL is not enforced without an initialized MODX session (testbench API boot).'
-            );
+        if (!isset($_SESSION) || !is_array($_SESSION)) {
+            return;
+        }
+
+        $keys = preg_grep('/^modx\.user\..*attributes/', array_keys($_SESSION)) ?: [];
+        foreach ($keys as $key) {
+            unset($_SESSION[$key]);
         }
     }
 }


### PR DESCRIPTION
## Описание

В live-сьюте на testbench проверки `$permission` не работали: в CLI `getSessionState()` даёт `SESSION_STATE_UNAVAILABLE`, и `checkPolicy()` всегда возвращает `true`. Deny-тесты вечно пропускались.

Добавлен `withProcessorPoliciesEnforced()`: на время callback форсируется `SESSION_STATE_INITIALIZED`, затем состояние восстанавливается. Deny-тесты GetList/Status Create реально выполняются. Добавлен canary на `Product/Multiple` (`msproduct_save`). Сообщение отказа сверяется с лексиконом `permission_denied_processor`.

## Тип изменений

- [ ] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [x] Документация
- [x] Другое (опишите): тестовая инфраструктура live MODX / ACL

## Связанные Issues

Closes #696

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l tests/Modx/Support/ExtraTestCase.php
php -l tests/Modx/ProductProcessorAclTest.php
php -l tests/Modx/ProcessorCoverageTest.php
php -l tests/Modx/StatusCreateProcessorTest.php
php -l tests/Modx/ExtraFieldMapTest.php
# все exit 0

./vendor/bin/phpunit -c phpunit.modx.xml --filter \
  'ProcessorCoverageTest|StatusCreateProcessorTest|ProductProcessorAclTest|ExtraFieldMapTest|VendorCreateEventTest'
# exit 0 — Tests: 9, Assertions: 68, Skipped: 0 (для ACL deny)
```

Canary вручную: пустой `$permission` у `Product/Multiple` → `ProductProcessorAclTest` падает. После возврата `$permission = 'msproduct_save'` — зелёный.

Полный `composer ci:php` / vue lint / stan в этом PR не гонялись (только live Modx ACL-слой). Ожидается зелёный job live MODX в CI.

- [x] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-696-processor-acl-session`
- MODX: testbench live suite (как в CI)
- PHP: локальный CLI (8.x)

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Не продакшен-код: только `tests/Modx/*` и README сьюта.
- `ExtraFieldMapTest::tearDown` чистит map/cache после merge extra fields (изоляция от последующих тестов на `msVendor`).
- Вне скоупа: правки самого `modxkit/testbench`, покрытие Sort отдельно (canary — Multiple).