### PR TITLE
fix(web-api): Align catalog resolve context errors with get/{id}

### DIFF
--- a/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/CategoryController.php
@@ -65,20 +65,18 @@ class CategoryController
      */
     public function resolve(array $params = []): Response
     {
-        $parsed = CatalogResolve::parseLookup(
-            $params,
-            (string) ($this->modx->context->key ?? 'web'),
-        );
+        try {
+            $parsed = CatalogResolve::parseLookup(
+                $params,
+                (string) ($this->modx->context->key ?? 'web'),
+            );
+        } catch (CatalogContextException $e) {
+            return $this->catalogContextBadRequest($e);
+        }
 
         if (!$parsed['ok']) {
-            $lexiconKey = match ($parsed['error']) {
-                'required' => 'ms3_err_catalog_lookup_required',
-                'conflict' => 'ms3_err_catalog_lookup_conflict',
-                'invalid' => 'ms3_err_catalog_lookup_invalid',
-            };
-
             return Response::error(
-                $this->modx->lexicon($lexiconKey),
+                $this->modx->lexicon(CatalogResolve::lookupErrorLexiconKey($parsed['error'])),
                 HttpStatus::BAD_REQUEST
             );
         }

--- a/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
+++ b/core/components/minishop3/src/Controllers/Api/Web/ProductController.php
@@ -69,20 +69,18 @@ class ProductController
      */
     public function resolve(array $params = []): Response
     {
-        $parsed = CatalogResolve::parseLookup(
-            $params,
-            (string) ($this->modx->context->key ?? 'web'),
-        );
+        try {
+            $parsed = CatalogResolve::parseLookup(
+                $params,
+                (string) ($this->modx->context->key ?? 'web'),
+            );
+        } catch (CatalogContextException $e) {
+            return $this->catalogParamBadRequest($e);
+        }
 
         if (!$parsed['ok']) {
-            $lexiconKey = match ($parsed['error']) {
-                'required' => 'ms3_err_catalog_lookup_required',
-                'conflict' => 'ms3_err_catalog_lookup_conflict',
-                'invalid' => 'ms3_err_catalog_lookup_invalid',
-            };
-
             return Response::error(
-                $this->modx->lexicon($lexiconKey),
+                $this->modx->lexicon(CatalogResolve::lookupErrorLexiconKey($parsed['error'])),
                 HttpStatus::BAD_REQUEST
             );
         }

--- a/core/components/minishop3/src/Services/Catalog/CatalogResolve.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogResolve.php
@@ -98,6 +98,8 @@ final class CatalogResolve
 
     /**
      * Lexicon key for a failed {@see parseLookup()} result.
+     *
+     * @param 'required'|'conflict'|'invalid' $error
      */
     public static function lookupErrorLexiconKey(string $error): string
     {

--- a/core/components/minishop3/src/Services/Catalog/CatalogResolve.php
+++ b/core/components/minishop3/src/Services/Catalog/CatalogResolve.php
@@ -11,8 +11,6 @@ use MODX\Revolution\modX;
  */
 final class CatalogResolve
 {
-    private const MAX_CONTEXT_LENGTH = 100;
-
     /**
      * Return resource id when exactly one row matches $criteria; 0 or 2+ rows → null.
      *
@@ -45,61 +43,69 @@ final class CatalogResolve
     /**
      * @param array<string, mixed> $params
      * @return array{ok: true, field: 'alias'|'uri', value: string, context: string}|array{ok: false, error: 'required'|'conflict'|'invalid'}
+     *
+     * @throws CatalogContextException
      */
     public static function parseLookup(array $params, string $contextFallback = 'web'): array
     {
-        foreach (['alias', 'uri', 'context'] as $key) {
+        foreach (['alias', 'uri'] as $key) {
             if (array_key_exists($key, $params) && !self::isScalarLookupParam($params[$key])) {
                 return ['ok' => false, 'error' => 'invalid'];
             }
         }
 
-        $hasAlias = array_key_exists('alias', $params);
-        $hasUri = array_key_exists('uri', $params);
+        $alias = array_key_exists('alias', $params) ? trim((string) $params['alias']) : null;
+        $uri = array_key_exists('uri', $params) ? trim((string) $params['uri']) : null;
 
-        $aliasRaw = $hasAlias ? trim((string) $params['alias']) : '';
-        $uriRaw = $hasUri ? trim((string) $params['uri']) : '';
+        $hasAlias = $alias !== null && $alias !== '';
+        $hasUri = $uri !== null && $uri !== '';
 
-        $aliasProvided = $hasAlias && $aliasRaw !== '';
-        $uriProvided = $hasUri && $uriRaw !== '';
-
-        if ($aliasProvided && $uriProvided) {
+        if ($hasAlias && $hasUri) {
             return ['ok' => false, 'error' => 'conflict'];
         }
 
-        if (!$aliasProvided && !$uriProvided) {
+        if (!$hasAlias && !$hasUri) {
             return ['ok' => false, 'error' => 'required'];
         }
 
-        $context = self::resolveLookupContext($params, $contextFallback);
-        if ($context === null) {
-            return ['ok' => false, 'error' => 'invalid'];
-        }
+        $context = CatalogQuery::resolveContext($params, $contextFallback);
 
-        if ($aliasProvided) {
-            if (!self::isValidAlias($aliasRaw)) {
+        if ($hasAlias) {
+            if (self::containsUriRejectPattern($alias)) {
                 return ['ok' => false, 'error' => 'invalid'];
             }
 
             return [
                 'ok' => true,
                 'field' => 'alias',
-                'value' => $aliasRaw,
+                'value' => $alias,
                 'context' => $context,
             ];
         }
 
-        $uri = self::normalizeUri($uriRaw);
-        if ($uri === null) {
+        $normalizedUri = self::normalizeUri($uri ?? '');
+        if ($normalizedUri === null) {
             return ['ok' => false, 'error' => 'invalid'];
         }
 
         return [
             'ok' => true,
             'field' => 'uri',
-            'value' => $uri,
+            'value' => $normalizedUri,
             'context' => $context,
         ];
+    }
+
+    /**
+     * Lexicon key for a failed {@see parseLookup()} result.
+     */
+    public static function lookupErrorLexiconKey(string $error): string
+    {
+        return match ($error) {
+            'required' => 'ms3_err_catalog_lookup_required',
+            'conflict' => 'ms3_err_catalog_lookup_conflict',
+            'invalid' => 'ms3_err_catalog_lookup_invalid',
+        };
     }
 
     /**
@@ -141,49 +147,9 @@ final class CatalogResolve
         return array_values(array_unique($variants));
     }
 
-    /**
-     * @param array<string, mixed> $params
-     */
-    private static function resolveLookupContext(array $params, string $fallback): ?string
-    {
-        if (array_key_exists('context', $params)) {
-            $raw = trim((string) $params['context']);
-            if ($raw !== '') {
-                return self::sanitizeContext($raw);
-            }
-        }
-
-        $resolved = CatalogQuery::resolveContext($params, $fallback);
-
-        return self::sanitizeContext($resolved);
-    }
-
     private static function isScalarLookupParam(mixed $value): bool
     {
         return is_string($value) || is_int($value);
-    }
-
-    private static function sanitizeContext(string $key): ?string
-    {
-        $key = trim($key);
-        if ($key === '' || strlen($key) > self::MAX_CONTEXT_LENGTH) {
-            return null;
-        }
-
-        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $key)) {
-            return null;
-        }
-
-        if (str_starts_with(strtolower($key), 'mgr')) {
-            return null;
-        }
-
-        return $key;
-    }
-
-    private static function isValidAlias(string $alias): bool
-    {
-        return $alias !== '' && !self::containsUriRejectPattern($alias);
     }
 
     private static function containsUriRejectPattern(string $value): bool

--- a/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
+++ b/core/components/minishop3/tests/CategoryCatalogRoutesTest.php
@@ -63,6 +63,10 @@ if (!str_contains($controllerSrc, 'CatalogResolve::parseLookup')) {
     $fail('CategoryController must parse catalog lookup via CatalogResolve');
 }
 
+if (!str_contains($controllerSrc, 'CatalogContextException')) {
+    $fail('CategoryController resolve must map CatalogContextException');
+}
+
 if (!str_contains($serviceSrc, 'hidemenu')) {
     $fail('CategoryCatalogService must handle hidemenu / include_hidden');
 }

--- a/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
+++ b/core/components/minishop3/tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php
@@ -27,6 +27,25 @@ final class HeadlessStorefrontErrorsTest extends WebApiTestCase
         $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_err_catalog_lookup_required');
     }
 
+    #[DataProvider('invalidCatalogContextRoutes')]
+    public function testInvalidCatalogContextReturnsSameErrorKey(string $route, array $query): void
+    {
+        $res = $this->dispatch('GET', $route, $query);
+        $this->assertApiError($res, HttpStatus::BAD_REQUEST, 'ms3_err_catalog_context_invalid');
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: array<string, mixed>}>
+     */
+    public static function invalidCatalogContextRoutes(): iterable
+    {
+        // "bad" in #705 means an invalid key; charset/mgr rules live in CatalogQuery (#665).
+        yield 'product get by id' => ['/api/v1/product/get/1', ['context' => 'mgr']];
+        yield 'product get by alias' => ['/api/v1/product/get', ['alias' => 'x', 'context' => 'mgr']];
+        yield 'category get by id' => ['/api/v1/category/get/1', ['context' => 'mgr']];
+        yield 'category get by alias' => ['/api/v1/category/get', ['alias' => 'x', 'context' => 'mgr']];
+    }
+
     public function testInvalidBearerReturns401(): void
     {
         $res = $this->dispatch(

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCategoryCatalog.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyCategoryCatalog.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Integration\WebApi\Support;
+
+use MiniShop3\Services\Catalog\CatalogQuery;
+use MiniShop3\Services\Category\CategoryCatalogService;
+use MODX\Revolution\modX;
+
+/**
+ * Stub CategoryCatalogService for public catalog HTTP journey (#705).
+ */
+final class JourneyCategoryCatalog extends CategoryCatalogService
+{
+    public const FIXTURE_CATEGORY_ID = 21;
+
+    public function __construct(modX $modx)
+    {
+        parent::__construct($modx);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>|null
+     */
+    public function getById(int $categoryId, array $params = []): ?array
+    {
+        CatalogQuery::resolveContext($params, 'web');
+
+        if ($categoryId !== self::FIXTURE_CATEGORY_ID) {
+            return null;
+        }
+
+        return [
+            'id' => self::FIXTURE_CATEGORY_ID,
+            'pagetitle' => 'Journey Category',
+            'published' => 1,
+        ];
+    }
+}

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyProductCatalog.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyProductCatalog.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Integration\WebApi\Support;
 
+use MiniShop3\Services\Catalog\CatalogQuery;
 use MiniShop3\Services\Product\ProductCatalogService;
 use MODX\Revolution\modX;
 
@@ -25,7 +26,8 @@ final class JourneyProductCatalog extends ProductCatalogService
      */
     public function getById(int $productId, array $params = []): ?array
     {
-        unset($params);
+        CatalogQuery::resolveContext($params, 'web');
+
         if ($productId !== self::FIXTURE_PRODUCT_ID) {
             return null;
         }

--- a/core/components/minishop3/tests/Integration/WebApi/Support/JourneyWebApiModx.php
+++ b/core/components/minishop3/tests/Integration/WebApi/Support/JourneyWebApiModx.php
@@ -19,6 +19,8 @@ final class JourneyWebApiModx extends WebApiModxStub
 
     public JourneyProductCatalog $catalog;
 
+    public JourneyCategoryCatalog $categoryCatalog;
+
     public JourneyCustomerOrderService $customerOrders;
 
     /** @var array<string, mixed> */
@@ -41,6 +43,7 @@ final class JourneyWebApiModx extends WebApiModxStub
         $this->journeyTokens = new JourneyTokenService();
         $this->tokenService = $this->journeyTokens;
         $this->catalog = new JourneyProductCatalog($this);
+        $this->categoryCatalog = new JourneyCategoryCatalog($this);
         $this->customerOrders = new JourneyCustomerOrderService($this);
 
         $rlPath = sys_get_temp_dir() . '/ms3-webapi-rl-' . getmypid();
@@ -71,6 +74,7 @@ final class JourneyWebApiModx extends WebApiModxStub
                     'ms3',
                     'ms3_token_service',
                     'ms3_product_catalog',
+                    'ms3_category_catalog',
                     'ms3_customer_order',
                 ], true);
             }
@@ -81,6 +85,7 @@ final class JourneyWebApiModx extends WebApiModxStub
                     'ms3' => $this->modx->ms3,
                     'ms3_token_service' => $this->modx->tokenService,
                     'ms3_product_catalog' => $this->modx->catalog,
+                    'ms3_category_catalog' => $this->modx->categoryCatalog,
                     'ms3_customer_order' => $this->modx->customerOrders,
                     default => null,
                 };

--- a/core/components/minishop3/tests/ProductCatalogRoutesTest.php
+++ b/core/components/minishop3/tests/ProductCatalogRoutesTest.php
@@ -45,8 +45,12 @@ if (!str_contains($controllerSrc, 'CatalogResolve::parseLookup')) {
     $fail('ProductController must parse catalog lookup via CatalogResolve');
 }
 
-if (!str_contains($controllerSrc, 'ms3_err_catalog_lookup_required')) {
-    $fail('ProductController must map catalog lookup parse errors');
+if (!str_contains($controllerSrc, 'CatalogContextException')) {
+    $fail('ProductController resolve must map CatalogContextException');
+}
+
+if (!str_contains($controllerSrc, 'CatalogResolve::lookupErrorLexiconKey')) {
+    $fail('ProductController must map catalog lookup parse errors via CatalogResolve');
 }
 
 if (!str_contains($serviceSrc, 'resolveByLookup')) {
@@ -66,6 +70,12 @@ if (!str_contains($resolveSrc, "->select('id')")) {
 }
 if (preg_match('/getSelectColumns\s*\(\s*\$class\s*,\s*\$class\b/', $resolveSrc)) {
     $fail('CatalogResolve must not pass FQCN as getSelectColumns table alias');
+}
+if (!str_contains($resolveSrc, 'CatalogQuery::resolveContext')) {
+    $fail('CatalogResolve must validate context via CatalogQuery (#705)');
+}
+if (preg_match('/private static function sanitizeContext\b/', $resolveSrc)) {
+    $fail('CatalogResolve must not keep a private sanitizeContext duplicate (#705)');
 }
 
 fwrite(STDOUT, "OK ProductCatalogRoutesTest\n");

--- a/core/components/minishop3/tests/Unit/Services/Catalog/CatalogResolveTest.php
+++ b/core/components/minishop3/tests/Unit/Services/Catalog/CatalogResolveTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MiniShop3\Tests\Unit\Services\Catalog;
 
+use MiniShop3\Services\Catalog\CatalogContextException;
 use MiniShop3\Services\Catalog\CatalogResolve;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -49,13 +50,29 @@ final class CatalogResolveTest extends TestCase
         yield 'uri double slash' => [['uri' => 'a//b']];
         yield 'uri nul' => [['uri' => "bad\0uri"]];
         yield 'alias path traversal' => [['alias' => '..']];
+        yield 'alias array param' => [['alias' => ['x']]];
+        yield 'uri array param' => [['uri' => ['catalog/tea']]];
+        yield 'alias object param' => [['alias' => (object) ['x' => 1]]];
+    }
+
+    #[DataProvider('invalidContextParams')]
+    public function testInvalidContextThrowsCatalogContextException(array $params): void
+    {
+        $this->expectException(CatalogContextException::class);
+        $this->expectExceptionMessage(CatalogContextException::LEXICON_INVALID);
+
+        CatalogResolve::parseLookup($params);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>}>
+     */
+    public static function invalidContextParams(): iterable
+    {
         yield 'mgr context' => [['alias' => 'tea', 'context' => 'mgr']];
         yield 'mgr prefix context' => [['alias' => 'tea', 'context' => 'mgrCustom']];
         yield 'invalid context chars' => [['alias' => 'tea', 'context' => 'en us']];
-        yield 'alias array param' => [['alias' => ['x']]];
-        yield 'uri array param' => [['uri' => ['catalog/tea']]];
         yield 'context array param' => [['alias' => 'tea', 'context' => ['web']]];
-        yield 'alias object param' => [['alias' => (object) ['x' => 1]]];
     }
 
     public function testAliasLookupWithContextFallback(): void


### PR DESCRIPTION
## Описание

После #644 поиск по alias/uri проверял `context` своей копией правил и отдавал `ms3_err_catalog_lookup_invalid`. `get/{id}` через `CatalogQuery` уже отдавал `ms3_err_catalog_context_invalid`.

`CatalogResolve` вызывает `CatalogQuery::resolveContext()`. Контроллеры ловят `CatalogContextException` в `resolve()` так же, как в `get()`. Приватный `sanitizeContext` удалён.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [x] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #705

Связано: #644, #665

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Services/Catalog/CatalogResolve.php
php -l src/Controllers/Api/Web/ProductController.php
php -l src/Controllers/Api/Web/CategoryController.php
# exit 0

php tests/CatalogQueryTest.php
php tests/ProductCatalogRoutesTest.php
php tests/CategoryCatalogRoutesTest.php
# exit 0

./vendor/bin/phpunit tests/Unit/Services/Catalog/CatalogResolveTest.php \
  tests/Integration/WebApi/HeadlessStorefrontErrorsTest.php \
  --filter 'CatalogResolve|InvalidCatalogContext|ProductGetWithoutLookup'
# OK (29 tests, 53 assertions), exit 0
```

HTTP data-provider: product/category × get/{id} и get?alias, `context=mgr` → 400 и `ms3_err_catalog_context_invalid`.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-705-catalog-context-resolve`
- MODX: stubs / без live install
- PHP: 8.4.23

## Скриншоты (если применимо)

Не применимо (JSON API).

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en) — новых ключей нет
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue) — Vue не трогали
- [ ] Обновлён CHANGELOG.md (для значимых изменений) — запись на релизе

## Дополнительные заметки

Клиенты alias/uri, которые ждали `ms3_err_catalog_lookup_invalid` при плохом `context`, получат `ms3_err_catalog_context_invalid`. HTTP 400 тот же.

В тестах `context=mgr` — реальный невалидный ключ по правилам #665. Строка `bad` из формулировки issue по charset валидна.