### PR TITLE
Purge obsolete Extra files on package upgrade

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to MiniShop3
+
+## Obsolete Extra files (#704)
+
+MODX `ACTION_UPGRADE` copies the new package tree and does **not** delete files that left the Extra. Leftover processors under `core/components/minishop3/src/Processors/` remain callable via `assets/components/minishop3/connector.php`.
+
+When you delete a PHP file from the shipped component (`core/components/minishop3/` or `assets/components/minishop3/`), add its path to:
+
+`core/components/minishop3/config/obsolete_package_files.php`
+
+Paths are relative to that component root. Missing files on a site are skipped (not an error). The upgrade resolver `_build/resolvers/resolver_10_obsolete_files.php` purges the list via `MiniShop3\Utils\ObsoletePackageFiles` with path confinement under the component directory.

--- a/_build/resolvers/resolver_10_obsolete_files.php
+++ b/_build/resolvers/resolver_10_obsolete_files.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Remove leftover Extra files that ACTION_UPGRADE does not delete (#704, #688).
+ *
+ * File vehicles only copy the new tree. Connector still autoloads processors
+ * that remain on disk after they left the package.
+ */
+
+use MiniShop3\Utils\ObsoletePackageFiles;
+use MODX\Revolution\modX;
+use xPDO\Transport\xPDOTransport;
+
+/** @var xPDOTransport $transport */
+/** @var array $options */
+
+if (!$transport->xpdo || !($transport instanceof xPDOTransport)) {
+    return true;
+}
+
+$modx = $transport->xpdo;
+$action = $options[xPDOTransport::PACKAGE_ACTION] ?? null;
+if (!in_array($action, [xPDOTransport::ACTION_INSTALL, xPDOTransport::ACTION_UPGRADE], true)) {
+    return true;
+}
+
+$coreRoot = MODX_CORE_PATH . 'components/minishop3/';
+$config = $coreRoot . 'config/obsolete_package_files.php';
+$helper = $coreRoot . 'src/Utils/ObsoletePackageFiles.php';
+
+if (!is_file($config) || !is_file($helper)) {
+    $modx->log(modX::LOG_LEVEL_WARN, '[MiniShop3] Obsolete file list is missing, skip leftover purge.');
+
+    return true;
+}
+
+require_once $helper;
+
+$list = ObsoletePackageFiles::load($config);
+$targets = [
+    'core' => $coreRoot,
+    'assets' => MODX_ASSETS_PATH . 'components/minishop3/',
+];
+
+foreach ($targets as $bucket => $root) {
+    $result = ObsoletePackageFiles::purge($root, $list[$bucket]);
+    foreach ($result['removed'] as $relative) {
+        $modx->log(modX::LOG_LEVEL_INFO, "[MiniShop3] Removed leftover {$bucket} file: {$relative}");
+    }
+    foreach ($result['rejected'] as $relative) {
+        $modx->log(modX::LOG_LEVEL_WARN, "[MiniShop3] Rejected leftover {$bucket} path: {$relative}");
+    }
+}
+
+return true;

--- a/core/components/minishop3/config/obsolete_package_files.php
+++ b/core/components/minishop3/config/obsolete_package_files.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Leftover files removed from the Extra that MODX upgrade will not delete (#704).
+ *
+ * ACTION_UPGRADE copies the new tree via copyTree() and never unlinks files that
+ * left the package. Connector still autoloads leftover processors from disk.
+ *
+ * When you delete a PHP file from the shipped component, add its path here
+ * (relative to core/components/minishop3/ or assets/components/minishop3/).
+ * Missing files on a site are skipped, not an error.
+ *
+ * Product/Autocomplete.php is listed while still in the tree (#690 will remove
+ * the source). Install/upgrade then purge it so #688 SQLi cannot linger on disk.
+ *
+ * @return array{core: list<string>, assets: list<string>}
+ */
+return [
+    'core' => [
+        'src/Processors/Category/GetList.php',
+        'src/Processors/Category/Option/Activate.php',
+        'src/Processors/Category/Option/Add.php',
+        'src/Processors/Category/Option/Deactivate.php',
+        'src/Processors/Category/Option/Duplicate.php',
+        'src/Processors/Category/Option/GetList.php',
+        'src/Processors/Category/Option/Multiple.php',
+        'src/Processors/Category/Option/Remove.php',
+        'src/Processors/Category/Option/Required.php',
+        'src/Processors/Category/Option/Unrequired.php',
+        'src/Processors/Category/Option/Update.php',
+        'src/Processors/Category/Option/UpdateFromGrid.php',
+        'src/Processors/Config/Read.php',
+        'src/Processors/Gallery/RemoveCatalogs.php',
+        'src/Processors/Order/Create.php',
+        'src/Processors/Order/Get.php',
+        'src/Processors/Order/GetList.php',
+        'src/Processors/Order/GetLog.php',
+        'src/Processors/Order/Multiple.php',
+        'src/Processors/Order/Product/Create.php',
+        'src/Processors/Order/Product/Get.php',
+        'src/Processors/Order/Product/GetList.php',
+        'src/Processors/Order/Product/Remove.php',
+        'src/Processors/Order/Product/Update.php',
+        'src/Processors/Order/Remove.php',
+        'src/Processors/Order/ToggleDraft.php',
+        'src/Processors/Order/Update.php',
+        'src/Processors/Product/Autocomplete.php',
+        'src/Processors/Product/ProductLink/GetList.php',
+        'src/Processors/Product/ProductLink/Multiple.php',
+        'src/Processors/Settings/Delivery/Payments/Disable.php',
+        'src/Processors/Settings/Delivery/Payments/Enable.php',
+        'src/Processors/Settings/Delivery/Payments/GetList.php',
+        'src/Processors/Settings/Delivery/Payments/Multiple.php',
+        'src/Processors/Settings/Option/Assign.php',
+        'src/Processors/Settings/Option/Create.php',
+        'src/Processors/Settings/Option/Duplicate.php',
+        'src/Processors/Settings/Option/Get.php',
+        'src/Processors/Settings/Option/GetCategories.php',
+        'src/Processors/Settings/Option/GetList.php',
+        'src/Processors/Settings/Option/GetNodes.php',
+        'src/Processors/Settings/Option/GetTypes.php',
+        'src/Processors/Settings/Option/Multiple.php',
+        'src/Processors/Settings/Option/Remove.php',
+        'src/Processors/Settings/Option/Update.php',
+        'src/Processors/Settings/Payment/Deliveries/Disable.php',
+        'src/Processors/Settings/Payment/Deliveries/Enable.php',
+        'src/Processors/Settings/Payment/Deliveries/GetList.php',
+        'src/Processors/Settings/Payment/Deliveries/Multiple.php',
+        'src/Processors/Utilities/ExtraField/Create.php',
+        'src/Processors/Utilities/ExtraField/Get.php',
+        'src/Processors/Utilities/ExtraField/GetClassNodes.php',
+        'src/Processors/Utilities/ExtraField/GetList.php',
+        'src/Processors/Utilities/ExtraField/Multiple.php',
+        'src/Processors/Utilities/ExtraField/Remove.php',
+        'src/Processors/Utilities/ExtraField/Update.php',
+    ],
+    'assets' => [],
+];

--- a/core/components/minishop3/src/Utils/ObsoletePackageFiles.php
+++ b/core/components/minishop3/src/Utils/ObsoletePackageFiles.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Utils;
+
+/**
+ * Delete leftover Extra files that MODX upgrade leaves on disk (#704).
+ */
+final class ObsoletePackageFiles
+{
+    /**
+     * @return array{core: list<string>, assets: list<string>}
+     */
+    public static function load(string $configFile): array
+    {
+        $empty = ['core' => [], 'assets' => []];
+        if (!is_file($configFile)) {
+            return $empty;
+        }
+
+        $data = require $configFile;
+        if (!is_array($data)) {
+            return $empty;
+        }
+
+        return [
+            'core' => self::stringList($data['core'] ?? []),
+            'assets' => self::stringList($data['assets'] ?? []),
+        ];
+    }
+
+    /**
+     * Resolve a relative path under $root. Rejects absolute paths and `..`.
+     */
+    public static function resolveUnderRoot(string $root, string $relative): ?string
+    {
+        $parts = self::relativeSegments($relative);
+        if ($parts === null) {
+            return null;
+        }
+
+        $rootReal = realpath($root);
+        if ($rootReal === false) {
+            return null;
+        }
+
+        return $rootReal . DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $parts);
+    }
+
+    /**
+     * @param list<string> $relativePaths
+     * @return array{removed: list<string>, skipped: list<string>, rejected: list<string>}
+     */
+    public static function purge(string $root, array $relativePaths): array
+    {
+        $rootReal = realpath($root);
+        if ($rootReal === false) {
+            return ['removed' => [], 'skipped' => [], 'rejected' => $relativePaths];
+        }
+
+        $prefix = $rootReal . DIRECTORY_SEPARATOR;
+        $removed = [];
+        $skipped = [];
+        $rejected = [];
+
+        foreach ($relativePaths as $relative) {
+            $candidate = self::resolveUnderRoot($rootReal, $relative);
+            if ($candidate === null) {
+                $rejected[] = $relative;
+                continue;
+            }
+
+            $realFile = realpath($candidate);
+            if ($realFile === false) {
+                $skipped[] = $relative;
+                continue;
+            }
+            if (!is_file($realFile) || !str_starts_with($realFile, $prefix)) {
+                $rejected[] = $relative;
+                continue;
+            }
+            if (@unlink($realFile)) {
+                $removed[] = $relative;
+            } else {
+                $rejected[] = $relative;
+            }
+        }
+
+        return [
+            'removed' => $removed,
+            'skipped' => $skipped,
+            'rejected' => $rejected,
+        ];
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private static function relativeSegments(string $relative): ?array
+    {
+        $relative = str_replace('\\', '/', $relative);
+        if ($relative === '' || str_contains($relative, "\0")) {
+            return null;
+        }
+        if (str_starts_with($relative, '/') || preg_match('#^[A-Za-z]:/#', $relative) === 1) {
+            return null;
+        }
+
+        $parts = [];
+        foreach (explode('/', $relative) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                return null;
+            }
+            $parts[] = $segment;
+        }
+
+        return $parts === [] ? null : $parts;
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item) && $item !== '') {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/core/components/minishop3/tests/ObsoletePackageFilesTest.php
+++ b/core/components/minishop3/tests/ObsoletePackageFilesTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * #704: obsolete Extra files are listed and purged only under the component root.
+ *
+ * Run: php tests/ObsoletePackageFilesTest.php
+ */
+
+declare(strict_types=1);
+
+use MiniShop3\Utils\ObsoletePackageFiles;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "FAIL ObsoletePackageFilesTest: {$message}\n");
+    exit(1);
+};
+
+$repoRoot = dirname(__DIR__, 4);
+$coreRoot = dirname(__DIR__);
+$configPath = $coreRoot . '/config/obsolete_package_files.php';
+$resolverPath = $repoRoot . '/_build/resolvers/resolver_10_obsolete_files.php';
+$helperPath = $coreRoot . '/src/Utils/ObsoletePackageFiles.php';
+
+foreach ([$configPath, $resolverPath, $helperPath] as $path) {
+    if (!is_readable($path)) {
+        $fail(basename($path) . ' missing');
+    }
+}
+
+$resolverSrc = file_get_contents($resolverPath);
+if (!is_string($resolverSrc)) {
+    $fail('cannot read resolver_10_obsolete_files.php');
+}
+if (!str_contains($resolverSrc, 'ACTION_UPGRADE') || !str_contains($resolverSrc, 'ObsoletePackageFiles')) {
+    $fail('resolver must run on ACTION_UPGRADE via ObsoletePackageFiles');
+}
+
+require_once $helperPath;
+
+$list = ObsoletePackageFiles::load($configPath);
+$core = $list['core'];
+
+// Frozen set from git history of deleted Processors + Autocomplete (#690 / #688).
+$expectedCore = [
+    'src/Processors/Category/GetList.php',
+    'src/Processors/Category/Option/Activate.php',
+    'src/Processors/Category/Option/Add.php',
+    'src/Processors/Category/Option/Deactivate.php',
+    'src/Processors/Category/Option/Duplicate.php',
+    'src/Processors/Category/Option/GetList.php',
+    'src/Processors/Category/Option/Multiple.php',
+    'src/Processors/Category/Option/Remove.php',
+    'src/Processors/Category/Option/Required.php',
+    'src/Processors/Category/Option/Unrequired.php',
+    'src/Processors/Category/Option/Update.php',
+    'src/Processors/Category/Option/UpdateFromGrid.php',
+    'src/Processors/Config/Read.php',
+    'src/Processors/Gallery/RemoveCatalogs.php',
+    'src/Processors/Order/Create.php',
+    'src/Processors/Order/Get.php',
+    'src/Processors/Order/GetList.php',
+    'src/Processors/Order/GetLog.php',
+    'src/Processors/Order/Multiple.php',
+    'src/Processors/Order/Product/Create.php',
+    'src/Processors/Order/Product/Get.php',
+    'src/Processors/Order/Product/GetList.php',
+    'src/Processors/Order/Product/Remove.php',
+    'src/Processors/Order/Product/Update.php',
+    'src/Processors/Order/Remove.php',
+    'src/Processors/Order/ToggleDraft.php',
+    'src/Processors/Order/Update.php',
+    'src/Processors/Product/Autocomplete.php',
+    'src/Processors/Product/ProductLink/GetList.php',
+    'src/Processors/Product/ProductLink/Multiple.php',
+    'src/Processors/Settings/Delivery/Payments/Disable.php',
+    'src/Processors/Settings/Delivery/Payments/Enable.php',
+    'src/Processors/Settings/Delivery/Payments/GetList.php',
+    'src/Processors/Settings/Delivery/Payments/Multiple.php',
+    'src/Processors/Settings/Option/Assign.php',
+    'src/Processors/Settings/Option/Create.php',
+    'src/Processors/Settings/Option/Duplicate.php',
+    'src/Processors/Settings/Option/Get.php',
+    'src/Processors/Settings/Option/GetCategories.php',
+    'src/Processors/Settings/Option/GetList.php',
+    'src/Processors/Settings/Option/GetNodes.php',
+    'src/Processors/Settings/Option/GetTypes.php',
+    'src/Processors/Settings/Option/Multiple.php',
+    'src/Processors/Settings/Option/Remove.php',
+    'src/Processors/Settings/Option/Update.php',
+    'src/Processors/Settings/Payment/Deliveries/Disable.php',
+    'src/Processors/Settings/Payment/Deliveries/Enable.php',
+    'src/Processors/Settings/Payment/Deliveries/GetList.php',
+    'src/Processors/Settings/Payment/Deliveries/Multiple.php',
+    'src/Processors/Utilities/ExtraField/Create.php',
+    'src/Processors/Utilities/ExtraField/Get.php',
+    'src/Processors/Utilities/ExtraField/GetClassNodes.php',
+    'src/Processors/Utilities/ExtraField/GetList.php',
+    'src/Processors/Utilities/ExtraField/Multiple.php',
+    'src/Processors/Utilities/ExtraField/Remove.php',
+    'src/Processors/Utilities/ExtraField/Update.php',
+];
+
+sort($core);
+$expectedSorted = $expectedCore;
+sort($expectedSorted);
+if ($core !== $expectedSorted) {
+    $fail('obsolete core list must exactly match the frozen 55 deleted processors + Autocomplete');
+}
+
+foreach ($core as $path) {
+    if (ObsoletePackageFiles::resolveUnderRoot($coreRoot, $path) === null) {
+        $fail("unsafe obsolete path: {$path}");
+    }
+}
+
+// Autocomplete still ships until #690 removes it from the tree; upgrades purge it.
+$allowedStillShipped = ['src/Processors/Product/Autocomplete.php'];
+
+foreach ($core as $path) {
+    if (is_file($coreRoot . '/' . $path) && !in_array($path, $allowedStillShipped, true)) {
+        $fail("obsolete path still ships in the Extra: {$path}");
+    }
+}
+
+fwrite(STDOUT, "OK ObsoletePackageFilesTest\n");
+exit(0);

--- a/core/components/minishop3/tests/Unit/Utils/ObsoletePackageFilesTest.php
+++ b/core/components/minishop3/tests/Unit/Utils/ObsoletePackageFilesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiniShop3\Tests\Unit\Utils;
+
+use MiniShop3\Utils\ObsoletePackageFiles;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ObsoletePackageFilesTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ms3-obsolete-' . bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($dir, 0777, true));
+        $resolved = realpath($dir);
+        self::assertNotFalse($resolved);
+        $this->root = $resolved;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+    }
+
+    #[DataProvider('rejectedRelativePaths')]
+    public function testResolveUnderRootRejectsTraversal(string $relative): void
+    {
+        self::assertNull(ObsoletePackageFiles::resolveUnderRoot($this->root, $relative));
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function rejectedRelativePaths(): iterable
+    {
+        yield 'parent segment' => ['../Autocomplete.php'];
+        yield 'nested parent' => ['src/Processors/../../etc/passwd'];
+        yield 'absolute unix' => ['/etc/passwd'];
+        yield 'absolute windows' => ['C:/Windows/system.ini'];
+        yield 'empty' => [''];
+        yield 'dot only' => ['.'];
+        yield 'null byte' => ["src/\0Processors/Autocomplete.php"];
+    }
+
+    public function testResolveUnderRootKeepsNestedFile(): void
+    {
+        $resolved = ObsoletePackageFiles::resolveUnderRoot(
+            $this->root,
+            'src/Processors/Product/Autocomplete.php',
+        );
+
+        self::assertSame(
+            $this->root . DIRECTORY_SEPARATOR . 'src'
+            . DIRECTORY_SEPARATOR . 'Processors'
+            . DIRECTORY_SEPARATOR . 'Product'
+            . DIRECTORY_SEPARATOR . 'Autocomplete.php',
+            $resolved,
+        );
+    }
+
+    public function testPurgeDeletesExistingFileAndSkipsMissing(): void
+    {
+        $dir = $this->root . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Processors';
+        self::assertTrue(mkdir($dir, 0777, true));
+        $file = $dir . DIRECTORY_SEPARATOR . 'Autocomplete.php';
+        self::assertTrue(file_put_contents($file, '<?php') !== false);
+
+        $result = ObsoletePackageFiles::purge($this->root, [
+            'src/Processors/Autocomplete.php',
+            'src/Processors/Missing.php',
+        ]);
+
+        self::assertFileDoesNotExist($file);
+        self::assertSame(['src/Processors/Autocomplete.php'], $result['removed']);
+        self::assertSame(['src/Processors/Missing.php'], $result['skipped']);
+        self::assertSame([], $result['rejected']);
+    }
+
+    public function testPurgeRejectsSymlinkOutsideRoot(): void
+    {
+        $outside = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ms3-obsolete-outside-' . bin2hex(random_bytes(4));
+        self::assertTrue(file_put_contents($outside, 'secret') !== false);
+        $link = $this->root . DIRECTORY_SEPARATOR . 'escape.php';
+        if (!@symlink($outside, $link)) {
+            @unlink($outside);
+            self::markTestSkipped('symlink() is not available');
+        }
+
+        $result = ObsoletePackageFiles::purge($this->root, ['escape.php']);
+
+        self::assertFileExists($outside);
+        self::assertSame(['escape.php'], $result['rejected']);
+        self::assertSame([], $result['removed']);
+
+        @unlink($link);
+        @unlink($outside);
+    }
+
+    public function testLoadReadsCoreAndAssetsLists(): void
+    {
+        $config = $this->root . DIRECTORY_SEPARATOR . 'list.php';
+        self::assertTrue(file_put_contents(
+            $config,
+            "<?php\nreturn ['core' => ['src/Processors/Product/Autocomplete.php'], 'assets' => ['js/gone.js']];\n",
+        ) !== false);
+
+        self::assertSame(
+            [
+                'core' => ['src/Processors/Product/Autocomplete.php'],
+                'assets' => ['js/gone.js'],
+            ],
+            ObsoletePackageFiles::load($config),
+        );
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $full = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($full) && !is_link($full)) {
+                $this->removeTree($full);
+            } else {
+                @unlink($full);
+            }
+        }
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## Описание

При `ACTION_UPGRADE` MODX копирует новое дерево через `copyTree()` и не удаляет файлы, которых уже нет в пакете. Старые процессоры остаются на диске и вызываются через `connector.php`.

Добавлен явный список leftovers и resolver `_build/resolvers/resolver_10_obsolete_files.php`: на install/upgrade удаляет пути под `core|assets/components/minishop3/` с проверкой confinement (`..`, absolute, symlink наружу). Отсутствующий файл — skip, не ошибка.

В списке 55 удалённых процессоров + `Product/Autocomplete.php` (#688 / #690). Autocomplete пока ещё в дереве: после copyTree resolver сразу снимает его с диска. Удаление исходника — в #690.

Правило для контрибьюторов: шапка `obsolete_package_files.php` и `.github/CONTRIBUTING.md`.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #704

Связано: #688, #690

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l src/Utils/ObsoletePackageFiles.php
php -l ../../../../_build/resolvers/resolver_10_obsolete_files.php
php tests/ObsoletePackageFilesTest.php
./vendor/bin/phpunit tests/Unit/Utils/ObsoletePackageFilesTest.php
```

Exit codes: `0` (smoke OK, PHPUnit 11 tests / 42 assertions).

Ручной upgrade пакета на тестовом сайте в этом PR не прогонялся (нет локального Package Manager run). Логика purge покрыта unit-тестами на temp dir.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-704-obsolete-package-files`
- MODX: n/a (unit/smoke)
- PHP: локальный CLI 8.x

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- Out of scope: полный список удалённых assets, правка ядра MODX/`copyTree`, удаление Autocomplete из git (#690).
- AC «проверено обновлением на тестовом сайте» — нужен ручной прогон maintainer’ом после сборки пакета.