### PR TITLE
Repair missing product_fields.section foreign key

### DIFF
--- a/core/components/minishop3/migrations/20260912120000_repair_product_fields_section_fk.php
+++ b/core/components/minishop3/migrations/20260912120000_repair_product_fields_section_fk.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add missing FK ms3_product_fields.section → ms3_page_sections.id (#711).
+ *
+ * Self-contained: no MiniShop3 imports (transport Phinx may run early).
+ */
+final class RepairProductFieldsSectionFk extends AbstractMigration
+{
+    private const CONSTRAINT = 'fk_product_fields_section';
+
+    public function up(): void
+    {
+        if (!$this->hasTable('ms3_product_fields') || !$this->hasTable('ms3_page_sections')) {
+            throw new RuntimeException(
+                'Cannot repair ' . self::CONSTRAINT . ': ms3_product_fields and ms3_page_sections must both exist'
+            );
+        }
+
+        $table = $this->table('ms3_product_fields');
+        if ($table->hasForeignKey('section', self::CONSTRAINT)) {
+            return;
+        }
+
+        $prefix = (string) $this->getAdapter()->getOption('table_prefix');
+        $fields = $prefix . 'ms3_product_fields';
+        $sections = $prefix . 'ms3_page_sections';
+
+        // Legacy writes stored section as 0 (INT cast of "main"); not a valid autoincrement id.
+        $this->execute("UPDATE `{$fields}` SET `section` = NULL WHERE `section` = 0");
+
+        $orphans = $this->fetchAll(
+            "SELECT f.`id`, f.`name`, f.`section`"
+            . " FROM `{$fields}` f"
+            . " LEFT JOIN `{$sections}` s ON s.`id` = f.`section`"
+            . " WHERE f.`section` IS NOT NULL AND s.`id` IS NULL"
+            . " ORDER BY f.`id`"
+        );
+
+        if ($orphans !== []) {
+            $details = [];
+            foreach ($orphans as $row) {
+                $details[] = sprintf(
+                    'id=%s name=%s section=%s',
+                    (string) ($row['id'] ?? ''),
+                    (string) ($row['name'] ?? ''),
+                    (string) ($row['section'] ?? '')
+                );
+            }
+
+            throw new RuntimeException(
+                'Cannot add ' . self::CONSTRAINT . ': orphan ms3_product_fields.section values must be fixed first: '
+                . implode('; ', $details)
+            );
+        }
+
+        $table->addForeignKey('section', 'ms3_page_sections', 'id', [
+            'delete' => 'RESTRICT',
+            'update' => 'CASCADE',
+            'constraint' => self::CONSTRAINT,
+        ])->update();
+    }
+
+    public function down(): void
+    {
+        if (!$this->hasTable('ms3_product_fields')) {
+            return;
+        }
+
+        $table = $this->table('ms3_product_fields');
+        if (!$table->hasForeignKey('section', self::CONSTRAINT)) {
+            return;
+        }
+
+        $table->dropForeignKey('section', self::CONSTRAINT)->update();
+    }
+}

--- a/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
+++ b/core/components/minishop3/tests/Modx/PhinxSchemaLiveTest.php
@@ -141,6 +141,24 @@ final class PhinxSchemaLiveTest extends ExtraTestCase
         }
     }
 
+    public function testProductFieldsSectionForeignKeyExists(): void
+    {
+        $prefix = (string) $this->modx->getOption('table_prefix', null, '');
+        $table = $prefix . 'ms3_product_fields';
+        $statement = $this->modx->prepare(
+            'SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS'
+            . ' WHERE CONSTRAINT_SCHEMA = DATABASE()'
+            . ' AND TABLE_NAME = ?'
+            . ' AND CONSTRAINT_TYPE = \'FOREIGN KEY\''
+            . ' AND CONSTRAINT_NAME = ?'
+        );
+        $statement->execute([$table, 'fk_product_fields_section']);
+        self::assertNotFalse(
+            $statement->fetch(\PDO::FETCH_ASSOC),
+            'fk_product_fields_section must exist on ' . $table . ' (#711)'
+        );
+    }
+
     /**
      * @return list<string>
      */


### PR DESCRIPTION
## Описание

До #698 `InitialSchema` не создавал `fk_product_fields_section` (проверка таблиц шла не по тому соединению). После #698 ключ появляется только на чистых установках. Старые сайты остаются без FK.

Добавлена идемпотентная repair-миграция `20260912120000_repair_product_fields_section_fk.php`:
- FK уже есть → no-op;
- `section = 0` → `NULL` (наследие каста `'main'`);
- положительные orphan id → `RuntimeException` со списком строк;
- затем добавляет FK с теми же правилами, что InitialSchema.

Решение записано в [#711](https://github.com/modx-pro/MiniShop3/issues/711#issuecomment-5645353928): чиним, расхождение схем не оставляем.

## Тип изменений

- [x] Исправление бага (non-breaking change)
- [ ] Новая функциональность (non-breaking change)
- [ ] Breaking change (изменение, ломающее обратную совместимость)
- [ ] Рефакторинг (без изменения функциональности)
- [ ] Документация
- [ ] Другое (опишите):

## Связанные Issues

Closes #711

Связано: #695, #698

## Как это было протестировано?

```bash
cd core/components/minishop3
php -l migrations/20260912120000_repair_product_fields_section_fk.php
php -l tests/Modx/PhinxSchemaLiveTest.php
php tests/MigrationSelfContainedTest.php
```

Exit codes: `0`.

Live assert `testProductFieldsSectionForeignKeyExists` ожидает зелёный job `modx-testbench` в CI. Ручной апгрейд старой БД без FK в этом окружении не прогонялся.

- [ ] Ручное тестирование
- [x] Автоматические тесты (`composer ci:php` / `composer test`, `npm run lint:ci`, `composer stan` / GitHub Actions CI)
- [ ] Тестирование на разных версиях PHP/MODX

**Конфигурация тестирования:**
- MiniShop3: ветка `fix/issue-711-product-fields-section-fk`
- MODX: CI testbench
- PHP: локальный CLI 8.x

## Скриншоты (если применимо)

| До | После |
|:--:|:-----:|
| n/a | n/a |

## Чеклист

- [x] Код соответствует стилю проекта
- [x] Добавлены/обновлены комментарии в сложных местах
- [x] Изменения не ломают существующую функциональность
- [ ] Лексиконы добавлены на **двух языках** (ru/en)
- [ ] PHPStan проходит без новых ошибок (`composer stan` / CI job `PHPStan`)
- [ ] ESLint проходит без ошибок (`npm run lint:ci` для Vue)
- [ ] Обновлён CHANGELOG.md (для значимых изменений)

## Дополнительные заметки

- AC «проверено на тестовом сайте» — нужен maintainer-прогон апгрейда старой установки.
- Сайт с битыми положительными `section` увидит fail миграции со списком строк; это ожидаемо.